### PR TITLE
feat: make signup passwordless and switch signin to email OTP

### DIFF
--- a/infra/controller.ts
+++ b/infra/controller.ts
@@ -101,6 +101,7 @@ function injectAnonymousUser(req: NextApiRequest) {
     features: [
       "read:activation_token",
       "create:session",
+      "create:otp",
       "create:user",
       "read:public_game",
       "read:wishlist",

--- a/models/authentication.ts
+++ b/models/authentication.ts
@@ -33,8 +33,15 @@ async function getUser(providedEmail: string, providedPassword: string) {
 
 async function validatePassword(
   providedPassword: string,
-  storedPassword: string,
+  storedPassword: string | null,
 ) {
+  if (!storedPassword) {
+    throw new UnauthorizedError({
+      message: "Invalid password",
+      action: "Check your password",
+    });
+  }
+
   const isPasswordValid = await password.compare(
     providedPassword,
     storedPassword,

--- a/models/authorization.ts
+++ b/models/authorization.ts
@@ -23,6 +23,9 @@ const AVAILABLE_FEATURES = [
   "create:session",
   "read:session",
 
+  // OTP
+  "create:otp",
+
   // Activation Token
   "read:activation_token",
 

--- a/models/otp.ts
+++ b/models/otp.ts
@@ -1,0 +1,108 @@
+import crypto from "node:crypto";
+import { User } from "generated/prisma/client";
+import { prisma } from "infra/database";
+import email from "infra/email";
+import { UnauthorizedError } from "infra/errors";
+import password from "models/password";
+import user from "models/user";
+
+const EXPIRATION_IN_MILLISECONDS = 1000 * 60 * 10; // 10 minutes
+const CODE_LENGTH = 6;
+
+function generateCode(): string {
+  const max = 10 ** CODE_LENGTH;
+  const code = crypto.randomInt(0, max);
+  return code.toString().padStart(CODE_LENGTH, "0");
+}
+
+async function create(userId: string) {
+  const code = generateCode();
+  const codeHash = await password.hash(code);
+
+  const otp = await prisma.userOtp.create({
+    data: {
+      user_id: userId,
+      code_hash: codeHash,
+      expires_at: new Date(Date.now() + EXPIRATION_IN_MILLISECONDS),
+    },
+  });
+
+  return { code, otp };
+}
+
+async function sendEmailToUser(user: User, code: string) {
+  await email.send({
+    to: user.email,
+    subject: "Your Manifold login code",
+    text: `Hey ${user.username},
+
+Here is your one-time login code:
+
+${code}
+
+This code expires in 10 minutes and can only be used once.
+
+If you didn't request this code, you can safely ignore this email.
+
+The Manifold Team
+manifoldpowered.com`,
+  });
+}
+
+async function validateAndConsume(providedEmail: string, providedCode: string) {
+  const invalidOrExpiredError = new UnauthorizedError({
+    message: "Invalid or expired code",
+    action: "Request a new code and try again",
+  });
+
+  let userFound: User;
+  try {
+    userFound = await user.findOneByEmail(providedEmail);
+  } catch {
+    throw invalidOrExpiredError;
+  }
+
+  const candidateOtps = await prisma.userOtp.findMany({
+    where: {
+      user_id: userFound.id,
+      used_at: null,
+      expires_at: {
+        gt: new Date(),
+      },
+    },
+    orderBy: {
+      created_at: "desc",
+    },
+  });
+
+  for (const candidateOtp of candidateOtps) {
+    const isCodeValid = await password.compare(
+      providedCode,
+      candidateOtp.code_hash,
+    );
+
+    if (isCodeValid) {
+      await prisma.userOtp.update({
+        where: {
+          id: candidateOtp.id,
+        },
+        data: {
+          used_at: new Date(),
+        },
+      });
+
+      return userFound;
+    }
+  }
+
+  throw invalidOrExpiredError;
+}
+
+const otp = {
+  create,
+  sendEmailToUser,
+  validateAndConsume,
+  EXPIRATION_IN_MILLISECONDS,
+};
+
+export default otp;

--- a/models/otp.ts
+++ b/models/otp.ts
@@ -19,6 +19,8 @@ async function create(userId: string) {
   const code = generateCode();
   const codeHash = await password.hash(code);
 
+  await invalidateOutstandingCodes(userId);
+
   const otp = await prisma.userOtp.create({
     data: {
       user_id: userId,
@@ -28,6 +30,18 @@ async function create(userId: string) {
   });
 
   return { code, otp };
+}
+
+async function invalidateOutstandingCodes(userId: string) {
+  await prisma.userOtp.updateMany({
+    where: {
+      user_id: userId,
+      used_at: null,
+    },
+    data: {
+      used_at: new Date(),
+    },
+  });
 }
 
 async function sendEmailToUser(user: User, code: string) {
@@ -62,7 +76,7 @@ async function validateAndConsume(providedEmail: string, providedCode: string) {
     throw invalidOrExpiredError;
   }
 
-  const candidateOtps = await prisma.userOtp.findMany({
+  const activeOtp = await prisma.userOtp.findFirst({
     where: {
       user_id: userFound.id,
       used_at: null,
@@ -70,32 +84,28 @@ async function validateAndConsume(providedEmail: string, providedCode: string) {
         gt: new Date(),
       },
     },
-    orderBy: {
-      created_at: "desc",
+  });
+
+  if (!activeOtp) {
+    throw invalidOrExpiredError;
+  }
+
+  const isCodeValid = await password.compare(providedCode, activeOtp.code_hash);
+
+  if (!isCodeValid) {
+    throw invalidOrExpiredError;
+  }
+
+  await prisma.userOtp.update({
+    where: {
+      id: activeOtp.id,
+    },
+    data: {
+      used_at: new Date(),
     },
   });
 
-  for (const candidateOtp of candidateOtps) {
-    const isCodeValid = await password.compare(
-      providedCode,
-      candidateOtp.code_hash,
-    );
-
-    if (isCodeValid) {
-      await prisma.userOtp.update({
-        where: {
-          id: candidateOtp.id,
-        },
-        data: {
-          used_at: new Date(),
-        },
-      });
-
-      return userFound;
-    }
-  }
-
-  throw invalidOrExpiredError;
+  return userFound;
 }
 
 const otp = {

--- a/models/user.ts
+++ b/models/user.ts
@@ -1,13 +1,17 @@
 import { prisma } from "infra/database";
 import password from "models/password";
 import { NotFoundError, ValidationError } from "infra/errors";
+import { z } from "zod";
 
-interface CreateUserDto {
-  username: string;
-  email: string;
-  password: string;
+export const userSchema = z.object({
+  username: z.string().min(1).max(30),
+  email: z.email(),
+  password: z.string().min(1).nullable(),
+});
+
+export type CreateUserDto = z.infer<typeof userSchema> & {
   features?: string[];
-}
+};
 
 interface UpdateUserDto {
   username?: string;
@@ -73,6 +77,10 @@ const validateUniqueUsername = async (username: string) => {
 };
 
 const hashPasswordInObject = async (userDto: CreateUserDto | UpdateUserDto) => {
+  if (!userDto.password) {
+    return userDto;
+  }
+
   const hashedPassword = await password.hash(userDto.password);
   userDto.password = hashedPassword;
 

--- a/pages/api/v1/otp/index.ts
+++ b/pages/api/v1/otp/index.ts
@@ -1,0 +1,35 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { createRouter } from "next-connect";
+import controller from "infra/controller";
+import otp from "models/otp";
+import user from "models/user";
+import { ValidationError } from "infra/errors";
+import { z } from "zod";
+
+const requestOtpSchema = z.object({
+  email: z.email(),
+});
+
+export default createRouter<NextApiRequest, NextApiResponse>()
+  .use(controller.injectAnonymousOrUser)
+  .post(controller.canRequest("create:otp"), postHandler)
+  .handler(controller.errorHandlers);
+
+async function postHandler(req: NextApiRequest, res: NextApiResponse) {
+  const result = requestOtpSchema.safeParse(req.body);
+
+  if (!result.success) {
+    throw new ValidationError({
+      message: "One or more fields are invalid",
+      action: "Check the fields and try again",
+      context: result.error.issues,
+    });
+  }
+
+  const userRequestingCode = await user.findOneByEmail(result.data.email);
+
+  const { code } = await otp.create(userRequestingCode.id);
+  await otp.sendEmailToUser(userRequestingCode, code);
+
+  return res.status(201).json({ message: "OTP code sent to your email" });
+}

--- a/pages/api/v1/otp/sessions/index.ts
+++ b/pages/api/v1/otp/sessions/index.ts
@@ -1,0 +1,54 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { createRouter } from "next-connect";
+import controller from "infra/controller";
+import otp from "models/otp";
+import session from "models/session";
+import authorization from "models/authorization";
+import { ForbiddenError, ValidationError } from "infra/errors";
+import { z } from "zod";
+
+const verifyOtpSchema = z.object({
+  email: z.email(),
+  code: z.string().length(6),
+});
+
+export default createRouter<NextApiRequest, NextApiResponse>()
+  .use(controller.injectAnonymousOrUser)
+  .post(controller.canRequest("create:session"), postHandler)
+  .handler(controller.errorHandlers);
+
+async function postHandler(req: NextApiRequest, res: NextApiResponse) {
+  const result = verifyOtpSchema.safeParse(req.body);
+
+  if (!result.success) {
+    throw new ValidationError({
+      message: "One or more fields are invalid",
+      action: "Check the fields and try again",
+      context: result.error.issues,
+    });
+  }
+
+  const authUser = await otp.validateAndConsume(
+    result.data.email,
+    result.data.code,
+  );
+
+  if (!authorization.can(authUser, "create:session")) {
+    throw new ForbiddenError({
+      message: "You do not have permission to login",
+      action: "Contact support if you believe this is an error",
+    });
+  }
+
+  const newSession = await session.create(authUser.id);
+
+  controller.setSessionCookie(res, newSession.token);
+
+  const secureOutputValues = authorization.filterOutput(
+    authUser,
+    "read:session",
+    newSession,
+  );
+
+  return res.status(201).json(secureOutputValues);
+}

--- a/pages/api/v1/users/index.ts
+++ b/pages/api/v1/users/index.ts
@@ -1,9 +1,10 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { createRouter } from "next-connect";
 import controller from "infra/controller";
-import user from "models/user";
+import user, { userSchema } from "models/user";
 import activation from "models/activation";
 import authorization from "models/authorization";
+import { ValidationError } from "infra/errors";
 
 export default createRouter<NextApiRequest, NextApiResponse>()
   .use(controller.injectAnonymousOrUser)
@@ -11,10 +12,19 @@ export default createRouter<NextApiRequest, NextApiResponse>()
   .handler(controller.errorHandlers);
 
 async function postHandler(req: NextApiRequest, res: NextApiResponse) {
-  const userCreateDto = req.body;
+  const result = userSchema.safeParse(req.body);
+
+  if (!result.success) {
+    throw new ValidationError({
+      message: "One or more fields are invalid",
+      action: "Check the fields and try again",
+      context: result.error.issues,
+    });
+  }
+
   const userTryingToCreate = req.context.user;
 
-  const newUser = await user.create(userCreateDto);
+  const newUser = await user.create(result.data);
   const newActivation = await activation.create(newUser.id);
   await activation.sendEmailToUser(newUser, newActivation);
 

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -3,35 +3,75 @@ import { useRouter } from "next/router";
 import Link from "next/link";
 import AuthLayout from "../../components/AuthLayout";
 
+type Step = "email" | "code";
+
 export default function LoginPage() {
   const router = useRouter();
+  const [step, setStep] = useState<Step>("email");
   const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
+  const [code, setCode] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+  async function handleRequestCode(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setErrorMessage("");
 
     setIsSubmitting(true);
 
     try {
-      const response = await fetch("/api/v1/sessions", {
+      const response = await fetch("/api/v1/otp", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
           email: email.trim(),
-          password,
         }),
       });
 
       if (!response.ok) {
         const responseBody = await response.json().catch(() => null);
         throw new Error(
-          responseBody?.message || "Invalid credentials. Please try again.",
+          responseBody?.message || "Could not send the login code.",
+        );
+      }
+
+      // Success
+      setStep("code");
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "Could not send the login code.",
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  async function handleVerifyCode(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setErrorMessage("");
+
+    setIsSubmitting(true);
+
+    try {
+      const response = await fetch("/api/v1/otp/sessions", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          email: email.trim(),
+          code: code.trim(),
+        }),
+      });
+
+      if (!response.ok) {
+        const responseBody = await response.json().catch(() => null);
+        throw new Error(
+          responseBody?.message || "Invalid code. Please try again.",
         );
       }
 
@@ -44,11 +84,17 @@ export default function LoginPage() {
       setErrorMessage(
         error instanceof Error
           ? error.message
-          : "Invalid credentials. Please try again.",
+          : "Invalid code. Please try again.",
       );
     } finally {
       setIsSubmitting(false);
     }
+  }
+
+  function handleUseDifferentEmail() {
+    setStep("email");
+    setCode("");
+    setErrorMessage("");
   }
 
   return (
@@ -56,33 +102,46 @@ export default function LoginPage() {
       title="Login | Manifold"
       description="Login to your Manifold account."
     >
-      <form className="auth-form" onSubmit={handleSubmit}>
+      <form
+        className="auth-form"
+        onSubmit={step === "email" ? handleRequestCode : handleVerifyCode}
+      >
         <div className="modal-heading">
           <h2 id="login-title">Log In</h2>
-          <p>Welcome back to Manifold.</p>
+          <p>
+            {step === "email"
+              ? "Welcome back to Manifold."
+              : `Enter the code we sent to ${email.trim()}.`}
+          </p>
         </div>
 
-        <label className="field">
-          <span>Email</span>
-          <input
-            autoComplete="email"
-            required
-            type="email"
-            value={email}
-            onChange={(event) => setEmail(event.target.value)}
-          />
-        </label>
-
-        <label className="field">
-          <span>Password</span>
-          <input
-            autoComplete="current-password"
-            required
-            type="password"
-            value={password}
-            onChange={(event) => setPassword(event.target.value)}
-          />
-        </label>
+        {step === "email" ? (
+          <label className="field">
+            <span>Email</span>
+            <input
+              autoComplete="email"
+              required
+              type="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+            />
+          </label>
+        ) : (
+          <label className="field">
+            <span>Code</span>
+            <input
+              autoComplete="one-time-code"
+              inputMode="numeric"
+              maxLength={6}
+              minLength={6}
+              pattern="[0-9]{6}"
+              required
+              type="text"
+              value={code}
+              onChange={(event) => setCode(event.target.value)}
+            />
+          </label>
+        )}
 
         {errorMessage ? (
           <p className="form-message error" role="alert">
@@ -91,8 +150,25 @@ export default function LoginPage() {
         ) : null}
 
         <button className="submit-button" disabled={isSubmitting} type="submit">
-          {isSubmitting ? "Logging in..." : "Log In"}
+          {isSubmitting
+            ? step === "email"
+              ? "Sending..."
+              : "Verifying..."
+            : step === "email"
+              ? "Send Code"
+              : "Log In"}
         </button>
+
+        {step === "code" ? (
+          <button
+            className="submit-button"
+            type="button"
+            disabled={isSubmitting}
+            onClick={handleUseDifferentEmail}
+          >
+            Use a different email
+          </button>
+        ) : null}
 
         <p className="signup-prompt">
           Don&apos;t have an account?{" "}

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -5,15 +5,6 @@ import AuthLayout from "../../components/AuthLayout";
 const USERNAME_PATTERN = /^[A-Za-z0-9]{3,30}$/;
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-function generatePassword() {
-  const randomBytes = new Uint8Array(24);
-  window.crypto.getRandomValues(randomBytes);
-
-  return Array.from(randomBytes, (byte) =>
-    byte.toString(36).padStart(2, "0"),
-  ).join("");
-}
-
 export default function SignupPage() {
   const [username, setUsername] = useState("");
   const [email, setEmail] = useState("");
@@ -44,7 +35,6 @@ export default function SignupPage() {
     setIsSubmitting(true);
 
     try {
-      const password = generatePassword();
       const response = await fetch("/api/v1/users", {
         method: "POST",
         headers: {
@@ -53,7 +43,7 @@ export default function SignupPage() {
         body: JSON.stringify({
           username: trimmedUsername,
           email: trimmedEmail,
-          password,
+          password: null,
         }),
       });
 

--- a/prisma/migrations/20260716023920_create_user_otps_table/migration.sql
+++ b/prisma/migrations/20260716023920_create_user_otps_table/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "user_otps" (
+    "id" TEXT NOT NULL,
+    "used_at" TIMESTAMP(3),
+    "user_id" TEXT NOT NULL,
+    "code_hash" VARCHAR(60) NOT NULL,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "user_otps_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "user_otps_user_id_idx" ON "user_otps"("user_id");
+
+-- CreateIndex
+CREATE INDEX "user_otps_expires_at_idx" ON "user_otps"("expires_at");

--- a/prisma/migrations/20260716154520_make_user_password_nullable/migration.sql
+++ b/prisma/migrations/20260716154520_make_user_password_nullable/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ALTER COLUMN "password" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,7 +27,8 @@ model User {
   email String @unique @db.VarChar(234)
 
   // Why 60 characters? https://security.stackexchange.com/q/39849
-  password String @db.VarChar(60)
+  // Nullable: passwordless accounts authenticate via email OTP instead
+  password String? @db.VarChar(60)
 
   features String[] @default([])
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,6 +67,21 @@ model UserActivationToken {
   @@map("user_activation_tokens")
 }
 
+model UserOtp {
+  id         String    @id @default(uuid())
+  used_at    DateTime?
+  // No FK on purpose, we will experiment a no Foreign Key approach as github does ("At GitHub we do not use foreign keys, ever, anywhere.") https://github.com/github/gh-ost/issues/331#issuecomment-266027731
+  user_id    String
+  code_hash  String    @db.VarChar(60)
+  expires_at DateTime
+  created_at DateTime  @default(now())
+  updated_at DateTime  @updatedAt
+
+  @@index([user_id])
+  @@index([expires_at])
+  @@map("user_otps")
+}
+
 enum GameStatus {
   ACTIVE
   INACTIVE

--- a/tests/integration/_use-cases/passwordless-login-flow.test.ts
+++ b/tests/integration/_use-cases/passwordless-login-flow.test.ts
@@ -1,0 +1,89 @@
+import { User } from "generated/prisma/client";
+import webserver from "infra/webserver";
+import orchestrator from "tests/orchestrator";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+  await orchestrator.deleteAllEmails();
+});
+
+let newUser: User;
+let sessionToken: string;
+
+describe("Use case: Passwordless login flow via OTP (all successful)", () => {
+  test("Create and activate a user account", async () => {
+    newUser = await orchestrator.createUser({
+      email: "passwordless-flow@manifoldpowered.com",
+    });
+    await orchestrator.activateUser(newUser.id);
+  });
+
+  test("Request an OTP code", async () => {
+    const response = await fetch(`${webserver.getOrigin()}/api/v1/otp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: newUser.email }),
+    });
+
+    expect(response.status).toBe(201);
+  });
+
+  test("Receive the code by email", async () => {
+    const lastEmail = await orchestrator.getLastEmail();
+
+    expect(lastEmail.recipients[0]).toBe(
+      "<passwordless-flow@manifoldpowered.com>",
+    );
+    expect(lastEmail.subject).toBe("Your Manifold login code");
+
+    const code = orchestrator.extractOtpCode(lastEmail.text);
+    expect(code).toMatch(/^\d{6}$/);
+
+    const verifyResponse = await fetch(
+      `${webserver.getOrigin()}/api/v1/otp/sessions`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: newUser.email, code }),
+      },
+    );
+
+    expect(verifyResponse.status).toBe(201);
+
+    const verifyResponseBody = await verifyResponse.json();
+    expect(verifyResponseBody.user_id).toBe(newUser.id);
+
+    sessionToken = verifyResponseBody.token;
+  });
+
+  test("Access the authenticated profile with the issued session", async () => {
+    const response = await fetch(`${webserver.getOrigin()}/api/v1/user`, {
+      method: "GET",
+      headers: {
+        Cookie: `session_id=${sessionToken}`,
+      },
+    });
+
+    expect(response.status).toBe(200);
+
+    const responseBody = await response.json();
+    expect(responseBody.id).toBe(newUser.id);
+  });
+
+  test("Reusing the same code should now fail", async () => {
+    const lastEmail = await orchestrator.getLastEmail();
+    const code = orchestrator.extractOtpCode(lastEmail.text);
+
+    const response = await fetch(
+      `${webserver.getOrigin()}/api/v1/otp/sessions`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: newUser.email, code }),
+      },
+    );
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/tests/integration/api/v1/otp/post.test.ts
+++ b/tests/integration/api/v1/otp/post.test.ts
@@ -1,0 +1,69 @@
+import orchestrator from "tests/orchestrator";
+import webserver from "infra/webserver";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+  await orchestrator.deleteAllEmails();
+});
+
+describe("POST /api/v1/otp", () => {
+  describe("Anonymous user", () => {
+    test("With existing email should send a code and return 201", async () => {
+      const user = await orchestrator.createUser({
+        email: "otp-request@pedro.tec.br",
+      });
+
+      const response = await fetch(`${webserver.getOrigin()}/api/v1/otp`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: user.email }),
+      });
+
+      expect(response.status).toBe(201);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({ message: "OTP code sent to your email" });
+
+      const lastEmail = await orchestrator.getLastEmail();
+      expect(lastEmail.sender).toBe("<contact@manifoldpowered.com>");
+      expect(lastEmail.recipients[0]).toBe("<otp-request@pedro.tec.br>");
+      expect(lastEmail.subject).toBe("Your Manifold login code");
+
+      const code = orchestrator.extractOtpCode(lastEmail.text);
+      expect(code).toMatch(/^\d{6}$/);
+    });
+
+    test("With non-existent email should return 404", async () => {
+      const response = await fetch(`${webserver.getOrigin()}/api/v1/otp`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: "non-existent@pedro.tec.br" }),
+      });
+
+      expect(response.status).toBe(404);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        message: "User with email non-existent@pedro.tec.br not found",
+        name: "NotFoundError",
+        action: "Try another email",
+        status_code: 404,
+      });
+    });
+
+    test("With invalid email format should return 400", async () => {
+      const response = await fetch(`${webserver.getOrigin()}/api/v1/otp`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: "not-an-email" }),
+      });
+
+      expect(response.status).toBe(400);
+
+      const responseBody = await response.json();
+      expect(responseBody.name).toBe("ValidationError");
+      expect(responseBody.status_code).toBe(400);
+    });
+  });
+});

--- a/tests/integration/api/v1/otp/sessions/post.test.ts
+++ b/tests/integration/api/v1/otp/sessions/post.test.ts
@@ -1,0 +1,209 @@
+import orchestrator from "tests/orchestrator";
+import otp from "models/otp";
+import session from "models/session";
+import setCookieParser from "set-cookie-parser";
+import webserver from "infra/webserver";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+describe("POST /api/v1/otp/sessions", () => {
+  describe("Anonymous user", () => {
+    test("With valid and unexpired code should create a session and return 201", async () => {
+      const user = await orchestrator.createUser();
+      await orchestrator.activateUser(user.id);
+
+      const { code } = await otp.create(user.id);
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/otp/sessions`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: user.email, code }),
+        },
+      );
+
+      expect(response.status).toBe(201);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        id: responseBody.id,
+        token: responseBody.token,
+        user_id: user.id,
+        expires_at: responseBody.expires_at,
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+      });
+
+      const parsedSetCookie = setCookieParser(response, { map: true });
+      expect(parsedSetCookie.session_id).toEqual({
+        name: "session_id",
+        value: responseBody.token,
+        path: "/",
+        maxAge: session.EXPIRATION_IN_MILLISECONDS / 1000,
+        httpOnly: true,
+        sameSite: "Lax",
+      });
+    });
+
+    test("With invalid code should return 401", async () => {
+      const user = await orchestrator.createUser();
+      await orchestrator.activateUser(user.id);
+      await otp.create(user.id);
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/otp/sessions`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: user.email, code: "000000" }),
+        },
+      );
+
+      expect(response.status).toBe(401);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        message: "Invalid or expired code",
+        name: "UnauthorizedError",
+        action: "Request a new code and try again",
+        status_code: 401,
+      });
+    });
+
+    test("With non-existent email should return 401", async () => {
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/otp/sessions`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            email: "non-existent@pedro.tec.br",
+            code: "123456",
+          }),
+        },
+      );
+
+      expect(response.status).toBe(401);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        message: "Invalid or expired code",
+        name: "UnauthorizedError",
+        action: "Request a new code and try again",
+        status_code: 401,
+      });
+    });
+
+    test("With expired code should return 401", async () => {
+      const user = await orchestrator.createUser();
+      await orchestrator.activateUser(user.id);
+
+      jest.useFakeTimers({
+        now: Date.now() - otp.EXPIRATION_IN_MILLISECONDS - 3000,
+        doNotFake: orchestrator.DO_NOT_FAKE_TIMERS_FOR_PRISMA as FakeableAPI[],
+      });
+
+      const { code } = await otp.create(user.id);
+
+      jest.useRealTimers();
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/otp/sessions`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: user.email, code }),
+        },
+      );
+
+      expect(response.status).toBe(401);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        message: "Invalid or expired code",
+        name: "UnauthorizedError",
+        action: "Request a new code and try again",
+        status_code: 401,
+      });
+    });
+
+    test("With already used code should return 401", async () => {
+      const user = await orchestrator.createUser();
+      await orchestrator.activateUser(user.id);
+      const { code } = await otp.create(user.id);
+
+      const firstResponse = await fetch(
+        `${webserver.getOrigin()}/api/v1/otp/sessions`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: user.email, code }),
+        },
+      );
+      expect(firstResponse.status).toBe(201);
+
+      const secondResponse = await fetch(
+        `${webserver.getOrigin()}/api/v1/otp/sessions`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: user.email, code }),
+        },
+      );
+
+      expect(secondResponse.status).toBe(401);
+
+      const responseBody = await secondResponse.json();
+      expect(responseBody).toEqual({
+        message: "Invalid or expired code",
+        name: "UnauthorizedError",
+        action: "Request a new code and try again",
+        status_code: 401,
+      });
+    });
+
+    test("With unactivated user should return 403", async () => {
+      const user = await orchestrator.createUser();
+      const { code } = await otp.create(user.id);
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/otp/sessions`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: user.email, code }),
+        },
+      );
+
+      expect(response.status).toBe(403);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        message: "You do not have permission to login",
+        name: "ForbiddenError",
+        action: "Contact support if you believe this is an error",
+        status_code: 403,
+      });
+    });
+
+    test("With invalid body should return 400", async () => {
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/otp/sessions`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: "not-an-email", code: "1" }),
+        },
+      );
+
+      expect(response.status).toBe(400);
+
+      const responseBody = await response.json();
+      expect(responseBody.name).toBe("ValidationError");
+    });
+  });
+});

--- a/tests/integration/api/v1/sessions/post.test.ts
+++ b/tests/integration/api/v1/sessions/post.test.ts
@@ -89,6 +89,34 @@ describe("POST /api/v1/sessions", () => {
       });
     });
 
+    test("With correct-looking credentials against a passwordless account should return 401, not crash", async () => {
+      const passwordlessUser = await orchestrator.createUser({
+        email: "passwordless@pedro.tec.br",
+        password: null,
+      });
+      await orchestrator.activateUser(passwordlessUser.id);
+
+      const response = await fetch(`${webserver.getOrigin()}/api/v1/sessions`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          email: "passwordless@pedro.tec.br",
+          password: "any-password-guess",
+        }),
+      });
+      expect(response.status).toBe(401);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        message: "Invalid credentials",
+        name: "UnauthorizedError",
+        action: "Check your credentials",
+        status_code: 401,
+      });
+    });
+
     test("With correct email and correct password", async () => {
       const user = await orchestrator.createUser({
         email: "correct@pedro.tec.br",

--- a/tests/integration/api/v1/users/post.test.ts
+++ b/tests/integration/api/v1/users/post.test.ts
@@ -54,6 +54,53 @@ describe("POST /api/v1/users", () => {
       expect(isPasswordInvalid).toBe(false);
     });
 
+    test("With null password should return 201 Created and store a null password", async () => {
+      const response = await fetch(`${webserver.getOrigin()}/api/v1/users`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "Jane Doe",
+          email: "jane@pedro.tec.br",
+          password: null,
+        }),
+      });
+      expect(response.status).toBe(201);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        id: responseBody.id,
+        username: "jane doe",
+        features: ["read:activation_token"],
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+      });
+
+      const userInDatabase = await user.findOneByUsername("jane doe");
+      expect(userInDatabase.password).toBeNull();
+    });
+
+    test("With invalid password type should return 400", async () => {
+      const response = await fetch(`${webserver.getOrigin()}/api/v1/users`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "Bad Password",
+          email: "badpassword@pedro.tec.br",
+          password: 12345,
+        }),
+      });
+      expect(response.status).toBe(400);
+
+      const responseBody = await response.json();
+      expect(responseBody.name).toBe("ValidationError");
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.action).toBe("Check the fields and try again");
+    });
+
     test("With duplicate username", async () => {
       const response = await fetch(`${webserver.getOrigin()}/api/v1/users`, {
         method: "POST",

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -71,7 +71,10 @@ const createUser = async (userDto = {}) => {
     username:
       userDto.username || faker.internet.username().replace(/[_.-]/g, ""),
     email: userDto.email || faker.internet.email(),
-    password: userDto.password || faker.internet.password(),
+    password:
+      userDto.password !== undefined
+        ? userDto.password
+        : faker.internet.password(),
   });
 };
 

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -124,6 +124,12 @@ const extractUUID = (text) => {
   return match ? match[0] : null;
 };
 
+const extractOtpCode = (text) => {
+  const regex = /\b\d{6}\b/;
+  const match = text.match(regex);
+  return match ? match[0] : null;
+};
+
 // Games
 const createGame = async (userId, gameData = {}) => {
   return game.create({
@@ -193,6 +199,7 @@ const orchestrator = {
   getFileDownloadUrl,
   createStore,
   addStoreMember,
+  extractOtpCode,
 };
 
 export default orchestrator;


### PR DESCRIPTION
Removes the vestigial client-generated password from signup and switches signin to the existing email-OTP flow, per CLAUDE.md-compliance discussion in the linked planning conversation.

## Summary
- **Signup** (`pages/signup/index.tsx`) no longer generates a throwaway random password client-side — it sends `password: null` explicitly.
- **`User.password` is now nullable** (`prisma/schema.prisma` + migration) so the backend can actually store that.
- **`models/user.ts`** gains an exported `userSchema`/`CreateUserDto` pair (Zod schema + inferred DTO type), mirroring the existing `gameSchema`/`GameCreateDto` and `storeSchema`/`StoreCreateDto` pattern. `hashPasswordInObject` now no-ops when the password is null/falsy instead of hashing.
- **`pages/api/v1/users/index.ts`** now runs `userSchema.safeParse` + throws `ValidationError` on failure — this endpoint previously had **zero** input validation despite CLAUDE.md explicitly citing it as one of the two reference files for the "all inputs Zod-validated" rule.
- **`models/authentication.ts`** guards `validatePassword` against a null stored password, so a password-login attempt against a passwordless account returns the same generic `401 Invalid credentials` as any other bad-credentials case instead of crashing with an unhandled `bcrypt.compare(x, null)` error.
- **Signin** (`pages/login/index.tsx`) is rewritten as a two-step flow (email → request code, code → verify) against the already-merged `POST /api/v1/otp` / `POST /api/v1/otp/sessions` endpoints. The password field/state is gone entirely. `components/store/UserMenu.tsx` needed no changes — it's decoupled, polling `GET /api/v1/user` independently of how login happened.

## Explicitly out of scope
- `PATCH /api/v1/users/[username]` (password-change path) — untouched.
- Removing password login entirely — accounts that already have a password (or set one later via the untouched PATCH endpoint) keep working via `POST /api/v1/sessions`. Only new signups become genuinely passwordless.

## Test plan
- [x] `tests/integration/api/v1/users/post.test.ts` — new null-password success case (asserts `user.password` is `null` in the DB) + invalid-password-type 400 case (proves the new Zod schema works)
- [x] `tests/integration/api/v1/sessions/post.test.ts` — new case: password login against a passwordless account returns 401, not a 500
- [x] `tests/orchestrator.js`'s `createUser` fixed so `password: null` isn't silently coerced to a fake password by its `||` fallback
- [x] `npx prisma generate`, `tsc --noEmit`, `eslint`, `prettier --check` all pass clean on every touched file
- [x] `next build` succeeds (all routes compile, including both changed pages)
- [x] Manual browser verification via a static build + Playwright screenshots (no live backend available in this sandbox): confirmed the login page's email step, code step, and error state all render correctly, and confirmed the signup form's actual network payload is `{"username":"...","email":"...","password":null}`
- [ ] Full Docker-based `npm run test` suite — left to CI (this sandbox can't reach Docker Hub); will monitor once opened


---
_Generated by [Claude Code](https://claude.ai/code/session_01KqgzgcnJYJzXZBkVKpwhLz)_