### PR TITLE
feat: backoffice task 6 — users admin backend

### DIFF
--- a/models/user.ts
+++ b/models/user.ts
@@ -3,11 +3,18 @@ import password from "models/password";
 import { NotFoundError, ValidationError } from "infra/errors";
 import { z } from "zod";
 import authorization from "models/authorization";
+import { Prisma } from "generated/prisma/client";
 
 export const userSchema = z.object({
   username: z.string().min(1).max(30),
   email: z.email(),
   password: z.string().min(1).nullable(),
+});
+
+export const userAdminQuerySchema = z.object({
+  page: z.coerce.number().min(1).default(1),
+  limit: z.coerce.number().min(1).max(100).default(20),
+  q: z.string().optional(),
 });
 
 export type CreateUserDto = z.infer<typeof userSchema> & {
@@ -198,6 +205,45 @@ const addFeatures = async (id: string, features: string[]) => {
   return updatedUser;
 };
 
+const findAllPaginated = async ({
+  page = 1,
+  limit = 20,
+  q,
+}: {
+  page?: number;
+  limit?: number;
+  q?: string;
+}) => {
+  const where: Prisma.UserWhereInput = {};
+
+  if (q) {
+    where.OR = [
+      { username: { contains: q, mode: "insensitive" } },
+      { email: { contains: q, mode: "insensitive" } },
+    ];
+  }
+
+  const [users, total] = await Promise.all([
+    prisma.user.findMany({
+      where,
+      orderBy: { created_at: "desc" },
+      skip: (page - 1) * limit,
+      take: limit,
+    }),
+    prisma.user.count({ where }),
+  ]);
+
+  return {
+    users,
+    pagination: {
+      page,
+      limit,
+      total,
+      pages: Math.ceil(total / limit),
+    },
+  };
+};
+
 const disable = async (id: string) => {
   const existingUser = await findOneById(id);
   const previousFeatures = existingUser.features;
@@ -214,17 +260,26 @@ const enable = async (id: string, features: string[]) => {
   return setFeatures(id, features);
 };
 
+const isDisabled = (targetUser: { features: string[] }) => {
+  return (
+    JSON.stringify(targetUser.features) ===
+    JSON.stringify(authorization.DISABLED_USER_FEATURES)
+  );
+};
+
 const user = {
   create,
   findOneById,
   findOneByUsername,
   findOneByEmail,
+  findAllPaginated,
   updateByUsername,
   update,
   setFeatures,
   addFeatures,
   disable,
   enable,
+  isDisabled,
 };
 
 export default user;

--- a/pages/api/v1/backoffice/users/[id]/disable/index.ts
+++ b/pages/api/v1/backoffice/users/[id]/disable/index.ts
@@ -1,0 +1,60 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { createRouter } from "next-connect";
+import { z } from "zod";
+import controller from "infra/controller";
+import user from "models/user";
+import authorization from "models/authorization";
+import auditLog from "models/audit_log";
+import { ForbiddenError, ValidationError } from "infra/errors";
+
+const disableUserSchema = z.object({
+  reason: z.string().min(1).max(1000).optional(),
+});
+
+export default createRouter<NextApiRequest, NextApiResponse>()
+  .use(controller.injectAnonymousOrUser)
+  .patch(controller.canRequest("update:user:status:any"), patchHandler)
+  .handler(controller.errorHandlers);
+
+async function patchHandler(req: NextApiRequest, res: NextApiResponse) {
+  const { id } = req.query;
+  const adminUser = req.context.user;
+
+  if (adminUser.id === id) {
+    throw new ForbiddenError({
+      message: "You cannot disable your own account.",
+      action: "Ask another admin to do this for you.",
+    });
+  }
+
+  const result = disableUserSchema.safeParse(req.body ?? {});
+
+  if (!result.success) {
+    throw new ValidationError({
+      message: "Invalid request payload",
+      action: "Check the fields and try again",
+      context: result.error.issues,
+    });
+  }
+
+  const { user: disabledUser, previousFeatures } = await user.disable(
+    id as string,
+  );
+
+  await auditLog.record({
+    admin_user_id: adminUser.id as string,
+    action: "user:disable",
+    target_type: "user",
+    target_id: disabledUser.id,
+    reason: result.data.reason,
+    metadata: { previous_features: previousFeatures },
+  });
+
+  const secureOutputValues = authorization.filterOutput(
+    adminUser,
+    "update:user:status:any",
+    disabledUser,
+  );
+
+  return res.status(200).json(secureOutputValues);
+}

--- a/pages/api/v1/backoffice/users/[id]/enable/index.ts
+++ b/pages/api/v1/backoffice/users/[id]/enable/index.ts
@@ -1,0 +1,58 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { createRouter } from "next-connect";
+import controller from "infra/controller";
+import user from "models/user";
+import authorization from "models/authorization";
+import auditLog from "models/audit_log";
+import { ValidationError } from "infra/errors";
+
+interface AuditLogMetadata {
+  previous_features?: string[];
+}
+
+export default createRouter<NextApiRequest, NextApiResponse>()
+  .use(controller.injectAnonymousOrUser)
+  .patch(controller.canRequest("update:user:status:any"), patchHandler)
+  .handler(controller.errorHandlers);
+
+async function patchHandler(req: NextApiRequest, res: NextApiResponse) {
+  const { id } = req.query;
+  const adminUser = req.context.user;
+
+  const targetUser = await user.findOneById(id as string);
+
+  if (!user.isDisabled(targetUser)) {
+    throw new ValidationError({
+      message: "User is not currently disabled.",
+      action: "Only disabled users can be enabled.",
+    });
+  }
+
+  const { logs } = await auditLog.findAllPaginated({
+    target_type: "user",
+    target_id: targetUser.id,
+    action: "user:disable",
+    limit: 1,
+  });
+
+  const previousFeatures =
+    (logs[0]?.metadata as AuditLogMetadata | undefined)?.previous_features ??
+    authorization.ACTIVATED_USER_FEATURES;
+
+  const enabledUser = await user.enable(targetUser.id, previousFeatures);
+
+  await auditLog.record({
+    admin_user_id: adminUser.id as string,
+    action: "user:enable",
+    target_type: "user",
+    target_id: enabledUser.id,
+  });
+
+  const secureOutputValues = authorization.filterOutput(
+    adminUser,
+    "update:user:status:any",
+    enabledUser,
+  );
+
+  return res.status(200).json(secureOutputValues);
+}

--- a/pages/api/v1/backoffice/users/[id]/index.ts
+++ b/pages/api/v1/backoffice/users/[id]/index.ts
@@ -1,0 +1,24 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { createRouter } from "next-connect";
+import controller from "infra/controller";
+import user from "models/user";
+import authorization from "models/authorization";
+
+export default createRouter<NextApiRequest, NextApiResponse>()
+  .use(controller.injectAnonymousOrUser)
+  .get(controller.canRequest("read:user:any"), getHandler)
+  .handler(controller.errorHandlers);
+
+async function getHandler(req: NextApiRequest, res: NextApiResponse) {
+  const { id } = req.query;
+
+  const foundUser = await user.findOneById(id as string);
+
+  const secureOutputValues = authorization.filterOutput(
+    req.context.user,
+    "read:user:any",
+    foundUser,
+  );
+
+  return res.status(200).json(secureOutputValues);
+}

--- a/pages/api/v1/backoffice/users/index.ts
+++ b/pages/api/v1/backoffice/users/index.ts
@@ -1,0 +1,34 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { createRouter } from "next-connect";
+import controller from "infra/controller";
+import user, { userAdminQuerySchema } from "models/user";
+import authorization from "models/authorization";
+import { ValidationError } from "infra/errors";
+
+export default createRouter<NextApiRequest, NextApiResponse>()
+  .use(controller.injectAnonymousOrUser)
+  .get(controller.canRequest("read:user:any"), getHandler)
+  .handler(controller.errorHandlers);
+
+async function getHandler(req: NextApiRequest, res: NextApiResponse) {
+  const result = userAdminQuerySchema.safeParse(req.query);
+
+  if (!result.success) {
+    throw new ValidationError({
+      message: "Invalid query parameters",
+      action: "Check the fields and try again",
+      context: result.error.issues,
+    });
+  }
+
+  const { users, pagination } = await user.findAllPaginated(result.data);
+
+  const secureOutputValues = users.map((userItem) =>
+    authorization.filterOutput(req.context.user, "read:user:any", userItem),
+  );
+
+  return res.status(200).json({
+    users: secureOutputValues,
+    pagination,
+  });
+}

--- a/tests/integration/api/v1/backoffice/users/[id]/disable/patch.test.ts
+++ b/tests/integration/api/v1/backoffice/users/[id]/disable/patch.test.ts
@@ -1,0 +1,95 @@
+import webserver from "infra/webserver";
+import orchestrator from "tests/orchestrator";
+import auditLog from "models/audit_log";
+import authorization from "models/authorization";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+async function patchDisable(id: string, body: object, sessionToken?: string) {
+  return fetch(
+    `${webserver.getOrigin()}/api/v1/backoffice/users/${id}/disable`,
+    {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        ...(sessionToken ? { Cookie: `session_id=${sessionToken}` } : {}),
+      },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+describe("PATCH /api/v1/backoffice/users/[id]/disable", () => {
+  describe("Anonymous user", () => {
+    test("Should return 403 Forbidden", async () => {
+      const target = await orchestrator.createUser();
+      const response = await patchDisable(target.id, {});
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe("Authenticated admin user", () => {
+    test("Disables the target user and writes an audit log entry with the previous features", async () => {
+      const target = await orchestrator.createUser();
+      await orchestrator.activateUser(target.id);
+
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+
+      const response = await patchDisable(
+        target.id,
+        { reason: "Repeated abuse reports" },
+        session.token,
+      );
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+      expect(responseBody.features).toEqual(
+        authorization.DISABLED_USER_FEATURES,
+      );
+
+      const { logs } = await auditLog.findAllPaginated({
+        target_type: "user",
+        target_id: target.id,
+        action: "user:disable",
+      });
+      expect(logs).toHaveLength(1);
+      expect(logs[0].admin_user_id).toBe(admin.id);
+      expect(logs[0].reason).toBe("Repeated abuse reports");
+      expect(
+        (logs[0].metadata as { previous_features: string[] }).previous_features,
+      ).toEqual(authorization.ACTIVATED_USER_FEATURES);
+    });
+
+    test("An admin cannot disable their own account", async () => {
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+
+      const response = await patchDisable(admin.id, {}, session.token);
+      expect(response.status).toBe(403);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        name: "ForbiddenError",
+        message: "You cannot disable your own account.",
+        action: "Ask another admin to do this for you.",
+        status_code: 403,
+      });
+    });
+
+    test("With an unknown id should return 404 Not Found", async () => {
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+
+      const response = await patchDisable(
+        "00000000-0000-4000-8000-000000000000",
+        {},
+        session.token,
+      );
+      expect(response.status).toBe(404);
+    });
+  });
+});

--- a/tests/integration/api/v1/backoffice/users/[id]/enable/patch.test.ts
+++ b/tests/integration/api/v1/backoffice/users/[id]/enable/patch.test.ts
@@ -1,0 +1,128 @@
+import webserver from "infra/webserver";
+import orchestrator from "tests/orchestrator";
+import auditLog from "models/audit_log";
+import authorization from "models/authorization";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+async function patchEnable(id: string, sessionToken?: string) {
+  return fetch(
+    `${webserver.getOrigin()}/api/v1/backoffice/users/${id}/enable`,
+    {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        ...(sessionToken ? { Cookie: `session_id=${sessionToken}` } : {}),
+      },
+    },
+  );
+}
+
+// Goes through the real disable route (not the model function directly) so
+// its audit log write actually happens - enable's restore depends on it.
+async function patchDisable(
+  id: string,
+  adminSessionToken: string,
+): Promise<Response> {
+  return fetch(
+    `${webserver.getOrigin()}/api/v1/backoffice/users/${id}/disable`,
+    {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `session_id=${adminSessionToken}`,
+      },
+      body: JSON.stringify({}),
+    },
+  );
+}
+
+describe("PATCH /api/v1/backoffice/users/[id]/enable", () => {
+  describe("Anonymous user", () => {
+    test("Should return 403 Forbidden", async () => {
+      const target = await orchestrator.createUser();
+      const response = await patchEnable(target.id);
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe("Authenticated admin user", () => {
+    test("Restores the exact features the user had before being disabled", async () => {
+      const target = await orchestrator.createUser();
+      await orchestrator.activateUser(target.id);
+      await orchestrator.addFeaturesToUser(target.id, ["read:status:all"]);
+      const featuresBeforeDisable = (await orchestrator.getUserById(target.id))
+        .features;
+
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+
+      await patchDisable(target.id, session.token);
+
+      const response = await patchEnable(target.id, session.token);
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+      expect(responseBody.features).toEqual(featuresBeforeDisable);
+
+      const { logs } = await auditLog.findAllPaginated({
+        target_type: "user",
+        target_id: target.id,
+        action: "user:enable",
+      });
+      expect(logs).toHaveLength(1);
+      expect(logs[0].admin_user_id).toBe(admin.id);
+    });
+
+    test("A disabled admin fully regains their admin features on re-enable", async () => {
+      const admin = await orchestrator.createAdminUser();
+      const otherAdmin = await orchestrator.createAdminUser();
+      const featuresBeforeDisable = admin.features;
+      const otherAdminSession = await orchestrator.createSession(otherAdmin.id);
+
+      await patchDisable(admin.id, otherAdminSession.token);
+
+      const response = await patchEnable(admin.id, otherAdminSession.token);
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+      expect(responseBody.features).toEqual(
+        expect.arrayContaining(authorization.ADMIN_ONLY_FEATURES),
+      );
+      expect(responseBody.features).toEqual(featuresBeforeDisable);
+    });
+
+    test("Enabling a user who isn't disabled returns 400", async () => {
+      const target = await orchestrator.createUser();
+      await orchestrator.activateUser(target.id);
+
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+
+      const response = await patchEnable(target.id, session.token);
+      expect(response.status).toBe(400);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        name: "ValidationError",
+        message: "User is not currently disabled.",
+        action: "Only disabled users can be enabled.",
+        status_code: 400,
+      });
+    });
+
+    test("With an unknown id should return 404 Not Found", async () => {
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+
+      const response = await patchEnable(
+        "00000000-0000-4000-8000-000000000000",
+        session.token,
+      );
+      expect(response.status).toBe(404);
+    });
+  });
+});

--- a/tests/integration/api/v1/backoffice/users/[id]/get.test.ts
+++ b/tests/integration/api/v1/backoffice/users/[id]/get.test.ts
@@ -1,0 +1,53 @@
+import webserver from "infra/webserver";
+import orchestrator from "tests/orchestrator";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+async function fetchBackofficeUser(id: string, sessionToken?: string) {
+  return fetch(`${webserver.getOrigin()}/api/v1/backoffice/users/${id}`, {
+    headers: sessionToken ? { Cookie: `session_id=${sessionToken}` } : {},
+  });
+}
+
+describe("GET /api/v1/backoffice/users/[id]", () => {
+  describe("Anonymous user", () => {
+    test("Should return 403 Forbidden", async () => {
+      const target = await orchestrator.createUser();
+      const response = await fetchBackofficeUser(target.id);
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe("Authenticated admin user", () => {
+    test("Should return the full user record, including email", async () => {
+      const target = await orchestrator.createUser({
+        email: "detail-target@example.com",
+      });
+      await orchestrator.activateUser(target.id);
+
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+
+      const response = await fetchBackofficeUser(target.id, session.token);
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+      expect(responseBody.id).toBe(target.id);
+      expect(responseBody.email).toBe("detail-target@example.com");
+    });
+
+    test("With an unknown id should return 404 Not Found", async () => {
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+
+      const response = await fetchBackofficeUser(
+        "00000000-0000-4000-8000-000000000000",
+        session.token,
+      );
+      expect(response.status).toBe(404);
+    });
+  });
+});

--- a/tests/integration/api/v1/backoffice/users/get.test.ts
+++ b/tests/integration/api/v1/backoffice/users/get.test.ts
@@ -1,0 +1,96 @@
+import webserver from "infra/webserver";
+import orchestrator from "tests/orchestrator";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+async function fetchBackofficeUsers(query = "", sessionToken?: string) {
+  return fetch(`${webserver.getOrigin()}/api/v1/backoffice/users${query}`, {
+    headers: sessionToken ? { Cookie: `session_id=${sessionToken}` } : {},
+  });
+}
+
+describe("GET /api/v1/backoffice/users", () => {
+  describe("Anonymous user", () => {
+    test("Should return 403 Forbidden", async () => {
+      const response = await fetchBackofficeUsers();
+      expect(response.status).toBe(403);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        name: "ForbiddenError",
+        message: "You do not have permission to perform this action",
+        action: "Verify your user has the following features: read:user:any",
+        status_code: 403,
+      });
+    });
+  });
+
+  describe("Authenticated non-admin user", () => {
+    test("Should return 403 Forbidden", async () => {
+      const nonAdmin = await orchestrator.createUser();
+      await orchestrator.activateUser(nonAdmin.id);
+      const session = await orchestrator.createSession(nonAdmin.id);
+
+      const response = await fetchBackofficeUsers("", session.token);
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe("Authenticated admin user", () => {
+    test("Should return users including email, unlike the public read:user output", async () => {
+      const target = await orchestrator.createUser({
+        username: "backofficetarget",
+        email: "backofficetarget@example.com",
+      });
+      await orchestrator.activateUser(target.id);
+
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+
+      const response = await fetchBackofficeUsers(
+        "?q=backofficetarget",
+        session.token,
+      );
+      expect(response.status).toBe(200);
+
+      const body = await response.json();
+      expect(body.users).toHaveLength(1);
+      expect(body.users[0].id).toBe(target.id);
+      expect(body.users[0].email).toBe("backofficetarget@example.com");
+    });
+
+    test("Should search by username or email", async () => {
+      await orchestrator.clearDatabaseRows();
+      await orchestrator.createUser({
+        username: "searchablealice",
+        email: "alice@example.com",
+      });
+      await orchestrator.createUser({
+        username: "bobnomatch",
+        email: "match-by-email@example.com",
+      });
+
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+
+      const byUsername = await fetchBackofficeUsers(
+        "?q=searchablealice",
+        session.token,
+      );
+      const byUsernameBody = await byUsername.json();
+      expect(byUsernameBody.users).toHaveLength(1);
+      expect(byUsernameBody.users[0].username).toBe("searchablealice");
+
+      const byEmail = await fetchBackofficeUsers(
+        "?q=match-by-email",
+        session.token,
+      );
+      const byEmailBody = await byEmail.json();
+      expect(byEmailBody.users).toHaveLength(1);
+      expect(byEmailBody.users[0].username).toBe("bobnomatch");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Sixth PR in the admin backoffice sequence (see `docs/backoffice-tasks.md`, task 6; depends on tasks 1/#105, 3/#107, 4/#108, all merged). **Not auto-merging** — leaving this open for manual review per your instruction.

- `models/user.ts`: `findAllPaginated({page, limit, q})` (case-insensitive search across username/email), `isDisabled(user)` (exact-match against `DISABLED_USER_FEATURES`, used by the enable route to reject enabling someone who isn't disabled).
- `GET /api/v1/backoffice/users` — list/search, requires `read:user:any`.
- `GET /api/v1/backoffice/users/[id]` — detail; includes `email`, unlike the public `read:user` output.
- `PATCH /api/v1/backoffice/users/[id]/disable` — requires `update:user:status:any`. **Self-protection: an admin can never disable their own account** (checked before anything else, `403 ForbiddenError`). Writes an `AdminActionLog` entry with the pre-disable `features` snapshotted in `metadata.previous_features`, and an optional `reason`.
- `PATCH /api/v1/backoffice/users/[id]/enable` — `400 ValidationError` if the target isn't currently disabled. Otherwise looks up that user's most recent `user:disable` audit entry and restores its `previous_features` snapshot exactly (falls back to `ACTIVATED_USER_FEATURES` only if no such entry exists, which shouldn't happen in practice since disable always writes one).

## Test plan

- [x] `eslint` / `prettier --check` — clean.
- [x] New tests (16, all passing) across `tests/integration/api/v1/backoffice/users/`: list search-by-username/email and 403s for anon/non-admin; detail 200/404; disable writes the correct audit entry + snapshot, blocks self-disable, 404 on unknown id; enable restores exact previous features (verified for both a regular user with a custom extra feature and a disabled admin regaining full admin access), 400 when the target isn't disabled, 404 on unknown id.
- [x] Caught my own test bug during local runs: two enable tests originally called `models/user.ts`'s `disable()` function directly instead of the real HTTP route, which skips the audit-log write the route does — silently broke the "restore exact features" assertions since there was no snapshot to restore from. Fixed by routing those tests through the actual `PATCH .../disable` endpoint.
- [x] Ran the full `npx jest --runInBand` suite locally against real Postgres: 281/325 passing, same 12 pre-existing environment-gap failures as prior PRs (no SMTP/S3 in this sandbox, one Postgres minor-version assertion) — confirmed unchanged failing-suite list, no regressions.
- [x] Full `npm run test` integration suite: confirmed green via CI's "Jest Ubuntu" check on this PR.
