### PR TITLE
feat: advanced search filters (min_price/max_price, sort_by)

### DIFF
--- a/models/game.ts
+++ b/models/game.ts
@@ -341,12 +341,16 @@ async function findAllPaginated({
   order = "newest",
   tags,
   q,
+  min_price,
+  max_price,
 }: {
   page?: number;
   limit?: number;
   order?: string;
   tags?: string[];
   q?: string;
+  min_price?: number;
+  max_price?: number;
 }) {
   const where: Prisma.GameWhereInput = {
     status: "ACTIVE",
@@ -363,6 +367,26 @@ async function findAllPaginated({
       { title: { contains: q, mode: "insensitive" } },
       { description: { contains: q, mode: "insensitive" } },
     ];
+  }
+
+  if (min_price !== undefined || max_price !== undefined) {
+    // `price` is stored as VARCHAR for financial precision, so a plain
+    // Prisma string comparison would sort/filter lexicographically
+    // (e.g. "9.99" > "19.99"). Cast to numeric in raw SQL to get a
+    // correct range, then constrain the typed query by the matching ids.
+    const priceConditions: Prisma.Sql[] = [];
+    if (min_price !== undefined) {
+      priceConditions.push(Prisma.sql`price::numeric >= ${min_price}`);
+    }
+    if (max_price !== undefined) {
+      priceConditions.push(Prisma.sql`price::numeric <= ${max_price}`);
+    }
+
+    const matchingGames = await prisma.$queryRaw<{ id: string }[]>`
+      SELECT id FROM games WHERE ${Prisma.join(priceConditions, " AND ")}
+    `;
+
+    where.id = { in: matchingGames.map((matchingGame) => matchingGame.id) };
   }
 
   const orderByMap = {

--- a/pages/api/v1/games/index.ts
+++ b/pages/api/v1/games/index.ts
@@ -6,25 +6,49 @@ import authorization from "models/authorization";
 import { ValidationError } from "infra/errors";
 import { z } from "zod";
 
+const ORDER_VALUES = [
+  "newest",
+  "oldest",
+  "price_asc",
+  "price_desc",
+  "title_asc",
+] as const;
+
+// `sort_by` is kept as an alias of `order` (rather than a rename) because
+// the /search frontend page already reads and writes `order` query params.
+const getQuerySchema = z
+  .object({
+    page: z.coerce.number().min(1).default(1),
+    limit: z.coerce.number().min(1).max(100).default(20),
+    order: z.enum(ORDER_VALUES).optional(),
+    sort_by: z.enum(ORDER_VALUES).optional(),
+    tags: z
+      .string()
+      .transform((s) => s.split(","))
+      .optional(),
+    q: z.string().optional(),
+    min_price: z.coerce.number().min(0).optional(),
+    max_price: z.coerce.number().min(0).optional(),
+  })
+  .refine(
+    (data) =>
+      !(
+        data.min_price !== undefined &&
+        data.max_price !== undefined &&
+        data.min_price > data.max_price
+      ),
+    {
+      message: "min_price must not be greater than max_price",
+      path: ["min_price"],
+    },
+  );
+
 export default createRouter<NextApiRequest, NextApiResponse>()
   .use(controller.injectAnonymousOrUser)
   .get(controller.canRequest("read:public_game"), getHandler)
   .handler(controller.errorHandlers);
 
 async function getHandler(req: NextApiRequest, res: NextApiResponse) {
-  const getQuerySchema = z.object({
-    page: z.coerce.number().min(1).default(1),
-    limit: z.coerce.number().min(1).max(100).default(20),
-    order: z
-      .enum(["newest", "oldest", "price_asc", "price_desc", "title_asc"])
-      .default("newest"),
-    tags: z
-      .string()
-      .transform((s) => s.split(","))
-      .optional(),
-    q: z.string().optional(),
-  });
-
   const result = getQuerySchema.safeParse(req.query);
 
   if (!result.success) {
@@ -35,7 +59,12 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
     });
   }
 
-  const { games, pagination } = await game.findAllPaginated(result.data);
+  const { order, sort_by, ...rest } = result.data;
+
+  const { games, pagination } = await game.findAllPaginated({
+    ...rest,
+    order: sort_by ?? order ?? "newest",
+  });
 
   const secureOutputValues = games.map((gameItem) =>
     authorization.filterOutput(req.context.user, "read:public_game", gameItem),

--- a/tests/integration/api/v1/games/get.test.ts
+++ b/tests/integration/api/v1/games/get.test.ts
@@ -76,5 +76,113 @@ describe("GET /api/v1/games", () => {
       expect(body.games).toHaveLength(1);
       expect(body.pagination.pages).toBe(2);
     });
+
+    test("With invalid order value should return 400", async () => {
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/games?order=not_a_real_order`,
+      );
+      expect(response.status).toBe(400);
+
+      const responseBody = await response.json();
+      expect(responseBody.name).toBe("ValidationError");
+    });
+
+    describe("Advanced filters", () => {
+      test("Should filter by min_price and max_price", async () => {
+        const user = await orchestrator.createUser();
+        await orchestrator.activateUser(user.id);
+
+        const gameModel = (await import("models/game")).default;
+
+        const budgetGame = await orchestrator.createGame(user.id, {
+          title: "Budget Bundle",
+          tags: ["indie"],
+          price: 5,
+        });
+        const midRangeGame = await orchestrator.createGame(user.id, {
+          title: "Midrange Adventure",
+          tags: ["indie"],
+          price: 50,
+        });
+        const premiumGame = await orchestrator.createGame(user.id, {
+          title: "Premium Epic",
+          tags: ["indie"],
+          price: 500,
+        });
+        await gameModel.makePublic(budgetGame.id);
+        await gameModel.makePublic(midRangeGame.id);
+        await gameModel.makePublic(premiumGame.id);
+
+        const response = await fetch(
+          `${webserver.getOrigin()}/api/v1/games?min_price=40&max_price=60`,
+        );
+        expect(response.status).toBe(200);
+
+        const body = await response.json();
+        const titles = body.games.map((g) => g.title);
+        expect(titles).toEqual(["Midrange Adventure"]);
+      });
+
+      test("Should combine a tag filter with max_price", async () => {
+        const response = await fetch(
+          `${webserver.getOrigin()}/api/v1/games?tags=indie&max_price=10`,
+        );
+        expect(response.status).toBe(200);
+
+        const body = await response.json();
+        const titles = body.games.map((g) => g.title);
+        expect(titles).toEqual(["Budget Bundle"]);
+      });
+
+      test("With invalid min_price value should return 400", async () => {
+        const response = await fetch(
+          `${webserver.getOrigin()}/api/v1/games?min_price=not-a-number`,
+        );
+        expect(response.status).toBe(400);
+
+        const responseBody = await response.json();
+        expect(responseBody.name).toBe("ValidationError");
+      });
+
+      test("With min_price greater than max_price should return 400", async () => {
+        const response = await fetch(
+          `${webserver.getOrigin()}/api/v1/games?min_price=100&max_price=10`,
+        );
+        expect(response.status).toBe(400);
+
+        const responseBody = await response.json();
+        expect(responseBody.name).toBe("ValidationError");
+      });
+
+      test("Should order results using sort_by as an alias for order", async () => {
+        const response = await fetch(
+          `${webserver.getOrigin()}/api/v1/games?tags=indie&sort_by=price_desc`,
+        );
+        expect(response.status).toBe(200);
+
+        const body = await response.json();
+        const titles = body.games.map((g) => g.title);
+        expect(titles).toEqual([
+          "Premium Epic",
+          "Midrange Adventure",
+          "Budget Bundle",
+        ]);
+      });
+
+      test("sort_by should take precedence when both order and sort_by are provided", async () => {
+        const response = await fetch(
+          `${webserver.getOrigin()}/api/v1/games?tags=indie&order=price_asc&sort_by=price_desc`,
+        );
+        expect(response.status).toBe(200);
+
+        const body = await response.json();
+        const titles = body.games.map((g) => g.title);
+        expect(titles).toEqual([
+          "Premium Epic",
+          "Midrange Adventure",
+          "Budget Bundle",
+        ]);
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Independent of tasks 2/3 — branched directly off `main`.
- Add `min_price` / `max_price` query params to `GET /api/v1/games`. `price` is stored as `VARCHAR` for financial precision, so a plain Prisma string comparison would sort/filter lexicographically (e.g. `"9.99" > "19.99"`); the range is resolved with a raw `price::numeric` cast against the `games` table, then the matching ids constrain the normal typed query.
- Add `sort_by` as an **alias** of `order`, not a rename: `pages/search/index.tsx` already reads and writes the `order` query param, so renaming it would silently break that page. If both are given, `sort_by` wins.
- `min_price > max_price` and any invalid `order`/`sort_by`/`min_price`/`max_price` value now return a friendly `400 ValidationError` via the existing Zod `safeParse` → `ValidationError` pattern.

## Test plan
- [x] `npx tsc --noEmit --ignoreDeprecations 6.0` (only pre-existing Jest-global noise on test files)
- [x] `npx eslint .`
- [x] `npx prettier --check .`
- [x] `next build`
- [x] Extended `tests/integration/api/v1/games/get.test.ts`: combined tag + `max_price` filter, `min_price`/`max_price` range filter, `sort_by` alias and its precedence over `order` when both are given, 400 for invalid `order`, invalid `min_price`, and `min_price > max_price`.
- [ ] Full Docker-based `npm run test` suite — left to CI, no Docker available in this sandbox.


---
_Generated by [Claude Code](https://claude.ai/code/session_0126eyf2U6dBZwD1ZbMith1g)_