### PR TITLE
feat: game curation via store tag filters and game overrides

### DIFF
--- a/models/authorization.ts
+++ b/models/authorization.ts
@@ -6,6 +6,8 @@ import {
   Review,
   Store,
   StoreMember,
+  StoreTagFilter,
+  StoreGameOverride,
 } from "generated/prisma/client";
 import { InternalServerError } from "infra/errors";
 
@@ -65,6 +67,8 @@ const AVAILABLE_FEATURES = [
   "update:store:any",
   "manage:store_members",
   "manage:store_members:any",
+  "read:store_tag_filter",
+  "read:store_game_override",
 ];
 
 function can(user: Partial<User>, feature: string, resource?: unknown) {
@@ -322,6 +326,33 @@ function filterOutput(user: Partial<User>, feature: string, resource: unknown) {
       permissions: memberOutput.permissions,
       created_at: memberOutput.created_at,
       updated_at: memberOutput.updated_at,
+    };
+  }
+
+  if (feature === "read:store_tag_filter") {
+    const tagFilterOutput = resource as StoreTagFilter;
+    return {
+      id: tagFilterOutput.id,
+      store_id: tagFilterOutput.store_id,
+      tag: tagFilterOutput.tag,
+      mode: tagFilterOutput.mode,
+      created_at: tagFilterOutput.created_at,
+      updated_at: tagFilterOutput.updated_at,
+    };
+  }
+
+  if (feature === "read:store_game_override") {
+    const overrideOutput = resource as StoreGameOverride & {
+      game_slug: string;
+    };
+    return {
+      id: overrideOutput.id,
+      store_id: overrideOutput.store_id,
+      game_id: overrideOutput.game_id,
+      game_slug: overrideOutput.game_slug,
+      visibility: overrideOutput.visibility,
+      created_at: overrideOutput.created_at,
+      updated_at: overrideOutput.updated_at,
     };
   }
 

--- a/models/game.ts
+++ b/models/game.ts
@@ -341,12 +341,14 @@ async function findAllPaginated({
   order = "newest",
   tags,
   q,
+  curationWhere,
 }: {
   page?: number;
   limit?: number;
   order?: string;
   tags?: string[];
   q?: string;
+  curationWhere?: Prisma.GameWhereInput;
 }) {
   const where: Prisma.GameWhereInput = {
     status: "ACTIVE",
@@ -365,12 +367,19 @@ async function findAllPaginated({
     ];
   }
 
+  if (curationWhere && Object.keys(curationWhere).length > 0) {
+    where.AND = [curationWhere];
+  }
+
   const orderByMap = {
     newest: { created_at: "desc" },
     oldest: { created_at: "asc" },
     price_asc: { price: "asc" },
     price_desc: { price: "desc" },
     title_asc: { title: "asc" },
+    featured: [{ positive_reviews: "desc" }, { created_at: "desc" }],
+    trending: [{ updated_at: "desc" }, { positive_reviews: "desc" }],
+    new_releases: [{ launch_date: "desc" }],
   };
 
   const [games, total] = await Promise.all([

--- a/models/store_curation.ts
+++ b/models/store_curation.ts
@@ -1,0 +1,304 @@
+import { prisma } from "infra/database";
+import { z } from "zod";
+import { NotFoundError, ValidationError } from "infra/errors";
+import { Prisma } from "generated/prisma/client";
+import gameModel from "models/game";
+
+export const TAG_FILTER_MODES = ["WHITELIST", "BLACKLIST"] as const;
+
+export const tagFilterSchema = z.object({
+  tag: z.string().min(1).max(100),
+  mode: z.enum(TAG_FILTER_MODES),
+});
+
+export type TagFilterCreateDto = z.infer<typeof tagFilterSchema>;
+
+export const tagFilterModeSchema = tagFilterSchema.pick({ mode: true });
+
+export const GAME_OVERRIDE_VISIBILITIES = ["SHOW", "HIDE"] as const;
+
+export const gameOverrideSchema = z.object({
+  game_slug: z.string().min(1),
+  visibility: z.enum(GAME_OVERRIDE_VISIBILITIES),
+});
+
+export type GameOverrideCreateDto = z.infer<typeof gameOverrideSchema>;
+
+export const gameOverrideVisibilitySchema = gameOverrideSchema.pick({
+  visibility: true,
+});
+
+async function addTagFilter(
+  storeId: string,
+  tag: string,
+  mode: (typeof TAG_FILTER_MODES)[number],
+) {
+  try {
+    return await prisma.storeTagFilter.create({
+      data: {
+        store_id: storeId,
+        tag,
+        mode,
+      },
+    });
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      throw new ValidationError({
+        message: `Tag "${tag}" already has a filter configured for this store.`,
+        action: "Update the existing filter instead of creating a new one.",
+      });
+    }
+    throw error;
+  }
+}
+
+async function findOneTagFilterByTag(storeId: string, tag: string) {
+  const filter = await prisma.storeTagFilter.findUnique({
+    where: {
+      store_id_tag: {
+        store_id: storeId,
+        tag,
+      },
+    },
+  });
+
+  if (!filter) {
+    throw new NotFoundError({
+      message: `No filter configured for tag "${tag}" in this store.`,
+      action: "Check the tag and try again.",
+    });
+  }
+
+  return filter;
+}
+
+async function updateTagFilterMode(
+  storeId: string,
+  tag: string,
+  mode: (typeof TAG_FILTER_MODES)[number],
+) {
+  const filter = await findOneTagFilterByTag(storeId, tag);
+
+  return await prisma.storeTagFilter.update({
+    where: {
+      id: filter.id,
+    },
+    data: {
+      mode,
+    },
+  });
+}
+
+async function removeTagFilter(storeId: string, tag: string) {
+  const filter = await findOneTagFilterByTag(storeId, tag);
+
+  await prisma.storeTagFilter.delete({
+    where: {
+      id: filter.id,
+    },
+  });
+}
+
+async function listTagFilters(storeId: string) {
+  return await prisma.storeTagFilter.findMany({
+    where: {
+      store_id: storeId,
+    },
+    orderBy: {
+      created_at: "asc",
+    },
+  });
+}
+
+async function addGameOverride(
+  storeId: string,
+  gameSlug: string,
+  visibility: (typeof GAME_OVERRIDE_VISIBILITIES)[number],
+) {
+  const targetGame = await gameModel.findOneBySlug(gameSlug);
+
+  if (!targetGame) {
+    throw new NotFoundError({
+      message: `Game with slug "${gameSlug}" was not found.`,
+      action: "Check the slug and try again.",
+    });
+  }
+
+  try {
+    return await prisma.storeGameOverride.create({
+      data: {
+        store_id: storeId,
+        game_id: targetGame.id,
+        visibility,
+      },
+    });
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      throw new ValidationError({
+        message: `Game "${gameSlug}" already has an override configured for this store.`,
+        action: "Update the existing override instead of creating a new one.",
+      });
+    }
+    throw error;
+  }
+}
+
+async function findOneGameOverrideBySlug(storeId: string, gameSlug: string) {
+  const targetGame = await gameModel.findOneBySlug(gameSlug);
+
+  if (!targetGame) {
+    throw new NotFoundError({
+      message: `Game with slug "${gameSlug}" was not found.`,
+      action: "Check the slug and try again.",
+    });
+  }
+
+  const override = await prisma.storeGameOverride.findUnique({
+    where: {
+      store_id_game_id: {
+        store_id: storeId,
+        game_id: targetGame.id,
+      },
+    },
+  });
+
+  if (!override) {
+    throw new NotFoundError({
+      message: `No override configured for game "${gameSlug}" in this store.`,
+      action: "Check the slug and try again.",
+    });
+  }
+
+  return override;
+}
+
+async function updateGameOverrideVisibility(
+  storeId: string,
+  gameSlug: string,
+  visibility: (typeof GAME_OVERRIDE_VISIBILITIES)[number],
+) {
+  const override = await findOneGameOverrideBySlug(storeId, gameSlug);
+
+  return await prisma.storeGameOverride.update({
+    where: {
+      id: override.id,
+    },
+    data: {
+      visibility,
+    },
+  });
+}
+
+async function removeGameOverride(storeId: string, gameSlug: string) {
+  const override = await findOneGameOverrideBySlug(storeId, gameSlug);
+
+  await prisma.storeGameOverride.delete({
+    where: {
+      id: override.id,
+    },
+  });
+}
+
+async function listGameOverridesWithSlugs(storeId: string) {
+  const overrides = await prisma.storeGameOverride.findMany({
+    where: {
+      store_id: storeId,
+    },
+    orderBy: {
+      created_at: "asc",
+    },
+  });
+
+  const gameIds = overrides.map((override) => override.game_id);
+  const games = await prisma.game.findMany({
+    where: {
+      id: { in: gameIds },
+    },
+    select: {
+      id: true,
+      slug: true,
+    },
+  });
+
+  const slugByGameId = games.reduce(
+    (acc, gameRow) => {
+      acc[gameRow.id] = gameRow.slug;
+      return acc;
+    },
+    {} as Record<string, string>,
+  );
+
+  return overrides.map((override) => ({
+    ...override,
+    game_slug: slugByGameId[override.game_id] || "unknown",
+  }));
+}
+
+async function getCurationWhereClause(
+  storeId: string,
+): Promise<Prisma.GameWhereInput> {
+  const [filters, overrides] = await Promise.all([
+    prisma.storeTagFilter.findMany({ where: { store_id: storeId } }),
+    prisma.storeGameOverride.findMany({ where: { store_id: storeId } }),
+  ]);
+
+  const whitelist = filters
+    .filter((filter) => filter.mode === "WHITELIST")
+    .map((filter) => filter.tag);
+  const blacklist = filters
+    .filter((filter) => filter.mode === "BLACKLIST")
+    .map((filter) => filter.tag);
+  const forceShowIds = overrides
+    .filter((override) => override.visibility === "SHOW")
+    .map((override) => override.game_id);
+  const forceHideIds = overrides
+    .filter((override) => override.visibility === "HIDE")
+    .map((override) => override.game_id);
+
+  if (
+    whitelist.length === 0 &&
+    blacklist.length === 0 &&
+    forceShowIds.length === 0 &&
+    forceHideIds.length === 0
+  ) {
+    return {};
+  }
+
+  // Overrides always win over tag-based rules: a force-hidden game is excluded
+  // even if it matches the whitelist, and a force-shown game is included even
+  // if it carries a blacklisted tag or doesn't match the whitelist.
+  const tagRuleWhere: Prisma.GameWhereInput = {};
+  if (whitelist.length > 0) {
+    tagRuleWhere.tags = { hasSome: whitelist };
+  }
+  if (blacklist.length > 0) {
+    tagRuleWhere.NOT = { tags: { hasSome: blacklist } };
+  }
+
+  return {
+    AND: [
+      { id: { notIn: forceHideIds } },
+      { OR: [{ id: { in: forceShowIds } }, tagRuleWhere] },
+    ],
+  };
+}
+
+const storeCuration = {
+  addTagFilter,
+  updateTagFilterMode,
+  removeTagFilter,
+  listTagFilters,
+  addGameOverride,
+  updateGameOverrideVisibility,
+  removeGameOverride,
+  listGameOverridesWithSlugs,
+  getCurationWhereClause,
+};
+
+export default storeCuration;

--- a/pages/api/v1/stores/[slug]/game-overrides/[gameSlug]/index.ts
+++ b/pages/api/v1/stores/[slug]/game-overrides/[gameSlug]/index.ts
@@ -1,0 +1,73 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { createRouter } from "next-connect";
+import controller from "infra/controller";
+import store from "models/store";
+import storeCuration, {
+  gameOverrideVisibilitySchema,
+} from "models/store_curation";
+import authorization from "models/authorization";
+import { ForbiddenError, ValidationError } from "infra/errors";
+
+export default createRouter<NextApiRequest, NextApiResponse>()
+  .use(controller.injectAnonymousOrUser)
+  .patch(controller.canRequest("update:store"), patchHandler)
+  .delete(controller.canRequest("update:store"), deleteHandler)
+  .handler(controller.errorHandlers);
+
+async function patchHandler(req: NextApiRequest, res: NextApiResponse) {
+  const { slug, gameSlug } = req.query;
+
+  const result = gameOverrideVisibilitySchema.safeParse(req.body);
+
+  if (!result.success) {
+    throw new ValidationError({
+      message: "One or more fields are invalid",
+      action: "Check the fields and try again",
+      context: result.error.issues,
+    });
+  }
+
+  const userTryingToUpdate = req.context.user;
+  const foundStore = await store.findOneBySlugWithMembers(slug as string);
+
+  if (!authorization.can(userTryingToUpdate, "update:store", foundStore)) {
+    throw new ForbiddenError({
+      message:
+        "You do not have permission to manage this store's game overrides",
+      action: "Verify if you are an administrator of this store",
+    });
+  }
+
+  const updatedOverride = await storeCuration.updateGameOverrideVisibility(
+    foundStore.id,
+    gameSlug as string,
+    result.data.visibility,
+  );
+
+  const secureOutputValues = authorization.filterOutput(
+    userTryingToUpdate,
+    "read:store_game_override",
+    { ...updatedOverride, game_slug: gameSlug as string },
+  );
+
+  return res.status(200).json(secureOutputValues);
+}
+
+async function deleteHandler(req: NextApiRequest, res: NextApiResponse) {
+  const { slug, gameSlug } = req.query;
+
+  const userTryingToRemove = req.context.user;
+  const foundStore = await store.findOneBySlugWithMembers(slug as string);
+
+  if (!authorization.can(userTryingToRemove, "update:store", foundStore)) {
+    throw new ForbiddenError({
+      message:
+        "You do not have permission to manage this store's game overrides",
+      action: "Verify if you are an administrator of this store",
+    });
+  }
+
+  await storeCuration.removeGameOverride(foundStore.id, gameSlug as string);
+
+  return res.status(200).json({ message: "Game override removed from store" });
+}

--- a/pages/api/v1/stores/[slug]/game-overrides/index.ts
+++ b/pages/api/v1/stores/[slug]/game-overrides/index.ts
@@ -1,0 +1,80 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { createRouter } from "next-connect";
+import controller from "infra/controller";
+import store from "models/store";
+import storeCuration, { gameOverrideSchema } from "models/store_curation";
+import authorization from "models/authorization";
+import { ForbiddenError, ValidationError } from "infra/errors";
+
+export default createRouter<NextApiRequest, NextApiResponse>()
+  .use(controller.injectAnonymousOrUser)
+  .get(controller.canRequest("update:store"), getHandler)
+  .post(controller.canRequest("update:store"), postHandler)
+  .handler(controller.errorHandlers);
+
+async function getHandler(req: NextApiRequest, res: NextApiResponse) {
+  const { slug } = req.query;
+
+  const userTryingToRead = req.context.user;
+  const foundStore = await store.findOneBySlugWithMembers(slug as string);
+
+  if (!authorization.can(userTryingToRead, "update:store", foundStore)) {
+    throw new ForbiddenError({
+      message: "You do not have permission to view this store's game overrides",
+      action: "Verify if you are an administrator of this store",
+    });
+  }
+
+  const overrides = await storeCuration.listGameOverridesWithSlugs(
+    foundStore.id,
+  );
+
+  const secureOutputValues = overrides.map((override) =>
+    authorization.filterOutput(
+      userTryingToRead,
+      "read:store_game_override",
+      override,
+    ),
+  );
+
+  return res.status(200).json(secureOutputValues);
+}
+
+async function postHandler(req: NextApiRequest, res: NextApiResponse) {
+  const { slug } = req.query;
+
+  const result = gameOverrideSchema.safeParse(req.body);
+
+  if (!result.success) {
+    throw new ValidationError({
+      message: "One or more fields are invalid",
+      action: "Check the fields and try again",
+      context: result.error.issues,
+    });
+  }
+
+  const userTryingToAdd = req.context.user;
+  const foundStore = await store.findOneBySlugWithMembers(slug as string);
+
+  if (!authorization.can(userTryingToAdd, "update:store", foundStore)) {
+    throw new ForbiddenError({
+      message:
+        "You do not have permission to manage this store's game overrides",
+      action: "Verify if you are an administrator of this store",
+    });
+  }
+
+  const createdOverride = await storeCuration.addGameOverride(
+    foundStore.id,
+    result.data.game_slug,
+    result.data.visibility,
+  );
+
+  const secureOutputValues = authorization.filterOutput(
+    userTryingToAdd,
+    "read:store_game_override",
+    { ...createdOverride, game_slug: result.data.game_slug },
+  );
+
+  return res.status(201).json(secureOutputValues);
+}

--- a/pages/api/v1/stores/[slug]/tag-filters/[tag]/index.ts
+++ b/pages/api/v1/stores/[slug]/tag-filters/[tag]/index.ts
@@ -1,0 +1,69 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { createRouter } from "next-connect";
+import controller from "infra/controller";
+import store from "models/store";
+import storeCuration, { tagFilterModeSchema } from "models/store_curation";
+import authorization from "models/authorization";
+import { ForbiddenError, ValidationError } from "infra/errors";
+
+export default createRouter<NextApiRequest, NextApiResponse>()
+  .use(controller.injectAnonymousOrUser)
+  .patch(controller.canRequest("update:store"), patchHandler)
+  .delete(controller.canRequest("update:store"), deleteHandler)
+  .handler(controller.errorHandlers);
+
+async function patchHandler(req: NextApiRequest, res: NextApiResponse) {
+  const { slug, tag } = req.query;
+
+  const result = tagFilterModeSchema.safeParse(req.body);
+
+  if (!result.success) {
+    throw new ValidationError({
+      message: "One or more fields are invalid",
+      action: "Check the fields and try again",
+      context: result.error.issues,
+    });
+  }
+
+  const userTryingToUpdate = req.context.user;
+  const foundStore = await store.findOneBySlugWithMembers(slug as string);
+
+  if (!authorization.can(userTryingToUpdate, "update:store", foundStore)) {
+    throw new ForbiddenError({
+      message: "You do not have permission to manage this store's tag filters",
+      action: "Verify if you are an administrator of this store",
+    });
+  }
+
+  const updatedFilter = await storeCuration.updateTagFilterMode(
+    foundStore.id,
+    tag as string,
+    result.data.mode,
+  );
+
+  const secureOutputValues = authorization.filterOutput(
+    userTryingToUpdate,
+    "read:store_tag_filter",
+    updatedFilter,
+  );
+
+  return res.status(200).json(secureOutputValues);
+}
+
+async function deleteHandler(req: NextApiRequest, res: NextApiResponse) {
+  const { slug, tag } = req.query;
+
+  const userTryingToRemove = req.context.user;
+  const foundStore = await store.findOneBySlugWithMembers(slug as string);
+
+  if (!authorization.can(userTryingToRemove, "update:store", foundStore)) {
+    throw new ForbiddenError({
+      message: "You do not have permission to manage this store's tag filters",
+      action: "Verify if you are an administrator of this store",
+    });
+  }
+
+  await storeCuration.removeTagFilter(foundStore.id, tag as string);
+
+  return res.status(200).json({ message: "Tag filter removed from store" });
+}

--- a/pages/api/v1/stores/[slug]/tag-filters/index.ts
+++ b/pages/api/v1/stores/[slug]/tag-filters/index.ts
@@ -1,0 +1,77 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { createRouter } from "next-connect";
+import controller from "infra/controller";
+import store from "models/store";
+import storeCuration, { tagFilterSchema } from "models/store_curation";
+import authorization from "models/authorization";
+import { ForbiddenError, ValidationError } from "infra/errors";
+
+export default createRouter<NextApiRequest, NextApiResponse>()
+  .use(controller.injectAnonymousOrUser)
+  .get(controller.canRequest("update:store"), getHandler)
+  .post(controller.canRequest("update:store"), postHandler)
+  .handler(controller.errorHandlers);
+
+async function getHandler(req: NextApiRequest, res: NextApiResponse) {
+  const { slug } = req.query;
+
+  const userTryingToRead = req.context.user;
+  const foundStore = await store.findOneBySlugWithMembers(slug as string);
+
+  if (!authorization.can(userTryingToRead, "update:store", foundStore)) {
+    throw new ForbiddenError({
+      message: "You do not have permission to view this store's tag filters",
+      action: "Verify if you are an administrator of this store",
+    });
+  }
+
+  const filters = await storeCuration.listTagFilters(foundStore.id);
+
+  const secureOutputValues = filters.map((filter) =>
+    authorization.filterOutput(
+      userTryingToRead,
+      "read:store_tag_filter",
+      filter,
+    ),
+  );
+
+  return res.status(200).json(secureOutputValues);
+}
+
+async function postHandler(req: NextApiRequest, res: NextApiResponse) {
+  const { slug } = req.query;
+
+  const result = tagFilterSchema.safeParse(req.body);
+
+  if (!result.success) {
+    throw new ValidationError({
+      message: "One or more fields are invalid",
+      action: "Check the fields and try again",
+      context: result.error.issues,
+    });
+  }
+
+  const userTryingToAdd = req.context.user;
+  const foundStore = await store.findOneBySlugWithMembers(slug as string);
+
+  if (!authorization.can(userTryingToAdd, "update:store", foundStore)) {
+    throw new ForbiddenError({
+      message: "You do not have permission to manage this store's tag filters",
+      action: "Verify if you are an administrator of this store",
+    });
+  }
+
+  const createdFilter = await storeCuration.addTagFilter(
+    foundStore.id,
+    result.data.tag,
+    result.data.mode,
+  );
+
+  const secureOutputValues = authorization.filterOutput(
+    userTryingToAdd,
+    "read:store_tag_filter",
+    createdFilter,
+  );
+
+  return res.status(201).json(secureOutputValues);
+}

--- a/prisma/migrations/20260716171900_create_store_curation_tables/migration.sql
+++ b/prisma/migrations/20260716171900_create_store_curation_tables/migration.sql
@@ -1,0 +1,41 @@
+-- CreateEnum
+CREATE TYPE "TagFilterMode" AS ENUM ('WHITELIST', 'BLACKLIST');
+
+-- CreateEnum
+CREATE TYPE "GameOverrideVisibility" AS ENUM ('SHOW', 'HIDE');
+
+-- CreateTable
+CREATE TABLE "store_tag_filters" (
+    "id" TEXT NOT NULL,
+    "store_id" TEXT NOT NULL,
+    "tag" VARCHAR(100) NOT NULL,
+    "mode" "TagFilterMode" NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "store_tag_filters_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "store_game_overrides" (
+    "id" TEXT NOT NULL,
+    "store_id" TEXT NOT NULL,
+    "game_id" TEXT NOT NULL,
+    "visibility" "GameOverrideVisibility" NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "store_game_overrides_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "store_tag_filters_store_id_idx" ON "store_tag_filters"("store_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "store_tag_filters_store_id_tag_key" ON "store_tag_filters"("store_id", "tag");
+
+-- CreateIndex
+CREATE INDEX "store_game_overrides_store_id_idx" ON "store_game_overrides"("store_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "store_game_overrides_store_id_game_id_key" ON "store_game_overrides"("store_id", "game_id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -231,3 +231,39 @@ model StoreMember {
   @@index([user_id])
   @@map("store_members")
 }
+
+enum TagFilterMode {
+  WHITELIST
+  BLACKLIST
+}
+
+model StoreTagFilter {
+  id         String        @id @default(uuid())
+  store_id   String // Logical reference to Store.id
+  tag        String        @db.VarChar(100)
+  mode       TagFilterMode
+  created_at DateTime      @default(now())
+  updated_at DateTime      @updatedAt
+
+  @@unique([store_id, tag])
+  @@index([store_id])
+  @@map("store_tag_filters")
+}
+
+enum GameOverrideVisibility {
+  SHOW
+  HIDE
+}
+
+model StoreGameOverride {
+  id         String                 @id @default(uuid())
+  store_id   String // Logical reference to Store.id
+  game_id    String // Logical reference to Game.id
+  visibility GameOverrideVisibility
+  created_at DateTime               @default(now())
+  updated_at DateTime               @updatedAt
+
+  @@unique([store_id, game_id])
+  @@index([store_id])
+  @@map("store_game_overrides")
+}

--- a/tests/integration/api/v1/stores/[slug]/game-overrides/[gameSlug]/delete.test.ts
+++ b/tests/integration/api/v1/stores/[slug]/game-overrides/[gameSlug]/delete.test.ts
@@ -1,0 +1,98 @@
+import orchestrator from "tests/orchestrator";
+import webserver from "infra/webserver";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+describe("DELETE /api/v1/stores/[slug]/game-overrides/[gameSlug]", () => {
+  describe("Owner", () => {
+    test("Should remove the game override and return 200", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const ownerSession = await orchestrator.createSession(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+
+      const developer = await orchestrator.createUser();
+      await orchestrator.activateUser(developer.id);
+      const targetGame = await orchestrator.createGame(developer.id);
+      await orchestrator.addStoreGameOverride(
+        createdStore.id,
+        targetGame.slug,
+        "HIDE",
+      );
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/game-overrides/${targetGame.slug}`,
+        {
+          method: "DELETE",
+          headers: { Cookie: `session_id=${ownerSession.token}` },
+        },
+      );
+
+      expect(response.status).toBe(200);
+
+      const listResponse = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/game-overrides`,
+        {
+          headers: { Cookie: `session_id=${ownerSession.token}` },
+        },
+      );
+      const listBody = await listResponse.json();
+      expect(listBody).toHaveLength(0);
+    });
+
+    test("For a game with no override should return 404", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const ownerSession = await orchestrator.createSession(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+
+      const developer = await orchestrator.createUser();
+      await orchestrator.activateUser(developer.id);
+      const targetGame = await orchestrator.createGame(developer.id);
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/game-overrides/${targetGame.slug}`,
+        {
+          method: "DELETE",
+          headers: { Cookie: `session_id=${ownerSession.token}` },
+        },
+      );
+
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("Unrelated activated user", () => {
+    test("Should return 403", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+
+      const developer = await orchestrator.createUser();
+      await orchestrator.activateUser(developer.id);
+      const targetGame = await orchestrator.createGame(developer.id);
+      await orchestrator.addStoreGameOverride(
+        createdStore.id,
+        targetGame.slug,
+        "HIDE",
+      );
+
+      const outsider = await orchestrator.createUser();
+      await orchestrator.activateUser(outsider.id);
+      const outsiderSession = await orchestrator.createSession(outsider.id);
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/game-overrides/${targetGame.slug}`,
+        {
+          method: "DELETE",
+          headers: { Cookie: `session_id=${outsiderSession.token}` },
+        },
+      );
+
+      expect(response.status).toBe(403);
+    });
+  });
+});

--- a/tests/integration/api/v1/stores/[slug]/game-overrides/[gameSlug]/patch.test.ts
+++ b/tests/integration/api/v1/stores/[slug]/game-overrides/[gameSlug]/patch.test.ts
@@ -1,0 +1,112 @@
+import orchestrator from "tests/orchestrator";
+import webserver from "infra/webserver";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+describe("PATCH /api/v1/stores/[slug]/game-overrides/[gameSlug]", () => {
+  describe("Owner", () => {
+    test("With valid visibility should update the override and return 200", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const ownerSession = await orchestrator.createSession(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+
+      const developer = await orchestrator.createUser();
+      await orchestrator.activateUser(developer.id);
+      const targetGame = await orchestrator.createGame(developer.id);
+      await orchestrator.addStoreGameOverride(
+        createdStore.id,
+        targetGame.slug,
+        "SHOW",
+      );
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/game-overrides/${targetGame.slug}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${ownerSession.token}`,
+          },
+          body: JSON.stringify({ visibility: "HIDE" }),
+        },
+      );
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        id: responseBody.id,
+        store_id: createdStore.id,
+        game_id: targetGame.id,
+        game_slug: targetGame.slug,
+        visibility: "HIDE",
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+      });
+    });
+
+    test("For a game with no override should return 404", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const ownerSession = await orchestrator.createSession(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+
+      const developer = await orchestrator.createUser();
+      await orchestrator.activateUser(developer.id);
+      const targetGame = await orchestrator.createGame(developer.id);
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/game-overrides/${targetGame.slug}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${ownerSession.token}`,
+          },
+          body: JSON.stringify({ visibility: "HIDE" }),
+        },
+      );
+
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("Unrelated activated user", () => {
+    test("Should return 403", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+
+      const developer = await orchestrator.createUser();
+      await orchestrator.activateUser(developer.id);
+      const targetGame = await orchestrator.createGame(developer.id);
+      await orchestrator.addStoreGameOverride(
+        createdStore.id,
+        targetGame.slug,
+        "SHOW",
+      );
+
+      const outsider = await orchestrator.createUser();
+      await orchestrator.activateUser(outsider.id);
+      const outsiderSession = await orchestrator.createSession(outsider.id);
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/game-overrides/${targetGame.slug}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${outsiderSession.token}`,
+          },
+          body: JSON.stringify({ visibility: "HIDE" }),
+        },
+      );
+
+      expect(response.status).toBe(403);
+    });
+  });
+});

--- a/tests/integration/api/v1/stores/[slug]/game-overrides/get.test.ts
+++ b/tests/integration/api/v1/stores/[slug]/game-overrides/get.test.ts
@@ -1,0 +1,69 @@
+import orchestrator from "tests/orchestrator";
+import webserver from "infra/webserver";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+describe("GET /api/v1/stores/[slug]/game-overrides", () => {
+  describe("Owner", () => {
+    test("Should list the store's game overrides and return 200", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const ownerSession = await orchestrator.createSession(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+
+      const developer = await orchestrator.createUser();
+      await orchestrator.activateUser(developer.id);
+      const targetGame = await orchestrator.createGame(developer.id);
+      await orchestrator.addStoreGameOverride(
+        createdStore.id,
+        targetGame.slug,
+        "HIDE",
+      );
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/game-overrides`,
+        {
+          headers: { Cookie: `session_id=${ownerSession.token}` },
+        },
+      );
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+      expect(responseBody).toHaveLength(1);
+      expect(responseBody[0]).toEqual({
+        id: responseBody[0].id,
+        store_id: createdStore.id,
+        game_id: targetGame.id,
+        game_slug: targetGame.slug,
+        visibility: "HIDE",
+        created_at: responseBody[0].created_at,
+        updated_at: responseBody[0].updated_at,
+      });
+    });
+  });
+
+  describe("Unrelated activated user", () => {
+    test("Should return 403", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+
+      const outsider = await orchestrator.createUser();
+      await orchestrator.activateUser(outsider.id);
+      const outsiderSession = await orchestrator.createSession(outsider.id);
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/game-overrides`,
+        {
+          headers: { Cookie: `session_id=${outsiderSession.token}` },
+        },
+      );
+
+      expect(response.status).toBe(403);
+    });
+  });
+});

--- a/tests/integration/api/v1/stores/[slug]/game-overrides/post.test.ts
+++ b/tests/integration/api/v1/stores/[slug]/game-overrides/post.test.ts
@@ -1,0 +1,168 @@
+import orchestrator from "tests/orchestrator";
+import webserver from "infra/webserver";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+describe("POST /api/v1/stores/[slug]/game-overrides", () => {
+  describe("Anonymous user", () => {
+    test("Should return 403", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+      const developer = await orchestrator.createUser();
+      await orchestrator.activateUser(developer.id);
+      const targetGame = await orchestrator.createGame(developer.id);
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/game-overrides`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            game_slug: targetGame.slug,
+            visibility: "HIDE",
+          }),
+        },
+      );
+
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe("Owner", () => {
+    test("With valid body should create a game override and return 201", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const ownerSession = await orchestrator.createSession(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+
+      const developer = await orchestrator.createUser();
+      await orchestrator.activateUser(developer.id);
+      const targetGame = await orchestrator.createGame(developer.id);
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/game-overrides`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${ownerSession.token}`,
+          },
+          body: JSON.stringify({
+            game_slug: targetGame.slug,
+            visibility: "SHOW",
+          }),
+        },
+      );
+
+      expect(response.status).toBe(201);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        id: responseBody.id,
+        store_id: createdStore.id,
+        game_id: targetGame.id,
+        game_slug: targetGame.slug,
+        visibility: "SHOW",
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+      });
+    });
+
+    test("For an unknown game slug should return 404", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const ownerSession = await orchestrator.createSession(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/game-overrides`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${ownerSession.token}`,
+          },
+          body: JSON.stringify({
+            game_slug: "does-not-exist",
+            visibility: "SHOW",
+          }),
+        },
+      );
+
+      expect(response.status).toBe(404);
+    });
+
+    test("Adding an override twice for the same game should return 400", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const ownerSession = await orchestrator.createSession(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+
+      const developer = await orchestrator.createUser();
+      await orchestrator.activateUser(developer.id);
+      const targetGame = await orchestrator.createGame(developer.id);
+      await orchestrator.addStoreGameOverride(
+        createdStore.id,
+        targetGame.slug,
+        "SHOW",
+      );
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/game-overrides`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${ownerSession.token}`,
+          },
+          body: JSON.stringify({
+            game_slug: targetGame.slug,
+            visibility: "HIDE",
+          }),
+        },
+      );
+
+      expect(response.status).toBe(400);
+
+      const responseBody = await response.json();
+      expect(responseBody.name).toBe("ValidationError");
+    });
+  });
+
+  describe("Unrelated activated user", () => {
+    test("Targeting a store they do not administer should return 403", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+
+      const developer = await orchestrator.createUser();
+      await orchestrator.activateUser(developer.id);
+      const targetGame = await orchestrator.createGame(developer.id);
+
+      const outsider = await orchestrator.createUser();
+      await orchestrator.activateUser(outsider.id);
+      const outsiderSession = await orchestrator.createSession(outsider.id);
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/game-overrides`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${outsiderSession.token}`,
+          },
+          body: JSON.stringify({
+            game_slug: targetGame.slug,
+            visibility: "HIDE",
+          }),
+        },
+      );
+
+      expect(response.status).toBe(403);
+    });
+  });
+});

--- a/tests/integration/api/v1/stores/[slug]/tag-filters/[tag]/delete.test.ts
+++ b/tests/integration/api/v1/stores/[slug]/tag-filters/[tag]/delete.test.ts
@@ -1,0 +1,87 @@
+import orchestrator from "tests/orchestrator";
+import webserver from "infra/webserver";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+describe("DELETE /api/v1/stores/[slug]/tag-filters/[tag]", () => {
+  describe("Owner", () => {
+    test("Should remove the tag filter and return 200", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const ownerSession = await orchestrator.createSession(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+
+      await orchestrator.addStoreTagFilter(
+        createdStore.id,
+        "shooter",
+        "BLACKLIST",
+      );
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/tag-filters/shooter`,
+        {
+          method: "DELETE",
+          headers: { Cookie: `session_id=${ownerSession.token}` },
+        },
+      );
+
+      expect(response.status).toBe(200);
+
+      const listResponse = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/tag-filters`,
+        {
+          headers: { Cookie: `session_id=${ownerSession.token}` },
+        },
+      );
+      const listBody = await listResponse.json();
+      expect(listBody).toHaveLength(0);
+    });
+
+    test("For a tag with no filter should return 404", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const ownerSession = await orchestrator.createSession(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/tag-filters/unknown-tag`,
+        {
+          method: "DELETE",
+          headers: { Cookie: `session_id=${ownerSession.token}` },
+        },
+      );
+
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("Unrelated activated user", () => {
+    test("Should return 403", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+      await orchestrator.addStoreTagFilter(
+        createdStore.id,
+        "strategy",
+        "WHITELIST",
+      );
+
+      const outsider = await orchestrator.createUser();
+      await orchestrator.activateUser(outsider.id);
+      const outsiderSession = await orchestrator.createSession(outsider.id);
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/tag-filters/strategy`,
+        {
+          method: "DELETE",
+          headers: { Cookie: `session_id=${outsiderSession.token}` },
+        },
+      );
+
+      expect(response.status).toBe(403);
+    });
+  });
+});

--- a/tests/integration/api/v1/stores/[slug]/tag-filters/[tag]/patch.test.ts
+++ b/tests/integration/api/v1/stores/[slug]/tag-filters/[tag]/patch.test.ts
@@ -1,0 +1,96 @@
+import orchestrator from "tests/orchestrator";
+import webserver from "infra/webserver";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+describe("PATCH /api/v1/stores/[slug]/tag-filters/[tag]", () => {
+  describe("Owner", () => {
+    test("With valid mode should update the tag filter and return 200", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const ownerSession = await orchestrator.createSession(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+
+      await orchestrator.addStoreTagFilter(createdStore.id, "rpg", "WHITELIST");
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/tag-filters/rpg`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${ownerSession.token}`,
+          },
+          body: JSON.stringify({ mode: "BLACKLIST" }),
+        },
+      );
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        id: responseBody.id,
+        store_id: createdStore.id,
+        tag: "rpg",
+        mode: "BLACKLIST",
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+      });
+    });
+
+    test("For a tag with no filter should return 404", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const ownerSession = await orchestrator.createSession(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/tag-filters/unknown-tag`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${ownerSession.token}`,
+          },
+          body: JSON.stringify({ mode: "BLACKLIST" }),
+        },
+      );
+
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("Unrelated activated user", () => {
+    test("Should return 403", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+      await orchestrator.addStoreTagFilter(
+        createdStore.id,
+        "puzzle",
+        "WHITELIST",
+      );
+
+      const outsider = await orchestrator.createUser();
+      await orchestrator.activateUser(outsider.id);
+      const outsiderSession = await orchestrator.createSession(outsider.id);
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/tag-filters/puzzle`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${outsiderSession.token}`,
+          },
+          body: JSON.stringify({ mode: "BLACKLIST" }),
+        },
+      );
+
+      expect(response.status).toBe(403);
+    });
+  });
+});

--- a/tests/integration/api/v1/stores/[slug]/tag-filters/get.test.ts
+++ b/tests/integration/api/v1/stores/[slug]/tag-filters/get.test.ts
@@ -1,0 +1,65 @@
+import orchestrator from "tests/orchestrator";
+import webserver from "infra/webserver";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+describe("GET /api/v1/stores/[slug]/tag-filters", () => {
+  describe("Owner", () => {
+    test("Should list the store's tag filters and return 200", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const ownerSession = await orchestrator.createSession(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+
+      await orchestrator.addStoreTagFilter(
+        createdStore.id,
+        "horror",
+        "BLACKLIST",
+      );
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/tag-filters`,
+        {
+          headers: { Cookie: `session_id=${ownerSession.token}` },
+        },
+      );
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+      expect(responseBody).toHaveLength(1);
+      expect(responseBody[0]).toEqual({
+        id: responseBody[0].id,
+        store_id: createdStore.id,
+        tag: "horror",
+        mode: "BLACKLIST",
+        created_at: responseBody[0].created_at,
+        updated_at: responseBody[0].updated_at,
+      });
+    });
+  });
+
+  describe("Unrelated activated user", () => {
+    test("Should return 403", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+
+      const outsider = await orchestrator.createUser();
+      await orchestrator.activateUser(outsider.id);
+      const outsiderSession = await orchestrator.createSession(outsider.id);
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/tag-filters`,
+        {
+          headers: { Cookie: `session_id=${outsiderSession.token}` },
+        },
+      );
+
+      expect(response.status).toBe(403);
+    });
+  });
+});

--- a/tests/integration/api/v1/stores/[slug]/tag-filters/post.test.ts
+++ b/tests/integration/api/v1/stores/[slug]/tag-filters/post.test.ts
@@ -1,0 +1,183 @@
+import orchestrator from "tests/orchestrator";
+import webserver from "infra/webserver";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+describe("POST /api/v1/stores/[slug]/tag-filters", () => {
+  describe("Anonymous user", () => {
+    test("Should return 403", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/tag-filters`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ tag: "horror", mode: "BLACKLIST" }),
+        },
+      );
+
+      expect(response.status).toBe(403);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        message: "You do not have permission to perform this action",
+        name: "ForbiddenError",
+        action: "Verify your user has the following features: update:store",
+        status_code: 403,
+      });
+    });
+  });
+
+  describe("Owner", () => {
+    test("With valid body should create a tag filter and return 201", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const ownerSession = await orchestrator.createSession(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/tag-filters`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${ownerSession.token}`,
+          },
+          body: JSON.stringify({ tag: "horror", mode: "BLACKLIST" }),
+        },
+      );
+
+      expect(response.status).toBe(201);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        id: responseBody.id,
+        store_id: createdStore.id,
+        tag: "horror",
+        mode: "BLACKLIST",
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+      });
+    });
+
+    test("Adding a filter twice for the same tag should return 400", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const ownerSession = await orchestrator.createSession(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+
+      await orchestrator.addStoreTagFilter(createdStore.id, "rpg", "WHITELIST");
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/tag-filters`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${ownerSession.token}`,
+          },
+          body: JSON.stringify({ tag: "rpg", mode: "BLACKLIST" }),
+        },
+      );
+
+      expect(response.status).toBe(400);
+
+      const responseBody = await response.json();
+      expect(responseBody.name).toBe("ValidationError");
+    });
+
+    test("With invalid mode should return 400", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const ownerSession = await orchestrator.createSession(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/tag-filters`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${ownerSession.token}`,
+          },
+          body: JSON.stringify({ tag: "rpg", mode: "SOMETHING_ELSE" }),
+        },
+      );
+
+      expect(response.status).toBe(400);
+
+      const responseBody = await response.json();
+      expect(responseBody.name).toBe("ValidationError");
+    });
+  });
+
+  describe("Unrelated activated user", () => {
+    test("Targeting a store they do not administer should return 403", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+
+      const outsider = await orchestrator.createUser();
+      await orchestrator.activateUser(outsider.id);
+      const outsiderSession = await orchestrator.createSession(outsider.id);
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/tag-filters`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${outsiderSession.token}`,
+          },
+          body: JSON.stringify({ tag: "horror", mode: "BLACKLIST" }),
+        },
+      );
+
+      expect(response.status).toBe(403);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        message:
+          "You do not have permission to manage this store's tag filters",
+        name: "ForbiddenError",
+        action: "Verify if you are an administrator of this store",
+        status_code: 403,
+      });
+    });
+  });
+
+  describe("Permitted member", () => {
+    test("With update:store permission should be able to create a tag filter", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+
+      const member = await orchestrator.createUser();
+      await orchestrator.activateUser(member.id);
+      const memberSession = await orchestrator.createSession(member.id);
+      await orchestrator.addStoreMember(createdStore.id, member.username, [
+        "update:store",
+      ]);
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/tag-filters`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${memberSession.token}`,
+          },
+          body: JSON.stringify({ tag: "action", mode: "WHITELIST" }),
+        },
+      );
+
+      expect(response.status).toBe(201);
+    });
+  });
+});

--- a/tests/integration/models/store_curation.test.ts
+++ b/tests/integration/models/store_curation.test.ts
@@ -1,0 +1,144 @@
+import orchestrator from "tests/orchestrator";
+import gameModel from "models/game";
+import storeCuration from "models/store_curation";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+async function findCuratedTitles(storeId: string) {
+  const curationWhere = await storeCuration.getCurationWhereClause(storeId);
+  const { games } = await gameModel.findAllPaginated({
+    limit: 100,
+    curationWhere,
+  });
+  return games.map((game) => game.title).sort();
+}
+
+describe("models/store_curation.ts curation rules", () => {
+  test("With no filters or overrides configured, all active games are returned", async () => {
+    const owner = await orchestrator.createUser();
+    await orchestrator.activateUser(owner.id);
+    const createdStore = await orchestrator.createStore(owner.id);
+
+    const rpgGame = await orchestrator.createGame(owner.id, {
+      title: "Baseline RPG",
+      tags: ["rpg"],
+    });
+    await gameModel.makePublic(rpgGame.id);
+
+    const horrorGame = await orchestrator.createGame(owner.id, {
+      title: "Baseline Horror",
+      tags: ["horror"],
+    });
+    await gameModel.makePublic(horrorGame.id);
+
+    const titles = await findCuratedTitles(createdStore.id);
+    expect(titles).toEqual(["Baseline Horror", "Baseline RPG"].sort());
+  });
+
+  test("A blacklisted tag excludes games carrying it", async () => {
+    const owner = await orchestrator.createUser();
+    await orchestrator.activateUser(owner.id);
+    const createdStore = await orchestrator.createStore(owner.id);
+
+    const rpgGame = await orchestrator.createGame(owner.id, {
+      title: "Blacklist RPG",
+      tags: ["rpg"],
+    });
+    await gameModel.makePublic(rpgGame.id);
+
+    const horrorGame = await orchestrator.createGame(owner.id, {
+      title: "Blacklist Horror",
+      tags: ["horror"],
+    });
+    await gameModel.makePublic(horrorGame.id);
+
+    await orchestrator.addStoreTagFilter(
+      createdStore.id,
+      "horror",
+      "BLACKLIST",
+    );
+
+    const titles = await findCuratedTitles(createdStore.id);
+    expect(titles).toEqual(["Blacklist RPG"]);
+  });
+
+  test("A whitelisted tag only includes games carrying it", async () => {
+    const owner = await orchestrator.createUser();
+    await orchestrator.activateUser(owner.id);
+    const createdStore = await orchestrator.createStore(owner.id);
+
+    const rpgGame = await orchestrator.createGame(owner.id, {
+      title: "Whitelist RPG",
+      tags: ["rpg"],
+    });
+    await gameModel.makePublic(rpgGame.id);
+
+    const horrorGame = await orchestrator.createGame(owner.id, {
+      title: "Whitelist Horror",
+      tags: ["horror"],
+    });
+    await gameModel.makePublic(horrorGame.id);
+
+    await orchestrator.addStoreTagFilter(createdStore.id, "rpg", "WHITELIST");
+
+    const titles = await findCuratedTitles(createdStore.id);
+    expect(titles).toEqual(["Whitelist RPG"]);
+  });
+
+  test("A force-show override wins over a blacklisted tag", async () => {
+    const owner = await orchestrator.createUser();
+    await orchestrator.activateUser(owner.id);
+    const createdStore = await orchestrator.createStore(owner.id);
+
+    const bannedGame = await orchestrator.createGame(owner.id, {
+      title: "Force Show Horror",
+      tags: ["horror"],
+    });
+    await gameModel.makePublic(bannedGame.id);
+
+    await orchestrator.addStoreTagFilter(
+      createdStore.id,
+      "horror",
+      "BLACKLIST",
+    );
+    await orchestrator.addStoreGameOverride(
+      createdStore.id,
+      bannedGame.slug,
+      "SHOW",
+    );
+
+    const titles = await findCuratedTitles(createdStore.id);
+    expect(titles).toEqual(["Force Show Horror"]);
+  });
+
+  test("A force-hide override wins over a whitelisted tag", async () => {
+    const owner = await orchestrator.createUser();
+    await orchestrator.activateUser(owner.id);
+    const createdStore = await orchestrator.createStore(owner.id);
+
+    const allowedGame = await orchestrator.createGame(owner.id, {
+      title: "Force Hide RPG",
+      tags: ["rpg"],
+    });
+    await gameModel.makePublic(allowedGame.id);
+
+    const otherAllowedGame = await orchestrator.createGame(owner.id, {
+      title: "Still Visible RPG",
+      tags: ["rpg"],
+    });
+    await gameModel.makePublic(otherAllowedGame.id);
+
+    await orchestrator.addStoreTagFilter(createdStore.id, "rpg", "WHITELIST");
+    await orchestrator.addStoreGameOverride(
+      createdStore.id,
+      allowedGame.slug,
+      "HIDE",
+    );
+
+    const titles = await findCuratedTitles(createdStore.id);
+    expect(titles).toEqual(["Still Visible RPG"]);
+  });
+});

--- a/tests/integration/models/store_curation.test.ts
+++ b/tests/integration/models/store_curation.test.ts
@@ -13,7 +13,7 @@ async function findCuratedTitles(storeId: string) {
     limit: 100,
     curationWhere,
   });
-  return games.map((game) => game.title).sort();
+  return games.map((game) => game.title);
 }
 
 describe("models/store_curation.ts curation rules", () => {
@@ -35,7 +35,8 @@ describe("models/store_curation.ts curation rules", () => {
     await gameModel.makePublic(horrorGame.id);
 
     const titles = await findCuratedTitles(createdStore.id);
-    expect(titles).toEqual(["Baseline Horror", "Baseline RPG"].sort());
+    expect(titles).toContain("Baseline Horror");
+    expect(titles).toContain("Baseline RPG");
   });
 
   test("A blacklisted tag excludes games carrying it", async () => {
@@ -62,7 +63,8 @@ describe("models/store_curation.ts curation rules", () => {
     );
 
     const titles = await findCuratedTitles(createdStore.id);
-    expect(titles).toEqual(["Blacklist RPG"]);
+    expect(titles).toContain("Blacklist RPG");
+    expect(titles).not.toContain("Blacklist Horror");
   });
 
   test("A whitelisted tag only includes games carrying it", async () => {
@@ -85,7 +87,8 @@ describe("models/store_curation.ts curation rules", () => {
     await orchestrator.addStoreTagFilter(createdStore.id, "rpg", "WHITELIST");
 
     const titles = await findCuratedTitles(createdStore.id);
-    expect(titles).toEqual(["Whitelist RPG"]);
+    expect(titles).toContain("Whitelist RPG");
+    expect(titles).not.toContain("Whitelist Horror");
   });
 
   test("A force-show override wins over a blacklisted tag", async () => {
@@ -111,7 +114,7 @@ describe("models/store_curation.ts curation rules", () => {
     );
 
     const titles = await findCuratedTitles(createdStore.id);
-    expect(titles).toEqual(["Force Show Horror"]);
+    expect(titles).toContain("Force Show Horror");
   });
 
   test("A force-hide override wins over a whitelisted tag", async () => {
@@ -139,6 +142,7 @@ describe("models/store_curation.ts curation rules", () => {
     );
 
     const titles = await findCuratedTitles(createdStore.id);
-    expect(titles).toEqual(["Still Visible RPG"]);
+    expect(titles).toContain("Still Visible RPG");
+    expect(titles).not.toContain("Force Hide RPG");
   });
 });

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -9,6 +9,7 @@ import webserver from "infra/webserver";
 import game from "models/game";
 import library from "models/library";
 import store from "models/store";
+import storeCuration from "models/store_curation";
 
 const EMAIL_HTTP_URL = `http://${process.env.EMAIL_HTTP_HOST}:${process.env.EMAIL_HTTP_PORT}`;
 
@@ -182,6 +183,15 @@ const addStoreMember = async (storeId, username, permissions) => {
   return store.addMember(storeId, username, permissions);
 };
 
+// Store Curation
+const addStoreTagFilter = async (storeId, tag, mode) => {
+  return storeCuration.addTagFilter(storeId, tag, mode);
+};
+
+const addStoreGameOverride = async (storeId, gameSlug, visibility) => {
+  return storeCuration.addGameOverride(storeId, gameSlug, visibility);
+};
+
 const orchestrator = {
   waitForAllServices,
   clearDatabase,
@@ -202,6 +212,8 @@ const orchestrator = {
   getFileDownloadUrl,
   createStore,
   addStoreMember,
+  addStoreTagFilter,
+  addStoreGameOverride,
   extractOtpCode,
 };
 


### PR DESCRIPTION
## Summary
- Add `StoreTagFilter` and `StoreGameOverride` Prisma models (no FKs) so store admins can whitelist/blacklist tags and force-show/force-hide specific games for their storefront.
- Add `models/store_curation.ts` with CRUD for both resources plus `getCurationWhereClause(storeId)`, a reusable Prisma `where` builder: overrides always win — force-hide always excludes, force-show always includes, and only otherwise does tag whitelist/blacklist apply.
- Wire `models/game.ts`'s `findAllPaginated` to accept an optional `curationWhere` so future listing endpoints (task 3) can layer curation on top without duplicating query logic. Also added `featured`/`trending`/`new_releases` order options for that follow-up work.
- New routes under `pages/api/v1/stores/[slug]/tag-filters` and `.../game-overrides`, CRUD gated by the existing `update:store` authorization pattern (owner or permitted `StoreMember`), mirroring the members endpoints.
- Registered `read:store_tag_filter` / `read:store_game_override` output-filter features in `models/authorization.ts`.

## Test plan
- [x] `npx prisma generate`
- [x] `npx tsc --noEmit --ignoreDeprecations 6.0` (only pre-existing Jest-global noise on test files)
- [x] `npx eslint .`
- [x] `npx prettier --check .`
- [x] `next build`
- [x] Added integration tests (one file per HTTP method) for tag-filters and game-overrides CRUD: anonymous/owner/permitted-member/unrelated-user paths, duplicate/invalid/not-found error cases.
- [x] Added `tests/integration/models/store_curation.test.ts` exercising `getCurationWhereClause` + `findAllPaginated` together: no rules → all games returned, blacklist excludes, whitelist restricts, force-show wins over blacklist, force-hide wins over whitelist.
- [ ] Full Docker-based `npm run test` suite — left to CI, no Docker available in this sandbox.


---
_Generated by [Claude Code](https://claude.ai/code/session_0126eyf2U6dBZwD1ZbMith1g)_