### PR TITLE
chore: activation time from 15 minutes to 24 hours

### DIFF
--- a/models/activation.ts
+++ b/models/activation.ts
@@ -6,7 +6,7 @@ import webserver from "infra/webserver";
 import user from "models/user";
 import authorization from "./authorization";
 
-const EXPIRATION_IN_MILLISECONDS = 1000 * 60 * 15; // 15 minutes
+const EXPIRATION_IN_MILLISECONDS = 1000 * 60 * 60 * 24; // 24 hours
 
 async function create(userId: string) {
   return prisma.userActivationToken.create({

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -67,7 +67,7 @@ export default function SignupPage() {
       setUsername("");
       setEmail("");
       setSuccessMessage(
-        "We sent you an activation email. Please activate your account within 15 minutes.",
+        "We sent you an activation email. Please activate your account within 24 hours.",
       );
     } catch (error) {
       setErrorMessage(


### PR DESCRIPTION
This pull request extends the user activation window from 15 minutes to 24 hours. It updates both the backend token expiration logic and the user-facing message on the signup page to reflect this change.

**User activation expiration period update:**

* Increased the activation token expiration time from 15 minutes to 24 hours in `models/activation.ts`.

**User interface messaging:**

* Updated the signup success message to inform users they have 24 hours (instead of 15 minutes) to activate their account in `pages/signup/index.tsx`.