### PR TITLE
feat: backoffice task 1 — admin authorization foundation

### DIFF
--- a/models/activation.ts
+++ b/models/activation.ts
@@ -82,29 +82,7 @@ async function activateUserByUserId(userId: string) {
     });
   }
 
-  return await user.setFeatures(userId, [
-    "create:session",
-    "read:session",
-    "update:user",
-    "read:public_game",
-    "create:wishlist",
-    "read:wishlist",
-    "delete:wishlist",
-    "create:review",
-    "read:review",
-    "delete:review",
-    "read:game_file",
-    "read:library",
-    "create:library",
-    "create:store",
-    "read:public_store",
-    "update:store",
-    "manage:store_members",
-    "create:studio",
-    "read:public_studio",
-    "update:studio",
-    "manage:studio_members",
-  ]);
+  return await user.setFeatures(userId, authorization.ACTIVATED_USER_FEATURES);
 }
 
 const activation = {

--- a/models/authorization.ts
+++ b/models/authorization.ts
@@ -82,7 +82,62 @@ const AVAILABLE_FEATURES = [
   "update:studio:any",
   "manage:studio_members",
   "manage:studio_members:any",
+
+  // Backoffice (admin)
+  "read:user:any",
+  "update:user:status:any",
+  "read:studio:any",
+  "read:store:any",
+  "read:game:any",
+  "update:game:status:any",
+  "read:dashboard:any",
+  "read:audit_log:any",
 ];
+
+// The feature set granted to every user once they activate their account
+// (see models/activation.ts). Kept here, rather than inline in activation.ts,
+// so it can be reused as the base of the admin feature bundle below without a
+// circular import between the two modules.
+const ACTIVATED_USER_FEATURES = [
+  "create:session",
+  "read:session",
+  "update:user",
+  "read:public_game",
+  "create:wishlist",
+  "read:wishlist",
+  "delete:wishlist",
+  "create:review",
+  "read:review",
+  "delete:review",
+  "read:game_file",
+  "read:library",
+  "create:library",
+  "create:store",
+  "read:public_store",
+  "update:store",
+  "manage:store_members",
+  "create:studio",
+  "read:public_studio",
+  "update:studio",
+  "manage:studio_members",
+];
+
+// Admin-only features layered on top of the activated-user set. Granted as a
+// whole via the admin bootstrap script (scripts/create-admin.js) and the
+// tests/orchestrator.js `createAdminUser` helper — there are no partial admin
+// tiers today.
+const ADMIN_ONLY_FEATURES = [
+  "read:user:any",
+  "update:user:status:any",
+  "read:studio:any",
+  "read:store:any",
+  "read:game:any",
+  "update:game:status:any",
+  "read:dashboard:any",
+  "read:audit_log:any",
+];
+
+const ADMIN_FEATURES = [...ACTIVATED_USER_FEATURES, ...ADMIN_ONLY_FEATURES];
 
 function can(user: Partial<User>, feature: string, resource?: unknown) {
   validateUser(user);
@@ -216,6 +271,18 @@ function filterOutput(user: Partial<User>, feature: string, resource: unknown) {
     }
   }
 
+  if (feature === "read:user:any" || feature === "update:user:status:any") {
+    const userOutput = resource as User;
+    return {
+      id: userOutput.id,
+      username: userOutput.username,
+      email: userOutput.email,
+      features: userOutput.features,
+      created_at: userOutput.created_at,
+      updated_at: userOutput.updated_at,
+    };
+  }
+
   if (feature === "read:session") {
     const sessionOutput = resource as Session;
     if (user.id === sessionOutput.user_id) {
@@ -278,7 +345,9 @@ function filterOutput(user: Partial<User>, feature: string, resource: unknown) {
   if (
     feature === "create:game" ||
     feature === "read:public_game" ||
-    feature === "update:game"
+    feature === "update:game" ||
+    feature === "read:game:any" ||
+    feature === "update:game:status:any"
   ) {
     const gameOutput = resource as Game;
     return {
@@ -352,7 +421,8 @@ function filterOutput(user: Partial<User>, feature: string, resource: unknown) {
   if (
     feature === "create:store" ||
     feature === "read:public_store" ||
-    feature === "update:store"
+    feature === "update:store" ||
+    feature === "read:store:any"
   ) {
     const storeOutput = resource as Store;
     return {
@@ -418,7 +488,8 @@ function filterOutput(user: Partial<User>, feature: string, resource: unknown) {
   if (
     feature === "create:studio" ||
     feature === "read:public_studio" ||
-    feature === "update:studio"
+    feature === "update:studio" ||
+    feature === "read:studio:any"
   ) {
     const studioOutput = resource as Studio;
     return {
@@ -497,6 +568,9 @@ function validateFeature(feature: string) {
 const authorization = {
   can,
   filterOutput,
+  ACTIVATED_USER_FEATURES,
+  ADMIN_ONLY_FEATURES,
+  ADMIN_FEATURES,
 };
 
 export default authorization;

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -11,6 +11,7 @@ import library from "models/library";
 import store from "models/store";
 import storeCuration from "models/store_curation";
 import studio from "models/studio";
+import authorization from "models/authorization";
 
 const EMAIL_HTTP_URL = `http://${process.env.EMAIL_HTTP_HOST}:${process.env.EMAIL_HTTP_PORT}`;
 
@@ -90,6 +91,13 @@ const activateUser = async (userId) => {
 
 const addFeaturesToUser = async (userId, features) => {
   return user.addFeatures(userId, features);
+};
+
+const createAdminUser = async (userDto = {}) => {
+  const createdUser = await createUser(userDto);
+  await activateUser(createdUser.id);
+  await addFeaturesToUser(createdUser.id, authorization.ADMIN_ONLY_FEATURES);
+  return getUserById(createdUser.id);
 };
 
 const createSession = async (userId) => {
@@ -220,6 +228,7 @@ const orchestrator = {
   clearDatabaseRows,
   createUser,
   activateUser,
+  createAdminUser,
   createSession,
   deleteAllEmails,
   getLastEmail,

--- a/tests/unit/models/authorization.test.ts
+++ b/tests/unit/models/authorization.test.ts
@@ -79,5 +79,56 @@ describe("models/authorization.ts", () => {
         updated_at: createdUser.updated_at,
       });
     });
+
+    test("with `read:user:any`, includes email regardless of who's asking", () => {
+      const targetUser: User = {
+        id: "1",
+        username: "test",
+        email: "test@example.com",
+        password: "password",
+        features: ["read:activation_token"],
+        created_at: new Date(),
+        updated_at: new Date(),
+      };
+      const admin: Partial<User> = { id: "2", features: ["read:user:any"] };
+
+      const filteredUser = authorization.filterOutput(
+        admin,
+        "read:user:any",
+        targetUser,
+      );
+
+      expect(filteredUser).toEqual({
+        id: "1",
+        username: "test",
+        email: "test@example.com",
+        features: ["read:activation_token"],
+        created_at: targetUser.created_at,
+        updated_at: targetUser.updated_at,
+      });
+    });
+  });
+
+  describe(".ADMIN_ONLY_FEATURES / .ADMIN_FEATURES", () => {
+    test("every admin-only feature is registered and grantable via `can()`", () => {
+      for (const feature of authorization.ADMIN_ONLY_FEATURES) {
+        expect(() => {
+          authorization.can({ id: "1", features: [feature] }, feature);
+        }).not.toThrow();
+        expect(
+          authorization.can({ id: "1", features: [feature] }, feature),
+        ).toBe(true);
+      }
+    });
+
+    test("ADMIN_FEATURES is the activated-user set plus the admin-only set, with no duplicates", () => {
+      expect(authorization.ADMIN_FEATURES).toEqual([
+        ...authorization.ACTIVATED_USER_FEATURES,
+        ...authorization.ADMIN_ONLY_FEATURES,
+      ]);
+      expect(new Set(authorization.ADMIN_FEATURES).size).toBe(
+        authorization.ADMIN_FEATURES.length,
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary

First PR in the admin backoffice sequence (see `docs/backoffice-tasks.md`, added on `claude/backoffice-planning-setup-9mdiy7`). This is pure authorization groundwork — no new routes, migrations, or UI yet.

- Registers the new backoffice feature strings in `AVAILABLE_FEATURES` (`models/authorization.ts`): `read:user:any`, `update:user:status:any`, `read:studio:any`, `read:store:any`, `read:game:any`, `update:game:status:any`, `read:dashboard:any`, `read:audit_log:any`.
- Extracts the activated-user feature set (previously inlined in `models/activation.ts`) into a shared `ACTIVATED_USER_FEATURES` constant, and layers the new admin-only features on top as `ADMIN_ONLY_FEATURES` / `ADMIN_FEATURES`, all exported from `models/authorization.ts` as the single source of truth for both the upcoming bootstrap script and tests.
- Extends the existing `filterOutput` branches for game/store/studio (`read:game:any`, `read:store:any`, `read:studio:any`, `update:game:status:any`) to reuse the same field sets already returned to owners — admins get the same visibility a resource owner already has, no new field shapes needed. Adds a new `read:user:any` / `update:user:status:any` branch that includes `email` (unlike the public `read:user` branch).
- Adds a `createAdminUser` helper to `tests/orchestrator.js` (createUser → activateUser → grant `ADMIN_ONLY_FEATURES`) for use by every subsequent backoffice PR's tests.

## Test plan

- [x] `./node_modules/.bin/eslint models/authorization.ts models/activation.ts tests/orchestrator.js` — clean.
- [x] `npx jest tests/unit/models/authorization.test.ts` — 11/11 passing, including new coverage added for `read:user:any` output shape and the `ADMIN_FEATURES`/`ADMIN_ONLY_FEATURES` composition.
- [x] Confirmed the refactored `ACTIVATED_USER_FEATURES` array is byte-identical (same values, same order) to the inline array it replaces in `models/activation.ts`, by diffing against the exact `toEqual([...])` assertion in `tests/integration/api/v1/activations/[activation_id]/post.test.ts`.
- [ ] Full `npm run test` integration suite: **could not run in this sandbox** — Docker Compose needs to pull `postgres`/`minio`/`mailcatcher` images from Docker Hub, which this environment's egress proxy blocks (not in the allowlist). No migrations or DB-touching code changed in this PR, but this should be re-run in an environment with Docker Hub access before merging, per CLAUDE.md's mandatory full-suite check.


---
_Generated by [Claude Code](https://claude.ai/code/session_012vLvvWicRpfBfWwt1ZBVwy)_