### PR TITLE
feat: adding EMAIL_FROM env as default sending emmail

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -17,5 +17,8 @@ EMAIL_SMTP_HOST=localhost
 EMAIL_SMTP_PORT=1025
 EMAIL_SMTP_USER=
 EMAIL_SMTP_PASSWORD=
+EMAIL_FROM=contact@manifoldpowered.com
+
+# Mail Catcher HTTP API (Normaly only for development)
 EMAIL_HTTP_HOST=localhost
 EMAIL_HTTP_PORT=1080

--- a/infra/email.ts
+++ b/infra/email.ts
@@ -20,6 +20,14 @@ const transporter = nodemailer.createTransport({
 
 async function send(mailOptions: MailOptions) {
   try {
+    if (!mailOptions.from && !process.env.EMAIL_FROM) {
+      throw new Error(
+        "From is not defined in mailOptions nor in env EMAIL_FROM",
+      );
+    }
+
+    mailOptions.from =
+      mailOptions.from ?? `Manifold Powered <${process.env.EMAIL_FROM}>`;
     await transporter.sendMail(mailOptions);
   } catch (error) {
     throw new ServiceError({

--- a/models/activation.ts
+++ b/models/activation.ts
@@ -19,7 +19,6 @@ async function create(userId: string) {
 
 async function sendEmailToUser(user: User, activation: UserActivationToken) {
   await email.send({
-    from: "<contact@manifoldpowered.com>",
     to: user.email,
     subject: "Activate your account at Manifold!",
     text: `Welcome to Manifold, ${user.username}!

--- a/tests/integration/infra/email.test.ts
+++ b/tests/integration/infra/email.test.ts
@@ -1,4 +1,6 @@
 import email from "infra/email";
+import { ServiceError } from "infra/errors";
+import { describe } from "node:test";
 import orchestrator from "tests/orchestrator";
 
 beforeAll(async () => {
@@ -7,27 +9,90 @@ beforeAll(async () => {
 });
 
 describe("infra/email.ts", () => {
-  test("send()", async () => {
-    await email.send({
-      from: "Manifold <sender@manifoldpowered.com>",
-      to: "receiver@manifoldpowered.com",
-      subject: "First Email",
-      text: "Text First Email",
+  describe("send()", () => {
+    test("Sends an email and get the last one correctly", async () => {
+      await email.send({
+        from: "Manifold <sender@manifoldpowered.com>",
+        to: "receiver@manifoldpowered.com",
+        subject: "First Email",
+        text: "Text First Email",
+      });
+
+      await email.send({
+        from: "Manifold <sender@manifoldpowered.com>",
+        to: "receiver@manifoldpowered.com",
+        subject: "Last Email",
+        text: "Text Last Email",
+      });
+
+      const lastEmail = await orchestrator.getLastEmail();
+
+      expect(lastEmail).not.toBeNull();
+      expect(lastEmail.sender).toContain("<sender@manifoldpowered.com>");
+      expect(lastEmail.recipients[0]).toContain(
+        "<receiver@manifoldpowered.com>",
+      );
+      expect(lastEmail.subject).toBe("Last Email");
+      expect(lastEmail.text).toContain("Text Last Email");
     });
 
-    await email.send({
-      from: "Manifold <sender@manifoldpowered.com>",
-      to: "receiver@manifoldpowered.com",
-      subject: "Last Email",
-      text: "Text Last Email",
+    test("Sends an email without from and without env EMAIL_FROM", async () => {
+      const originalEmailFrom = process.env.EMAIL_FROM;
+      delete process.env.EMAIL_FROM;
+
+      try {
+        await email.send({
+          to: "receiver@manifoldpowered.com",
+          subject: "First Email",
+          text: "Text First Email",
+        });
+
+        fail("Should throw an error");
+      } catch (error) {
+        console.log(error.cause);
+        expect(error).toBeInstanceOf(ServiceError);
+        expect(error).toHaveProperty("message", "Could not send email");
+        expect(error).toHaveProperty(
+          "action",
+          "Check if email service is available",
+        );
+        expect(error).toHaveProperty("context", {
+          to: "receiver@manifoldpowered.com",
+          subject: "First Email",
+          text: "Text First Email",
+        });
+        expect(error.cause).toBeInstanceOf(Error);
+        expect(error.cause).toHaveProperty(
+          "message",
+          "From is not defined in mailOptions nor in env EMAIL_FROM",
+        );
+      }
+
+      process.env.EMAIL_FROM = originalEmailFrom;
     });
 
-    const lastEmail = await orchestrator.getLastEmail();
+    test("Sends an email without from", async () => {
+      await email.send({
+        to: "receiver@manifoldpowered.com",
+        subject: "First Email",
+        text: "Text First Email",
+      });
 
-    expect(lastEmail).not.toBeNull();
-    expect(lastEmail.sender).toContain("<sender@manifoldpowered.com>");
-    expect(lastEmail.recipients[0]).toContain("<receiver@manifoldpowered.com>");
-    expect(lastEmail.subject).toBe("Last Email");
-    expect(lastEmail.text).toContain("Text Last Email");
+      await email.send({
+        to: "receiver@manifoldpowered.com",
+        subject: "Last Email",
+        text: "Text Last Email",
+      });
+
+      const lastEmail = await orchestrator.getLastEmail();
+
+      expect(lastEmail).not.toBeNull();
+      expect(lastEmail.sender).toContain("<contact@manifoldpowered.com>");
+      expect(lastEmail.recipients[0]).toContain(
+        "<receiver@manifoldpowered.com>",
+      );
+      expect(lastEmail.subject).toBe("Last Email");
+      expect(lastEmail.text).toContain("Text Last Email");
+    });
   });
 });


### PR DESCRIPTION
This pull request improves the handling of the default "from" email address in outgoing emails, making it configurable via environment variables and ensuring robust error handling and test coverage. The changes ensure that the sender address is no longer hardcoded, and add tests to verify correct behavior in different scenarios.

**Email "from" address configuration and error handling:**

* Added `EMAIL_FROM` to the `.env.development` file, making the default sender address configurable via environment variables instead of hardcoding it.
* Updated `infra/email.ts` so that if `mailOptions.from` is not provided, it uses `EMAIL_FROM` from the environment; throws a clear error if neither is set.
* Removed the hardcoded `from: "<contact@manifoldpowered.com>"` in `models/activation.ts` so that emails use the new default-from logic.

**Testing improvements:**

* Expanded integration tests in `tests/integration/infra/email.test.ts` to cover cases where the "from" address is missing, ensuring an error is thrown, and to verify that the default is correctly used when not specified. [[1]](diffhunk://#diff-27d71924d8d44f365b7075f29f3c6ef5ed52a703199b0e59f78cc8e4c6269ea2L10-R13) [[2]](diffhunk://#diff-27d71924d8d44f365b7075f29f3c6ef5ed52a703199b0e59f78cc8e4c6269ea2L29-R97)
* Added missing imports and improved test structure for clarity and completeness.