### PR TITLE
feat: backoffice task 3 — admin action audit log

### DIFF
--- a/models/audit_log.ts
+++ b/models/audit_log.ts
@@ -1,0 +1,77 @@
+import { Prisma } from "generated/prisma/client";
+import { prisma } from "infra/database";
+
+interface RecordAdminActionDto {
+  admin_user_id: string;
+  action: string;
+  target_type: string;
+  target_id: string;
+  reason?: string;
+}
+
+async function record(logDto: RecordAdminActionDto) {
+  return await prisma.adminActionLog.create({
+    data: {
+      admin_user_id: logDto.admin_user_id,
+      action: logDto.action,
+      target_type: logDto.target_type,
+      target_id: logDto.target_id,
+      reason: logDto.reason,
+    },
+  });
+}
+
+async function findAllPaginated({
+  page = 1,
+  limit = 20,
+  admin_user_id,
+  target_type,
+  target_id,
+}: {
+  page?: number;
+  limit?: number;
+  admin_user_id?: string;
+  target_type?: string;
+  target_id?: string;
+}) {
+  const where: Prisma.AdminActionLogWhereInput = {};
+
+  if (admin_user_id) {
+    where.admin_user_id = admin_user_id;
+  }
+
+  if (target_type) {
+    where.target_type = target_type;
+  }
+
+  if (target_id) {
+    where.target_id = target_id;
+  }
+
+  const [logs, total] = await Promise.all([
+    prisma.adminActionLog.findMany({
+      where,
+      orderBy: { created_at: "desc" },
+      skip: (page - 1) * limit,
+      take: limit,
+    }),
+    prisma.adminActionLog.count({ where }),
+  ]);
+
+  return {
+    logs,
+    pagination: {
+      page,
+      limit,
+      total,
+      pages: Math.ceil(total / limit),
+    },
+  };
+}
+
+const auditLog = {
+  record,
+  findAllPaginated,
+};
+
+export default auditLog;

--- a/prisma/migrations/20260720220408_create_admin_action_logs/migration.sql
+++ b/prisma/migrations/20260720220408_create_admin_action_logs/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "admin_action_logs" (
+    "id" TEXT NOT NULL,
+    "admin_user_id" TEXT NOT NULL,
+    "action" VARCHAR(100) NOT NULL,
+    "target_type" VARCHAR(50) NOT NULL,
+    "target_id" TEXT NOT NULL,
+    "reason" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "admin_action_logs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "admin_action_logs_admin_user_id_idx" ON "admin_action_logs"("admin_user_id");
+
+-- CreateIndex
+CREATE INDEX "admin_action_logs_target_type_target_id_idx" ON "admin_action_logs"("target_type", "target_id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -300,3 +300,18 @@ model StoreGameOverride {
   @@index([store_id])
   @@map("store_game_overrides")
 }
+
+model AdminActionLog {
+  id            String   @id @default(uuid())
+  admin_user_id String // Logical reference to User.id (who performed the action)
+  action        String   @db.VarChar(100)
+  target_type   String   @db.VarChar(50)
+  target_id     String
+  reason        String?  @db.Text
+  // No updated_at: audit log entries are append-only and never modified.
+  created_at    DateTime @default(now())
+
+  @@index([admin_user_id])
+  @@index([target_type, target_id])
+  @@map("admin_action_logs")
+}

--- a/tests/integration/models/audit_log.test.ts
+++ b/tests/integration/models/audit_log.test.ts
@@ -1,0 +1,146 @@
+import orchestrator from "tests/orchestrator";
+import auditLog from "models/audit_log";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+describe("models/audit_log.ts", () => {
+  describe(".record()", () => {
+    test("creates an entry with the given fields", async () => {
+      const admin = await orchestrator.createAdminUser();
+
+      const entry = await auditLog.record({
+        admin_user_id: admin.id,
+        action: "game:status:update",
+        target_type: "game",
+        target_id: "some-game-id",
+        reason: "Missing store page assets",
+      });
+
+      expect(entry.admin_user_id).toBe(admin.id);
+      expect(entry.action).toBe("game:status:update");
+      expect(entry.target_type).toBe("game");
+      expect(entry.target_id).toBe("some-game-id");
+      expect(entry.reason).toBe("Missing store page assets");
+      expect(entry.created_at).toBeInstanceOf(Date);
+    });
+
+    test("`reason` is optional", async () => {
+      const admin = await orchestrator.createAdminUser();
+
+      const entry = await auditLog.record({
+        admin_user_id: admin.id,
+        action: "user:status:update",
+        target_type: "user",
+        target_id: "some-user-id",
+      });
+
+      expect(entry.reason).toBeNull();
+    });
+  });
+
+  describe(".findAllPaginated()", () => {
+    test("returns entries newest first", async () => {
+      await orchestrator.clearDatabaseRows();
+      const admin = await orchestrator.createAdminUser();
+
+      const first = await auditLog.record({
+        admin_user_id: admin.id,
+        action: "game:status:update",
+        target_type: "game",
+        target_id: "game-1",
+      });
+      const second = await auditLog.record({
+        admin_user_id: admin.id,
+        action: "game:status:update",
+        target_type: "game",
+        target_id: "game-2",
+      });
+
+      const { logs } = await auditLog.findAllPaginated({});
+
+      expect(logs.map((log) => log.id)).toEqual([second.id, first.id]);
+    });
+
+    test("filters by target_type and target_id", async () => {
+      await orchestrator.clearDatabaseRows();
+      const admin = await orchestrator.createAdminUser();
+
+      await auditLog.record({
+        admin_user_id: admin.id,
+        action: "game:status:update",
+        target_type: "game",
+        target_id: "game-1",
+      });
+      const userEntry = await auditLog.record({
+        admin_user_id: admin.id,
+        action: "user:status:update",
+        target_type: "user",
+        target_id: "user-1",
+      });
+
+      const { logs } = await auditLog.findAllPaginated({
+        target_type: "user",
+        target_id: "user-1",
+      });
+
+      expect(logs).toHaveLength(1);
+      expect(logs[0].id).toBe(userEntry.id);
+    });
+
+    test("filters by admin_user_id", async () => {
+      await orchestrator.clearDatabaseRows();
+      const firstAdmin = await orchestrator.createAdminUser();
+      const secondAdmin = await orchestrator.createAdminUser();
+
+      await auditLog.record({
+        admin_user_id: firstAdmin.id,
+        action: "game:status:update",
+        target_type: "game",
+        target_id: "game-1",
+      });
+      const secondAdminEntry = await auditLog.record({
+        admin_user_id: secondAdmin.id,
+        action: "game:status:update",
+        target_type: "game",
+        target_id: "game-2",
+      });
+
+      const { logs } = await auditLog.findAllPaginated({
+        admin_user_id: secondAdmin.id,
+      });
+
+      expect(logs).toHaveLength(1);
+      expect(logs[0].id).toBe(secondAdminEntry.id);
+    });
+
+    test("paginates results", async () => {
+      await orchestrator.clearDatabaseRows();
+      const admin = await orchestrator.createAdminUser();
+
+      for (let i = 0; i < 5; i++) {
+        await auditLog.record({
+          admin_user_id: admin.id,
+          action: "game:status:update",
+          target_type: "game",
+          target_id: `game-${i}`,
+        });
+      }
+
+      const { logs, pagination } = await auditLog.findAllPaginated({
+        page: 2,
+        limit: 2,
+      });
+
+      expect(logs).toHaveLength(2);
+      expect(pagination).toEqual({
+        page: 2,
+        limit: 2,
+        total: 5,
+        pages: 3,
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Third PR in the admin backoffice sequence (see `docs/backoffice-tasks.md`, task 3; depends on task 1 / #105, already merged).

- New `AdminActionLog` Prisma model / migration (`prisma/migrations/20260720220408_create_admin_action_logs`): `id, admin_user_id, action, target_type, target_id, reason?, created_at` — no FK (per CLAUDE.md's no-FK rule), and deliberately no `updated_at` since entries are append-only and never modified.
- `models/audit_log.ts`: `record(...)` writes an entry; `findAllPaginated({page, limit, admin_user_id?, target_type?, target_id?})` mirrors the pagination shape already used by `game.findAllPaginated`.
- No routes/callers yet — the games (task 5) and users (task 6) backoffice PRs will call `record()` from their mutation handlers.

## Test plan

- [x] `./node_modules/.bin/eslint` / `prettier --check` on the new TS files — clean. `npx prisma format` — no diff, schema addition already matches Prisma's formatting.
- [x] New `tests/integration/models/audit_log.test.ts` (6 tests): record with/without `reason`, newest-first ordering, filtering by `target_type`+`target_id`, filtering by `admin_user_id`, pagination math — all passing.
- [x] Ran the **full** `npx jest --runInBand` suite locally against a real Postgres 16 instance (this sandbox can't reach Docker Hub, so I installed Postgres directly and stood up `next dev` + a stub HTTP mail endpoint to get genuine integration coverage instead of skipping it — see #105/#106 for the earlier Docker Hub limitation). 241/285 passing; the 44 failures are 100% attributable to environment gaps that don't exist in CI: no real SMTP server behind my stub (OTP/signup/activation email routes), no S3-compatible storage (game file upload/download routes), and one Postgres *minor* version string assertion (`16.0` expected vs. local `16.13`) — none touch users, games, sessions, or this PR's new code. Individually verified each failing suite's root cause to confirm none are regressions.
- [x] Full `npm run test` integration suite: confirmed green via CI's "Jest Ubuntu" check on this PR.
