### PR TITLE
Adding  script and improving npm run dev command

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/Krypton
+v24.13.1

--- a/infra/compose.yaml
+++ b/infra/compose.yaml
@@ -1,5 +1,6 @@
 services:
   database:
+    container_name: "postgres-dev"
     image: postgres:16.0-alpine3.18
     env_file:
       - ../.env.development

--- a/infra/scripts/wait-for-postgres.js
+++ b/infra/scripts/wait-for-postgres.js
@@ -1,0 +1,19 @@
+const { exec } = require("node:child_process")
+
+function checkPostgres() {
+    exec("docker exec postgres-dev pg_isready --host localhost", handleReturn);
+
+    function handleReturn(error, stdout, stderr) {
+        process.stdout.write(".");
+        if (stdout.search("accepting connections") === -1) {
+            setTimeout(checkPostgres, 1000);
+            return;
+        }
+
+        process.stdout.write("\nPostgres is ready!\n");
+    }
+}
+
+
+process.stdout.write("\nWaiting for postgres..");
+checkPostgres();

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch",
-    "dev": "npm run services:up && next dev",
-    "services:up": "docker compose -f infra/compose.yaml up -d && npx prisma generate",
+    "dev": "npm run services:up && npm run wait-for-postgres && npm run prisma:generate && npm run migrate:dev && next dev",
+    "services:up": "docker compose -f infra/compose.yaml up -d",
     "services:stop": "docker compose -f infra/compose.yaml stop",
     "services:down": "docker compose -f infra/compose.yaml down",
     "build": "next build",
@@ -25,7 +25,8 @@
     "lint:fix": "prettier --write .",
     "prisma:generate": "npx prisma generate",
     "migrate:deploy": "npx prisma migrate deploy",
-    "migrate:dev": "npx prisma migrate dev"
+    "migrate:dev": "npx prisma migrate dev",
+    "wait-for-postgres": "node infra/scripts/wait-for-postgres.js"
   },
   "dependencies": {
     "@prisma/adapter-pg": "^7.4.0",

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -18,11 +18,9 @@ if (process.env["POSTGRES_PORT"]) {
 // Note: ?schema=public is NOT used here — Prisma 7's prisma.config.ts parses
 // the URL differently and including it corrupts the shadow database schema path.
 let connectionString = `${baseString}/${process.env["POSTGRES_DB"]}`;
-let shadowDatabaseConnectionString = `${baseString}/${process.env["POSTGRES_DB"]}_shadow`;
 
 if (process.env.NODE_ENV === "production") {
   connectionString += "?sslmode=require";
-  shadowDatabaseConnectionString += "?sslmode=require";
 }
 
 export default defineConfig({
@@ -32,6 +30,5 @@ export default defineConfig({
   },
   datasource: {
     url: connectionString,
-    shadowDatabaseUrl: shadowDatabaseConnectionString,
   },
 });


### PR DESCRIPTION
Closing #32 

This pull request updates the development workflow and infrastructure setup for the project, focusing on improving reliability and consistency when working with the local Postgres database. The most important changes include updating Node.js version management, introducing a script to wait for Postgres readiness, and modifying the development scripts to ensure database migrations run only after Postgres is ready. Additionally, there are adjustments to the Prisma configuration to simplify shadow database handling.

**Development workflow improvements:**

* Updated `.nvmrc` to use a specific Node.js version (`v24.13.1`) instead of the generic `lts/Krypton`, ensuring consistency across development environments.
* Enhanced the `dev` script in `package.json` to wait for Postgres to be ready before running Prisma commands and migrations, reducing errors related to database availability.
* Added a new script `infra/scripts/wait-for-postgres.js` that checks if the Postgres container is accepting connections before proceeding with migrations or development startup.
* Introduced a dedicated `wait-for-postgres` script entry in `package.json` for easier integration into the workflow.

**Infrastructure adjustments:**

* Set a fixed container name (`postgres-dev`) for the Postgres service in `infra/compose.yaml`, enabling reliable referencing from scripts and other services.

**Prisma configuration simplification:**

* Removed the `shadowDatabaseUrl` from `prisma.config.ts` and related connection string logic, streamlining the configuration and avoiding issues with shadow database schema paths. [[1]](diffhunk://#diff-c96950ab4b66f64a7a92db38b944cc2f9ba2b5a122969252d565586ed4e73e55L21-L25) [[2]](diffhunk://#diff-c96950ab4b66f64a7a92db38b944cc2f9ba2b5a122969252d565586ed4e73e55L35)