### PR TITLE
feat: apply store curation to featured, trending, new-releases and search

### DIFF
--- a/models/game.ts
+++ b/models/game.ts
@@ -65,6 +65,25 @@ export const gameSchema = z.object({
 
 export type GameCreateDto = z.infer<typeof gameSchema> & { user_id: string };
 
+export const gameOrderValues = [
+  "newest",
+  "oldest",
+  "price_asc",
+  "price_desc",
+  "title_asc",
+] as const;
+
+export const gameQuerySchema = z.object({
+  page: z.coerce.number().min(1).default(1),
+  limit: z.coerce.number().min(1).max(100).default(20),
+  order: z.enum(gameOrderValues).default("newest"),
+  tags: z
+    .string()
+    .transform((s) => s.split(","))
+    .optional(),
+  q: z.string().optional(),
+});
+
 async function create(gameData: GameCreateDto) {
   const slug = generateSlug(gameData.title);
   await validateUniqueSlug(slug);

--- a/pages/api/v1/stores/[slug]/featured/index.ts
+++ b/pages/api/v1/stores/[slug]/featured/index.ts
@@ -1,9 +1,17 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { createRouter } from "next-connect";
 import controller from "infra/controller";
-import game, { gameQuerySchema } from "models/game";
+import store from "models/store";
+import game from "models/game";
+import storeCuration from "models/store_curation";
 import authorization from "models/authorization";
 import { ValidationError } from "infra/errors";
+import { z } from "zod";
+
+const listQuerySchema = z.object({
+  page: z.coerce.number().min(1).default(1),
+  limit: z.coerce.number().min(1).max(100).default(20),
+});
 
 export default createRouter<NextApiRequest, NextApiResponse>()
   .use(controller.injectAnonymousOrUser)
@@ -11,7 +19,9 @@ export default createRouter<NextApiRequest, NextApiResponse>()
   .handler(controller.errorHandlers);
 
 async function getHandler(req: NextApiRequest, res: NextApiResponse) {
-  const result = gameQuerySchema.safeParse(req.query);
+  const { slug } = req.query;
+
+  const result = listQuerySchema.safeParse(req.query);
 
   if (!result.success) {
     throw new ValidationError({
@@ -21,7 +31,16 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
     });
   }
 
-  const { games, pagination } = await game.findAllPaginated(result.data);
+  const foundStore = await store.findOneBySlug(slug as string);
+  const curationWhere = await storeCuration.getCurationWhereClause(
+    foundStore.id,
+  );
+
+  const { games, pagination } = await game.findAllPaginated({
+    ...result.data,
+    order: "featured",
+    curationWhere,
+  });
 
   const secureOutputValues = games.map((gameItem) =>
     authorization.filterOutput(req.context.user, "read:public_game", gameItem),

--- a/pages/api/v1/stores/[slug]/new-releases/index.ts
+++ b/pages/api/v1/stores/[slug]/new-releases/index.ts
@@ -1,9 +1,17 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { createRouter } from "next-connect";
 import controller from "infra/controller";
-import game, { gameQuerySchema } from "models/game";
+import store from "models/store";
+import game from "models/game";
+import storeCuration from "models/store_curation";
 import authorization from "models/authorization";
 import { ValidationError } from "infra/errors";
+import { z } from "zod";
+
+const listQuerySchema = z.object({
+  page: z.coerce.number().min(1).default(1),
+  limit: z.coerce.number().min(1).max(100).default(20),
+});
 
 export default createRouter<NextApiRequest, NextApiResponse>()
   .use(controller.injectAnonymousOrUser)
@@ -11,7 +19,9 @@ export default createRouter<NextApiRequest, NextApiResponse>()
   .handler(controller.errorHandlers);
 
 async function getHandler(req: NextApiRequest, res: NextApiResponse) {
-  const result = gameQuerySchema.safeParse(req.query);
+  const { slug } = req.query;
+
+  const result = listQuerySchema.safeParse(req.query);
 
   if (!result.success) {
     throw new ValidationError({
@@ -21,7 +31,16 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
     });
   }
 
-  const { games, pagination } = await game.findAllPaginated(result.data);
+  const foundStore = await store.findOneBySlug(slug as string);
+  const curationWhere = await storeCuration.getCurationWhereClause(
+    foundStore.id,
+  );
+
+  const { games, pagination } = await game.findAllPaginated({
+    ...result.data,
+    order: "new_releases",
+    curationWhere,
+  });
 
   const secureOutputValues = games.map((gameItem) =>
     authorization.filterOutput(req.context.user, "read:public_game", gameItem),

--- a/pages/api/v1/stores/[slug]/search/index.ts
+++ b/pages/api/v1/stores/[slug]/search/index.ts
@@ -1,7 +1,9 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { createRouter } from "next-connect";
 import controller from "infra/controller";
+import store from "models/store";
 import game, { gameQuerySchema } from "models/game";
+import storeCuration from "models/store_curation";
 import authorization from "models/authorization";
 import { ValidationError } from "infra/errors";
 
@@ -11,6 +13,8 @@ export default createRouter<NextApiRequest, NextApiResponse>()
   .handler(controller.errorHandlers);
 
 async function getHandler(req: NextApiRequest, res: NextApiResponse) {
+  const { slug } = req.query;
+
   const result = gameQuerySchema.safeParse(req.query);
 
   if (!result.success) {
@@ -21,7 +25,15 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
     });
   }
 
-  const { games, pagination } = await game.findAllPaginated(result.data);
+  const foundStore = await store.findOneBySlug(slug as string);
+  const curationWhere = await storeCuration.getCurationWhereClause(
+    foundStore.id,
+  );
+
+  const { games, pagination } = await game.findAllPaginated({
+    ...result.data,
+    curationWhere,
+  });
 
   const secureOutputValues = games.map((gameItem) =>
     authorization.filterOutput(req.context.user, "read:public_game", gameItem),

--- a/pages/api/v1/stores/[slug]/trending/index.ts
+++ b/pages/api/v1/stores/[slug]/trending/index.ts
@@ -1,9 +1,17 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { createRouter } from "next-connect";
 import controller from "infra/controller";
-import game, { gameQuerySchema } from "models/game";
+import store from "models/store";
+import game from "models/game";
+import storeCuration from "models/store_curation";
 import authorization from "models/authorization";
 import { ValidationError } from "infra/errors";
+import { z } from "zod";
+
+const listQuerySchema = z.object({
+  page: z.coerce.number().min(1).default(1),
+  limit: z.coerce.number().min(1).max(100).default(20),
+});
 
 export default createRouter<NextApiRequest, NextApiResponse>()
   .use(controller.injectAnonymousOrUser)
@@ -11,7 +19,9 @@ export default createRouter<NextApiRequest, NextApiResponse>()
   .handler(controller.errorHandlers);
 
 async function getHandler(req: NextApiRequest, res: NextApiResponse) {
-  const result = gameQuerySchema.safeParse(req.query);
+  const { slug } = req.query;
+
+  const result = listQuerySchema.safeParse(req.query);
 
   if (!result.success) {
     throw new ValidationError({
@@ -21,7 +31,16 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
     });
   }
 
-  const { games, pagination } = await game.findAllPaginated(result.data);
+  const foundStore = await store.findOneBySlug(slug as string);
+  const curationWhere = await storeCuration.getCurationWhereClause(
+    foundStore.id,
+  );
+
+  const { games, pagination } = await game.findAllPaginated({
+    ...result.data,
+    order: "trending",
+    curationWhere,
+  });
 
   const secureOutputValues = games.map((gameItem) =>
     authorization.filterOutput(req.context.user, "read:public_game", gameItem),

--- a/tests/integration/api/v1/stores/[slug]/featured/get.test.ts
+++ b/tests/integration/api/v1/stores/[slug]/featured/get.test.ts
@@ -1,0 +1,54 @@
+import orchestrator from "tests/orchestrator";
+import webserver from "infra/webserver";
+import gameModel from "models/game";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+describe("GET /api/v1/stores/[slug]/featured", () => {
+  describe("Anonymous user", () => {
+    test("For an unknown store should return 404", async () => {
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/does-not-exist/featured`,
+      );
+
+      expect(response.status).toBe(404);
+    });
+
+    test("Should apply the store's curation rules", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+
+      const allowedGame = await orchestrator.createGame(owner.id, {
+        title: "Featured Allowed",
+        tags: ["rpg"],
+      });
+      await gameModel.makePublic(allowedGame.id);
+
+      const bannedGame = await orchestrator.createGame(owner.id, {
+        title: "Featured Banned",
+        tags: ["horror"],
+      });
+      await gameModel.makePublic(bannedGame.id);
+
+      await orchestrator.addStoreTagFilter(
+        createdStore.id,
+        "horror",
+        "BLACKLIST",
+      );
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/featured`,
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      const titles = body.games.map((g: { title: string }) => g.title);
+      expect(titles).toContain("Featured Allowed");
+      expect(titles).not.toContain("Featured Banned");
+    });
+  });
+});

--- a/tests/integration/api/v1/stores/[slug]/new-releases/get.test.ts
+++ b/tests/integration/api/v1/stores/[slug]/new-releases/get.test.ts
@@ -1,0 +1,65 @@
+import orchestrator from "tests/orchestrator";
+import webserver from "infra/webserver";
+import gameModel from "models/game";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+describe("GET /api/v1/stores/[slug]/new-releases", () => {
+  describe("Anonymous user", () => {
+    test("For an unknown store should return 404", async () => {
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/does-not-exist/new-releases`,
+      );
+
+      expect(response.status).toBe(404);
+    });
+
+    test("Should order by launch date and apply curation rules", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+
+      const olderGame = await orchestrator.createGame(owner.id, {
+        title: "Older Release",
+        tags: ["rpg"],
+        launch_date: new Date("2020-01-01"),
+      });
+      await gameModel.makePublic(olderGame.id);
+
+      const newerGame = await orchestrator.createGame(owner.id, {
+        title: "Newer Release",
+        tags: ["rpg"],
+        launch_date: new Date("2025-01-01"),
+      });
+      await gameModel.makePublic(newerGame.id);
+
+      const bannedGame = await orchestrator.createGame(owner.id, {
+        title: "Banned Release",
+        tags: ["horror"],
+        launch_date: new Date("2026-01-01"),
+      });
+      await gameModel.makePublic(bannedGame.id);
+
+      await orchestrator.addStoreTagFilter(
+        createdStore.id,
+        "horror",
+        "BLACKLIST",
+      );
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/new-releases`,
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      const titles = body.games.map((g: { title: string }) => g.title);
+      expect(titles).not.toContain("Banned Release");
+      expect(titles.indexOf("Newer Release")).toBeLessThan(
+        titles.indexOf("Older Release"),
+      );
+    });
+  });
+});

--- a/tests/integration/api/v1/stores/[slug]/search/get.test.ts
+++ b/tests/integration/api/v1/stores/[slug]/search/get.test.ts
@@ -1,0 +1,213 @@
+import orchestrator from "tests/orchestrator";
+import webserver from "infra/webserver";
+import gameModel from "models/game";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+describe("GET /api/v1/stores/[slug]/search", () => {
+  describe("Anonymous user", () => {
+    test("For an unknown store should return 404", async () => {
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/does-not-exist/search`,
+      );
+
+      expect(response.status).toBe(404);
+    });
+
+    test("With no curation rules should return every active game", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+
+      const rpgGame = await orchestrator.createGame(owner.id, {
+        title: "Search RPG",
+        tags: ["rpg"],
+      });
+      await gameModel.makePublic(rpgGame.id);
+
+      const horrorGame = await orchestrator.createGame(owner.id, {
+        title: "Search Horror",
+        tags: ["horror"],
+      });
+      await gameModel.makePublic(horrorGame.id);
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/search`,
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      const titles = body.games.map((g: { title: string }) => g.title);
+      expect(titles).toContain("Search RPG");
+      expect(titles).toContain("Search Horror");
+    });
+
+    test("A blacklisted tag excludes matching games from the results", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+
+      const allowedGame = await orchestrator.createGame(owner.id, {
+        title: "Blacklist Search Allowed",
+        tags: ["rpg"],
+      });
+      await gameModel.makePublic(allowedGame.id);
+
+      const bannedGame = await orchestrator.createGame(owner.id, {
+        title: "Blacklist Search Banned",
+        tags: ["horror"],
+      });
+      await gameModel.makePublic(bannedGame.id);
+
+      await orchestrator.addStoreTagFilter(
+        createdStore.id,
+        "horror",
+        "BLACKLIST",
+      );
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/search`,
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      const titles = body.games.map((g: { title: string }) => g.title);
+      expect(titles).toContain("Blacklist Search Allowed");
+      expect(titles).not.toContain("Blacklist Search Banned");
+    });
+
+    test("A whitelisted tag only includes matching games in the results", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+
+      const rpgGame = await orchestrator.createGame(owner.id, {
+        title: "Whitelist Search RPG",
+        tags: ["rpg"],
+      });
+      await gameModel.makePublic(rpgGame.id);
+
+      const horrorGame = await orchestrator.createGame(owner.id, {
+        title: "Whitelist Search Horror",
+        tags: ["horror"],
+      });
+      await gameModel.makePublic(horrorGame.id);
+
+      await orchestrator.addStoreTagFilter(createdStore.id, "rpg", "WHITELIST");
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/search`,
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      const titles = body.games.map((g: { title: string }) => g.title);
+      expect(titles).toContain("Whitelist Search RPG");
+      expect(titles).not.toContain("Whitelist Search Horror");
+    });
+
+    test("A force-show override always includes the game, even with a blacklisted tag", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+
+      const bannedButForced = await orchestrator.createGame(owner.id, {
+        title: "Force Show Search Horror",
+        tags: ["horror"],
+      });
+      await gameModel.makePublic(bannedButForced.id);
+
+      await orchestrator.addStoreTagFilter(
+        createdStore.id,
+        "horror",
+        "BLACKLIST",
+      );
+      await orchestrator.addStoreGameOverride(
+        createdStore.id,
+        bannedButForced.slug,
+        "SHOW",
+      );
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/search`,
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      const titles = body.games.map((g: { title: string }) => g.title);
+      expect(titles).toContain("Force Show Search Horror");
+    });
+
+    test("A force-hide override always excludes the game, even with a whitelisted tag", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+
+      const allowedButHidden = await orchestrator.createGame(owner.id, {
+        title: "Force Hide Search RPG",
+        tags: ["rpg"],
+      });
+      await gameModel.makePublic(allowedButHidden.id);
+
+      const stillVisible = await orchestrator.createGame(owner.id, {
+        title: "Still Visible Search RPG",
+        tags: ["rpg"],
+      });
+      await gameModel.makePublic(stillVisible.id);
+
+      await orchestrator.addStoreTagFilter(createdStore.id, "rpg", "WHITELIST");
+      await orchestrator.addStoreGameOverride(
+        createdStore.id,
+        allowedButHidden.slug,
+        "HIDE",
+      );
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/search`,
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      const titles = body.games.map((g: { title: string }) => g.title);
+      expect(titles).toContain("Still Visible Search RPG");
+      expect(titles).not.toContain("Force Hide Search RPG");
+    });
+
+    test("Should combine curation with the q search parameter", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+
+      const matchingGame = await orchestrator.createGame(owner.id, {
+        title: "Combined Query Dragon Quest",
+        tags: ["rpg"],
+      });
+      await gameModel.makePublic(matchingGame.id);
+
+      const bannedMatchingGame = await orchestrator.createGame(owner.id, {
+        title: "Combined Query Dragon Horror",
+        tags: ["horror"],
+      });
+      await gameModel.makePublic(bannedMatchingGame.id);
+
+      await orchestrator.addStoreTagFilter(
+        createdStore.id,
+        "horror",
+        "BLACKLIST",
+      );
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/search?q=dragon`,
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      const titles = body.games.map((g: { title: string }) => g.title);
+      expect(titles).toContain("Combined Query Dragon Quest");
+      expect(titles).not.toContain("Combined Query Dragon Horror");
+    });
+  });
+});

--- a/tests/integration/api/v1/stores/[slug]/trending/get.test.ts
+++ b/tests/integration/api/v1/stores/[slug]/trending/get.test.ts
@@ -1,0 +1,59 @@
+import orchestrator from "tests/orchestrator";
+import webserver from "infra/webserver";
+import gameModel from "models/game";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+describe("GET /api/v1/stores/[slug]/trending", () => {
+  describe("Anonymous user", () => {
+    test("For an unknown store should return 404", async () => {
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/does-not-exist/trending`,
+      );
+
+      expect(response.status).toBe(404);
+    });
+
+    test("Should apply the store's curation rules", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+
+      const forcedGame = await orchestrator.createGame(owner.id, {
+        title: "Trending Forced",
+        tags: ["horror"],
+      });
+      await gameModel.makePublic(forcedGame.id);
+
+      const bannedGame = await orchestrator.createGame(owner.id, {
+        title: "Trending Banned",
+        tags: ["horror"],
+      });
+      await gameModel.makePublic(bannedGame.id);
+
+      await orchestrator.addStoreTagFilter(
+        createdStore.id,
+        "horror",
+        "BLACKLIST",
+      );
+      await orchestrator.addStoreGameOverride(
+        createdStore.id,
+        forcedGame.slug,
+        "SHOW",
+      );
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/trending`,
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      const titles = body.games.map((g: { title: string }) => g.title);
+      expect(titles).toContain("Trending Forced");
+      expect(titles).not.toContain("Trending Banned");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Stacked on #101 (task 2's store curation models) — base branch is `task2-store-curation`, not `main`. Merge #101 first, then retarget/merge this one.
- Add `GET /api/v1/stores/{slug}/featured`, `/trending`, `/new-releases`, and `/search`, all reusing `models/game.ts`'s `findAllPaginated` with the store's curation `where` clause (from task 2's `storeCuration.getCurationWhereClause`) layered on top, so banned games never appear and forced-visible games always do.
- `featured`/`trending`/`new_releases` are new internal `order` values in `findAllPaginated`'s `orderByMap` (positive reviews, recent activity, and launch date respectively) — not part of the public sort enum, just used internally by these three routes.
- Extracted the `/api/v1/games` query schema into `models/game.ts` as `gameQuerySchema` (page/limit/order/tags/q) so `/search` reuses the exact same validation and pagination logic instead of duplicating it.

## Test plan
- [x] `npx tsc --noEmit --ignoreDeprecations 6.0` (only pre-existing Jest-global noise on test files)
- [x] `npx eslint .`
- [x] `npx prettier --check .`
- [x] `next build` — confirms all 4 new routes register
- [x] Integration tests per route: 404 for unknown store, and curation applied (blacklist excluded, whitelist included, override wins in both directions where applicable).
- [x] `/search` gets the fullest coverage since it's the general query surface: combined `q` + curation, no-rules passthrough, whitelist/blacklist/override-both-directions.
- [ ] Full Docker-based `npm run test` suite — left to CI, no Docker available in this sandbox.


---
_Generated by [Claude Code](https://claude.ai/code/session_0126eyf2U6dBZwD1ZbMith1g)_