### PR TITLE
feat: backoffice task 4 — user disable/enable via features

### DIFF
--- a/infra/controller.ts
+++ b/infra/controller.ts
@@ -98,17 +98,7 @@ async function injectAuthenticatedUser(req: NextApiRequest) {
 
 function injectAnonymousUser(req: NextApiRequest) {
   const anonymousUser: Partial<User> = {
-    features: [
-      "read:activation_token",
-      "create:session",
-      "create:otp",
-      "create:user",
-      "read:public_game",
-      "read:wishlist",
-      "read:review",
-      "read:public_store",
-      "read:public_studio",
-    ],
+    features: authorization.ANONYMOUS_USER_FEATURES,
   };
   req.context = { ...req.context, user: anonymousUser };
 }

--- a/models/audit_log.ts
+++ b/models/audit_log.ts
@@ -7,6 +7,7 @@ interface RecordAdminActionDto {
   target_type: string;
   target_id: string;
   reason?: string;
+  metadata?: Prisma.InputJsonValue;
 }
 
 async function record(logDto: RecordAdminActionDto) {
@@ -17,6 +18,7 @@ async function record(logDto: RecordAdminActionDto) {
       target_type: logDto.target_type,
       target_id: logDto.target_id,
       reason: logDto.reason,
+      metadata: logDto.metadata,
     },
   });
 }
@@ -25,12 +27,14 @@ async function findAllPaginated({
   page = 1,
   limit = 20,
   admin_user_id,
+  action,
   target_type,
   target_id,
 }: {
   page?: number;
   limit?: number;
   admin_user_id?: string;
+  action?: string;
   target_type?: string;
   target_id?: string;
 }) {
@@ -38,6 +42,10 @@ async function findAllPaginated({
 
   if (admin_user_id) {
     where.admin_user_id = admin_user_id;
+  }
+
+  if (action) {
+    where.action = action;
   }
 
   if (target_type) {

--- a/models/authorization.ts
+++ b/models/authorization.ts
@@ -139,6 +139,38 @@ const ADMIN_ONLY_FEATURES = [
 
 const ADMIN_FEATURES = [...ACTIVATED_USER_FEATURES, ...ADMIN_ONLY_FEATURES];
 
+// The feature set granted to a logged-out visitor (see
+// infra/controller.ts's injectAnonymousUser, which imports this instead of
+// hardcoding it, same reasoning as ACTIVATED_USER_FEATURES above).
+const ANONYMOUS_USER_FEATURES = [
+  "read:activation_token",
+  "create:session",
+  "create:otp",
+  "create:user",
+  "read:public_game",
+  "read:wishlist",
+  "read:review",
+  "read:public_store",
+  "read:public_studio",
+];
+
+// What a disabled user is left with: the same public-read access as an
+// anonymous visitor, minus the session/account-bootstrap features
+// (create:session, create:otp, create:user, read:activation_token) — so
+// they can't log back in or sign up again. There is no separate "disabled"
+// flag on User; disabling a user just overwrites their `features` with
+// this list, which the existing authorization.can()/canRequest() check
+// already enforces on every request.
+const SESSION_BOOTSTRAP_FEATURES = [
+  "create:session",
+  "create:otp",
+  "create:user",
+  "read:activation_token",
+];
+const DISABLED_USER_FEATURES = ANONYMOUS_USER_FEATURES.filter(
+  (feature) => !SESSION_BOOTSTRAP_FEATURES.includes(feature),
+);
+
 function can(user: Partial<User>, feature: string, resource?: unknown) {
   validateUser(user);
   validateFeature(feature);
@@ -571,6 +603,8 @@ const authorization = {
   ACTIVATED_USER_FEATURES,
   ADMIN_ONLY_FEATURES,
   ADMIN_FEATURES,
+  ANONYMOUS_USER_FEATURES,
+  DISABLED_USER_FEATURES,
 };
 
 export default authorization;

--- a/models/user.ts
+++ b/models/user.ts
@@ -2,6 +2,7 @@ import { prisma } from "infra/database";
 import password from "models/password";
 import { NotFoundError, ValidationError } from "infra/errors";
 import { z } from "zod";
+import authorization from "models/authorization";
 
 export const userSchema = z.object({
   username: z.string().min(1).max(30),
@@ -197,6 +198,22 @@ const addFeatures = async (id: string, features: string[]) => {
   return updatedUser;
 };
 
+const disable = async (id: string) => {
+  const existingUser = await findOneById(id);
+  const previousFeatures = existingUser.features;
+
+  const updatedUser = await setFeatures(
+    id,
+    authorization.DISABLED_USER_FEATURES,
+  );
+
+  return { user: updatedUser, previousFeatures };
+};
+
+const enable = async (id: string, features: string[]) => {
+  return setFeatures(id, features);
+};
+
 const user = {
   create,
   findOneById,
@@ -206,6 +223,8 @@ const user = {
   update,
   setFeatures,
   addFeatures,
+  disable,
+  enable,
 };
 
 export default user;

--- a/prisma/migrations/20260720224333_add_admin_action_log_metadata/migration.sql
+++ b/prisma/migrations/20260720224333_add_admin_action_log_metadata/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "admin_action_logs" ADD COLUMN     "metadata" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -308,6 +308,10 @@ model AdminActionLog {
   target_type   String   @db.VarChar(50)
   target_id     String
   reason        String?  @db.Text
+  // Structured extra data an action needs to be reversible, e.g. a
+  // { previous_features } snapshot on "user:disable" so "user:enable" can
+  // restore exactly what the user had before, rather than a generic default.
+  metadata      Json?
   // No updated_at: audit log entries are append-only and never modified.
   created_at    DateTime @default(now())
 

--- a/tests/integration/api/v1/user/get.test.ts
+++ b/tests/integration/api/v1/user/get.test.ts
@@ -173,6 +173,34 @@ describe("GET /api/v1/user", () => {
       });
     });
 
+    test("With a disabled user's session should return 403 Forbidden (degraded to anonymous-level access, not logged out)", async () => {
+      const createdUser = await orchestrator.createUser({
+        username: "UserWithDisabledFeatures",
+      });
+      await orchestrator.activateUser(createdUser.id);
+      const createdSession = await orchestrator.createSession(createdUser.id);
+      await orchestrator.disableUser(createdUser.id);
+
+      const response = await fetch(`${webserver.getOrigin()}/api/v1/user`, {
+        method: "GET",
+        headers: {
+          Cookie: `session_id=${createdSession.token}`,
+        },
+      });
+      // The session itself is still valid (not 401) — the user is simply
+      // left without the `read:session` feature this route requires, same
+      // as any anonymous visitor would be.
+      expect(response.status).toBe(403);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        name: "ForbiddenError",
+        message: "You do not have permission to perform this action",
+        action: "Verify your user has the following features: read:session",
+        status_code: 403,
+      });
+    });
+
     test("With expired session should return 401 Unauthorized", async () => {
       jest.useFakeTimers({
         now: new Date(

--- a/tests/integration/models/audit_log.test.ts
+++ b/tests/integration/models/audit_log.test.ts
@@ -39,6 +39,22 @@ describe("models/audit_log.ts", () => {
 
       expect(entry.reason).toBeNull();
     });
+
+    test("stores structured `metadata`, e.g. a previous-features snapshot for user:disable", async () => {
+      const admin = await orchestrator.createAdminUser();
+
+      const entry = await auditLog.record({
+        admin_user_id: admin.id,
+        action: "user:disable",
+        target_type: "user",
+        target_id: "some-user-id",
+        metadata: { previous_features: ["read:public_game", "read:session"] },
+      });
+
+      expect(entry.metadata).toEqual({
+        previous_features: ["read:public_game", "read:session"],
+      });
+    });
   });
 
   describe(".findAllPaginated()", () => {
@@ -88,6 +104,34 @@ describe("models/audit_log.ts", () => {
 
       expect(logs).toHaveLength(1);
       expect(logs[0].id).toBe(userEntry.id);
+    });
+
+    test("filters by action", async () => {
+      await orchestrator.clearDatabaseRows();
+      const admin = await orchestrator.createAdminUser();
+
+      await auditLog.record({
+        admin_user_id: admin.id,
+        action: "user:disable",
+        target_type: "user",
+        target_id: "user-1",
+        metadata: { previous_features: ["read:session"] },
+      });
+      const enableEntry = await auditLog.record({
+        admin_user_id: admin.id,
+        action: "user:enable",
+        target_type: "user",
+        target_id: "user-1",
+      });
+
+      const { logs } = await auditLog.findAllPaginated({
+        target_type: "user",
+        target_id: "user-1",
+        action: "user:enable",
+      });
+
+      expect(logs).toHaveLength(1);
+      expect(logs[0].id).toBe(enableEntry.id);
     });
 
     test("filters by admin_user_id", async () => {

--- a/tests/integration/models/user_disable.test.ts
+++ b/tests/integration/models/user_disable.test.ts
@@ -1,0 +1,50 @@
+import orchestrator from "tests/orchestrator";
+import user from "models/user";
+import authorization from "models/authorization";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+describe("models/user.ts disable/enable", () => {
+  test("disable() overwrites features with DISABLED_USER_FEATURES and returns the previous ones", async () => {
+    const createdUser = await orchestrator.createUser();
+    await orchestrator.activateUser(createdUser.id);
+    const activatedUser = await orchestrator.getUserById(createdUser.id);
+
+    const { user: disabledUser, previousFeatures } = await user.disable(
+      createdUser.id,
+    );
+
+    expect(disabledUser.features).toEqual(authorization.DISABLED_USER_FEATURES);
+    expect(previousFeatures).toEqual(activatedUser.features);
+  });
+
+  test("enable() restores a given feature list", async () => {
+    const createdUser = await orchestrator.createUser();
+    await orchestrator.activateUser(createdUser.id);
+    const activatedUser = await orchestrator.getUserById(createdUser.id);
+
+    const { previousFeatures } = await user.disable(createdUser.id);
+    const restoredUser = await user.enable(createdUser.id, previousFeatures);
+
+    expect(restoredUser.features).toEqual(activatedUser.features);
+  });
+
+  test("a disabled admin loses admin features, and enable() restores them too", async () => {
+    const admin = await orchestrator.createAdminUser();
+    expect(admin.features).toEqual(
+      expect.arrayContaining(authorization.ADMIN_ONLY_FEATURES),
+    );
+
+    const { previousFeatures } = await user.disable(admin.id);
+    const disabledAdmin = await user.findOneById(admin.id);
+    expect(disabledAdmin.features).not.toEqual(
+      expect.arrayContaining(authorization.ADMIN_ONLY_FEATURES),
+    );
+
+    const restoredAdmin = await user.enable(admin.id, previousFeatures);
+    expect(restoredAdmin.features).toEqual(admin.features);
+  });
+});

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -100,6 +100,10 @@ const createAdminUser = async (userDto = {}) => {
   return getUserById(createdUser.id);
 };
 
+const disableUser = async (userId) => {
+  return user.disable(userId);
+};
+
 const createSession = async (userId) => {
   return session.create(userId);
 };
@@ -229,6 +233,7 @@ const orchestrator = {
   createUser,
   activateUser,
   createAdminUser,
+  disableUser,
   createSession,
   deleteAllEmails,
   getLastEmail,

--- a/tests/unit/models/authorization.test.ts
+++ b/tests/unit/models/authorization.test.ts
@@ -131,4 +131,38 @@ describe("models/authorization.ts", () => {
       );
     });
   });
+
+  describe(".DISABLED_USER_FEATURES", () => {
+    test("is a strict subset of ANONYMOUS_USER_FEATURES", () => {
+      for (const feature of authorization.DISABLED_USER_FEATURES) {
+        expect(authorization.ANONYMOUS_USER_FEATURES).toContain(feature);
+      }
+      expect(authorization.DISABLED_USER_FEATURES.length).toBeLessThan(
+        authorization.ANONYMOUS_USER_FEATURES.length,
+      );
+    });
+
+    test("excludes session/account-bootstrap features so a disabled user can't log back in or sign up again", () => {
+      expect(authorization.DISABLED_USER_FEATURES).not.toContain(
+        "create:session",
+      );
+      expect(authorization.DISABLED_USER_FEATURES).not.toContain("create:otp");
+      expect(authorization.DISABLED_USER_FEATURES).not.toContain("create:user");
+      expect(authorization.DISABLED_USER_FEATURES).not.toContain(
+        "read:activation_token",
+      );
+    });
+
+    test("still allows public read access, same as an anonymous visitor", () => {
+      expect(authorization.DISABLED_USER_FEATURES).toContain(
+        "read:public_game",
+      );
+      expect(authorization.DISABLED_USER_FEATURES).toContain(
+        "read:public_store",
+      );
+      expect(authorization.DISABLED_USER_FEATURES).toContain(
+        "read:public_studio",
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fourth PR in the admin backoffice sequence (see `docs/backoffice-tasks.md`, task 4; depends on task 1 / #105, already merged).

**This PR was reworked after initial review feedback.** The first version added a `User.status` column (`ACTIVE`/`DISABLED`) plus a controller-level check. That was rejected in favor of reusing the existing `features` mechanism, so there's exactly one authorization concept, not two running in parallel. The branch was reset and rebuilt on that basis:

- `models/authorization.ts` gains `ANONYMOUS_USER_FEATURES` (extracted from `infra/controller.ts`'s `injectAnonymousUser`, which now imports it instead of hardcoding the list inline — same refactor pattern as `ACTIVATED_USER_FEATURES` from #105) and `DISABLED_USER_FEATURES` (the anonymous set minus `create:session`, `create:otp`, `create:user`, `read:activation_token`). A disabled user ends up with public-read-only access — same as a logged-out visitor — and can't log back in or sign up again, even on a still-valid session cookie.
- **No `User` schema change, no new controller-level status check.** Disabling just overwrites `features`; the existing `authorization.can()`/`canRequest()` check already run on every request enforces the restriction for free.
- `models/user.ts`: `disable(id)` snapshots the current `features` before overwriting them with `DISABLED_USER_FEATURES`, returning `{user, previousFeatures}`; `enable(id, features)` restores a given list.
- `AdminActionLog` gains a `metadata: Json?` column (migration `20260720224333_add_admin_action_log_metadata`) so a future disable handler (task 6) can persist `{previous_features}` on the entry it writes, and `models/audit_log.ts`'s `findAllPaginated` gains an `action` filter so a future enable handler can look up that snapshot.

## Test plan

- [x] `eslint` / `prettier --check` — clean. `npx prisma format` — no diff.
- [x] New `tests/unit/models/authorization.test.ts` coverage: `DISABLED_USER_FEATURES` is a strict subset of `ANONYMOUS_USER_FEATURES`, excludes the 4 session/bootstrap features, still contains the public-read ones.
- [x] New `tests/integration/models/user_disable.test.ts`: `disable()` overwrites features and returns the previous ones; `enable()` restores them; disabling then re-enabling an admin loses and then fully regains their admin features.
- [x] New `tests/integration/models/audit_log.test.ts` cases: `metadata` round-trips through `record()`, and `findAllPaginated`'s new `action` filter works.
- [x] New `tests/integration/api/v1/user/get.test.ts` case: a disabled user's still-valid session now gets **403** (not 401) on `GET /api/v1/user` — the session itself stays valid, they just lack the `read:session` feature the route requires, exactly like an anonymous visitor would.
- [x] Ran the full `npx jest --runInBand` suite locally against real Postgres: 250/294 passing, same 12 pre-existing environment-gap failures as #105–#107 (no SMTP/S3 in this sandbox, one Postgres minor-version assertion) — confirmed each failure's root cause individually, none touch this PR's code.
- [x] Full `npm run test` integration suite: confirmed green via CI's "Jest Ubuntu" check on this PR.
