### PR TITLE
feat: now youtube autoplay on MediaGallery starts muted

### DIFF
--- a/components/store/MediaGallery.tsx
+++ b/components/store/MediaGallery.tsx
@@ -145,7 +145,7 @@ export function MediaGallery({ videos, images, gameTitle }: MediaGalleryProps) {
         {/* Stage Content */}
         {activeMedia.type === "video" ? (
           <iframe
-            src={`https://www.youtube.com/embed/${activeMedia.id}?rel=0&modestbranding=1&autoplay=1`}
+            src={`https://www.youtube.com/embed/${activeMedia.id}?rel=0&modestbranding=1&autoplay=1&mute=1`}
             title={`${gameTitle} Trailer`}
             className="absolute inset-0 w-full h-full border-0"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"


### PR DESCRIPTION
This pull request makes a small update to the `MediaGallery` component to improve the user experience when playing videos.

* The embedded YouTube video now starts muted by default by adding `&mute=1` to the iframe `src` URL in `MediaGallery.tsx`.