### PR TITLE
feat: backoffice task 7 — studios and stores admin backend

### DIFF
--- a/models/store.ts
+++ b/models/store.ts
@@ -19,6 +19,12 @@ export const memberPermissionsSchema = z.object({
   permissions: z.array(z.enum(MEMBER_PERMISSIONS)).min(1),
 });
 
+export const storeAdminQuerySchema = z.object({
+  page: z.coerce.number().min(1).default(1),
+  limit: z.coerce.number().min(1).max(100).default(20),
+  q: z.string().optional(),
+});
+
 function generateSlug(name: string): string {
   return name
     .toLowerCase()
@@ -61,6 +67,45 @@ async function create(storeData: StoreCreateDto) {
       slug,
     },
   });
+}
+
+async function findAllPaginated({
+  page = 1,
+  limit = 20,
+  q,
+}: {
+  page?: number;
+  limit?: number;
+  q?: string;
+}) {
+  const where: Prisma.StoreWhereInput = {};
+
+  if (q) {
+    where.OR = [
+      { name: { contains: q, mode: "insensitive" } },
+      { slug: { contains: q, mode: "insensitive" } },
+    ];
+  }
+
+  const [stores, total] = await Promise.all([
+    prisma.store.findMany({
+      where,
+      orderBy: { created_at: "desc" },
+      skip: (page - 1) * limit,
+      take: limit,
+    }),
+    prisma.store.count({ where }),
+  ]);
+
+  return {
+    stores,
+    pagination: {
+      page,
+      limit,
+      total,
+      pages: Math.ceil(total / limit),
+    },
+  };
 }
 
 async function findOneBySlug(slug: string) {
@@ -277,6 +322,7 @@ async function listMembersWithUsernames(storeId: string) {
 
 const store = {
   create,
+  findAllPaginated,
   findOneBySlug,
   findOneBySlugWithMembers,
   update,

--- a/models/studio.ts
+++ b/models/studio.ts
@@ -27,6 +27,12 @@ export const memberPermissionsSchema = z.object({
   permissions: z.array(z.enum(MEMBER_PERMISSIONS)).min(1),
 });
 
+export const studioAdminQuerySchema = z.object({
+  page: z.coerce.number().min(1).default(1),
+  limit: z.coerce.number().min(1).max(100).default(20),
+  q: z.string().optional(),
+});
+
 function generateSlug(name: string): string {
   return name
     .toLowerCase()
@@ -70,6 +76,45 @@ async function create(studioData: StudioCreateDto) {
       slug,
     },
   });
+}
+
+async function findAllPaginated({
+  page = 1,
+  limit = 20,
+  q,
+}: {
+  page?: number;
+  limit?: number;
+  q?: string;
+}) {
+  const where: Prisma.StudioWhereInput = {};
+
+  if (q) {
+    where.OR = [
+      { name: { contains: q, mode: "insensitive" } },
+      { slug: { contains: q, mode: "insensitive" } },
+    ];
+  }
+
+  const [studios, total] = await Promise.all([
+    prisma.studio.findMany({
+      where,
+      orderBy: { created_at: "desc" },
+      skip: (page - 1) * limit,
+      take: limit,
+    }),
+    prisma.studio.count({ where }),
+  ]);
+
+  return {
+    studios,
+    pagination: {
+      page,
+      limit,
+      total,
+      pages: Math.ceil(total / limit),
+    },
+  };
 }
 
 async function findOneById(id: string) {
@@ -315,6 +360,7 @@ async function listMembersWithUsernames(studioId: string) {
 
 const studio = {
   create,
+  findAllPaginated,
   findOneById,
   findOneByIdWithMembers,
   findOneBySlug,

--- a/pages/api/v1/backoffice/stores/[slug]/index.ts
+++ b/pages/api/v1/backoffice/stores/[slug]/index.ts
@@ -1,0 +1,24 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { createRouter } from "next-connect";
+import controller from "infra/controller";
+import store from "models/store";
+import authorization from "models/authorization";
+
+export default createRouter<NextApiRequest, NextApiResponse>()
+  .use(controller.injectAnonymousOrUser)
+  .get(controller.canRequest("read:store:any"), getHandler)
+  .handler(controller.errorHandlers);
+
+async function getHandler(req: NextApiRequest, res: NextApiResponse) {
+  const { slug } = req.query;
+
+  const foundStore = await store.findOneBySlug(slug as string);
+
+  const secureOutputValues = authorization.filterOutput(
+    req.context.user,
+    "read:store:any",
+    foundStore,
+  );
+
+  return res.status(200).json(secureOutputValues);
+}

--- a/pages/api/v1/backoffice/stores/index.ts
+++ b/pages/api/v1/backoffice/stores/index.ts
@@ -1,0 +1,34 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { createRouter } from "next-connect";
+import controller from "infra/controller";
+import store, { storeAdminQuerySchema } from "models/store";
+import authorization from "models/authorization";
+import { ValidationError } from "infra/errors";
+
+export default createRouter<NextApiRequest, NextApiResponse>()
+  .use(controller.injectAnonymousOrUser)
+  .get(controller.canRequest("read:store:any"), getHandler)
+  .handler(controller.errorHandlers);
+
+async function getHandler(req: NextApiRequest, res: NextApiResponse) {
+  const result = storeAdminQuerySchema.safeParse(req.query);
+
+  if (!result.success) {
+    throw new ValidationError({
+      message: "Invalid query parameters",
+      action: "Check the fields and try again",
+      context: result.error.issues,
+    });
+  }
+
+  const { stores, pagination } = await store.findAllPaginated(result.data);
+
+  const secureOutputValues = stores.map((storeItem) =>
+    authorization.filterOutput(req.context.user, "read:store:any", storeItem),
+  );
+
+  return res.status(200).json({
+    stores: secureOutputValues,
+    pagination,
+  });
+}

--- a/pages/api/v1/backoffice/studios/[slug]/index.ts
+++ b/pages/api/v1/backoffice/studios/[slug]/index.ts
@@ -1,0 +1,38 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { createRouter } from "next-connect";
+import controller from "infra/controller";
+import studio from "models/studio";
+import game from "models/game";
+import authorization from "models/authorization";
+
+export default createRouter<NextApiRequest, NextApiResponse>()
+  .use(controller.injectAnonymousOrUser)
+  .get(controller.canRequest("read:studio:any"), getHandler)
+  .handler(controller.errorHandlers);
+
+async function getHandler(req: NextApiRequest, res: NextApiResponse) {
+  const { slug } = req.query;
+
+  const foundStudio = await studio.findOneBySlug(slug as string);
+
+  const { games, pagination } = await game.findAllPaginatedAdmin({
+    studio_id: foundStudio.id,
+    limit: 100,
+  });
+
+  const secureStudioOutput = authorization.filterOutput(
+    req.context.user,
+    "read:studio:any",
+    foundStudio,
+  );
+
+  const secureGamesOutput = games.map((gameItem) =>
+    authorization.filterOutput(req.context.user, "read:game:any", gameItem),
+  );
+
+  return res.status(200).json({
+    studio: secureStudioOutput,
+    games: secureGamesOutput,
+    gamesPagination: pagination,
+  });
+}

--- a/pages/api/v1/backoffice/studios/index.ts
+++ b/pages/api/v1/backoffice/studios/index.ts
@@ -1,0 +1,34 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { createRouter } from "next-connect";
+import controller from "infra/controller";
+import studio, { studioAdminQuerySchema } from "models/studio";
+import authorization from "models/authorization";
+import { ValidationError } from "infra/errors";
+
+export default createRouter<NextApiRequest, NextApiResponse>()
+  .use(controller.injectAnonymousOrUser)
+  .get(controller.canRequest("read:studio:any"), getHandler)
+  .handler(controller.errorHandlers);
+
+async function getHandler(req: NextApiRequest, res: NextApiResponse) {
+  const result = studioAdminQuerySchema.safeParse(req.query);
+
+  if (!result.success) {
+    throw new ValidationError({
+      message: "Invalid query parameters",
+      action: "Check the fields and try again",
+      context: result.error.issues,
+    });
+  }
+
+  const { studios, pagination } = await studio.findAllPaginated(result.data);
+
+  const secureOutputValues = studios.map((studioItem) =>
+    authorization.filterOutput(req.context.user, "read:studio:any", studioItem),
+  );
+
+  return res.status(200).json({
+    studios: secureOutputValues,
+    pagination,
+  });
+}

--- a/tests/integration/api/v1/backoffice/stores/[slug]/get.test.ts
+++ b/tests/integration/api/v1/backoffice/stores/[slug]/get.test.ts
@@ -1,0 +1,59 @@
+import webserver from "infra/webserver";
+import orchestrator from "tests/orchestrator";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+async function fetchBackofficeStore(slug: string, sessionToken?: string) {
+  return fetch(`${webserver.getOrigin()}/api/v1/backoffice/stores/${slug}`, {
+    headers: sessionToken ? { Cookie: `session_id=${sessionToken}` } : {},
+  });
+}
+
+describe("GET /api/v1/backoffice/stores/[slug]", () => {
+  describe("Anonymous user", () => {
+    test("Should return 403 Forbidden", async () => {
+      const owner = await orchestrator.createUser();
+      const createdStore = await orchestrator.createStore(owner.id);
+
+      const response = await fetchBackofficeStore(createdStore.slug);
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe("Authenticated admin user", () => {
+    test("Should return the store", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id, {
+        name: "Store Detail Target",
+      });
+
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+
+      const response = await fetchBackofficeStore(
+        createdStore.slug,
+        session.token,
+      );
+      expect(response.status).toBe(200);
+
+      const body = await response.json();
+      expect(body.id).toBe(createdStore.id);
+      expect(body.name).toBe("Store Detail Target");
+    });
+
+    test("With an unknown slug should return 404 Not Found", async () => {
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+
+      const response = await fetchBackofficeStore(
+        "does-not-exist",
+        session.token,
+      );
+      expect(response.status).toBe(404);
+    });
+  });
+});

--- a/tests/integration/api/v1/backoffice/stores/get.test.ts
+++ b/tests/integration/api/v1/backoffice/stores/get.test.ts
@@ -1,0 +1,64 @@
+import webserver from "infra/webserver";
+import orchestrator from "tests/orchestrator";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+async function fetchBackofficeStores(query = "", sessionToken?: string) {
+  return fetch(`${webserver.getOrigin()}/api/v1/backoffice/stores${query}`, {
+    headers: sessionToken ? { Cookie: `session_id=${sessionToken}` } : {},
+  });
+}
+
+describe("GET /api/v1/backoffice/stores", () => {
+  describe("Anonymous user", () => {
+    test("Should return 403 Forbidden", async () => {
+      const response = await fetchBackofficeStores();
+      expect(response.status).toBe(403);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        name: "ForbiddenError",
+        message: "You do not have permission to perform this action",
+        action: "Verify your user has the following features: read:store:any",
+        status_code: 403,
+      });
+    });
+  });
+
+  describe("Authenticated non-admin user", () => {
+    test("Should return 403 Forbidden", async () => {
+      const nonAdmin = await orchestrator.createUser();
+      await orchestrator.activateUser(nonAdmin.id);
+      const session = await orchestrator.createSession(nonAdmin.id);
+
+      const response = await fetchBackofficeStores("", session.token);
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe("Authenticated admin user", () => {
+    test("Should list stores and search by name", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      await orchestrator.createStore(owner.id, {
+        name: "Searchable Store Name",
+      });
+
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+
+      const response = await fetchBackofficeStores(
+        "?q=Searchable",
+        session.token,
+      );
+      expect(response.status).toBe(200);
+
+      const body = await response.json();
+      expect(body.stores).toHaveLength(1);
+      expect(body.stores[0].name).toBe("Searchable Store Name");
+    });
+  });
+});

--- a/tests/integration/api/v1/backoffice/studios/[slug]/get.test.ts
+++ b/tests/integration/api/v1/backoffice/studios/[slug]/get.test.ts
@@ -1,0 +1,63 @@
+import webserver from "infra/webserver";
+import orchestrator from "tests/orchestrator";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+async function fetchBackofficeStudio(slug: string, sessionToken?: string) {
+  return fetch(`${webserver.getOrigin()}/api/v1/backoffice/studios/${slug}`, {
+    headers: sessionToken ? { Cookie: `session_id=${sessionToken}` } : {},
+  });
+}
+
+describe("GET /api/v1/backoffice/studios/[slug]", () => {
+  describe("Anonymous user", () => {
+    test("Should return 403 Forbidden", async () => {
+      const owner = await orchestrator.createUser();
+      const createdStudio = await orchestrator.createStudio(owner.id);
+
+      const response = await fetchBackofficeStudio(createdStudio.slug);
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe("Authenticated admin user", () => {
+    test("Should return the studio plus its games, including PRIVATE ones", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const createdStudio = await orchestrator.createStudio(owner.id);
+      await orchestrator.createGame(owner.id, {
+        title: "Studio Detail Game",
+        studio_id: createdStudio.id,
+      });
+
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+
+      const response = await fetchBackofficeStudio(
+        createdStudio.slug,
+        session.token,
+      );
+      expect(response.status).toBe(200);
+
+      const body = await response.json();
+      expect(body.studio.id).toBe(createdStudio.id);
+      expect(body.games).toHaveLength(1);
+      expect(body.games[0].title).toBe("Studio Detail Game");
+      expect(body.games[0].status).toBe("PRIVATE");
+    });
+
+    test("With an unknown slug should return 404 Not Found", async () => {
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+
+      const response = await fetchBackofficeStudio(
+        "does-not-exist",
+        session.token,
+      );
+      expect(response.status).toBe(404);
+    });
+  });
+});

--- a/tests/integration/api/v1/backoffice/studios/get.test.ts
+++ b/tests/integration/api/v1/backoffice/studios/get.test.ts
@@ -1,0 +1,64 @@
+import webserver from "infra/webserver";
+import orchestrator from "tests/orchestrator";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+async function fetchBackofficeStudios(query = "", sessionToken?: string) {
+  return fetch(`${webserver.getOrigin()}/api/v1/backoffice/studios${query}`, {
+    headers: sessionToken ? { Cookie: `session_id=${sessionToken}` } : {},
+  });
+}
+
+describe("GET /api/v1/backoffice/studios", () => {
+  describe("Anonymous user", () => {
+    test("Should return 403 Forbidden", async () => {
+      const response = await fetchBackofficeStudios();
+      expect(response.status).toBe(403);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        name: "ForbiddenError",
+        message: "You do not have permission to perform this action",
+        action: "Verify your user has the following features: read:studio:any",
+        status_code: 403,
+      });
+    });
+  });
+
+  describe("Authenticated non-admin user", () => {
+    test("Should return 403 Forbidden", async () => {
+      const nonAdmin = await orchestrator.createUser();
+      await orchestrator.activateUser(nonAdmin.id);
+      const session = await orchestrator.createSession(nonAdmin.id);
+
+      const response = await fetchBackofficeStudios("", session.token);
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe("Authenticated admin user", () => {
+    test("Should list studios and search by name", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      await orchestrator.createStudio(owner.id, {
+        name: "Searchable Studio Name",
+      });
+
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+
+      const response = await fetchBackofficeStudios(
+        "?q=Searchable",
+        session.token,
+      );
+      expect(response.status).toBe(200);
+
+      const body = await response.json();
+      expect(body.studios).toHaveLength(1);
+      expect(body.studios[0].name).toBe("Searchable Studio Name");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Seventh PR in the admin backoffice sequence (see `docs/backoffice-tasks.md`, task 7; depends on task 1/#105, merged). **Not auto-merging** — leaving open for manual review per your instruction. Branched from `main` before task 6/#110 merged, so it doesn't include that PR's (still-open) users backend — no overlap either way, this task only depends on task 1.

Read-only, same shape applied twice — studios and stores had no "list all" before this:

- `models/studio.ts` / `models/store.ts`: `findAllPaginated({page, limit, q})`, case-insensitive search on name/slug.
- `GET /api/v1/backoffice/studios` (list/search), `GET /api/v1/backoffice/studios/[slug]` — detail plus the studio's games (via `game.findAllPaginatedAdmin`'s `studio_id` filter), **including PRIVATE ones** the public studio page wouldn't show — this is the "spot-check a studio" workflow the owner persona asked for.
- `GET /api/v1/backoffice/stores` (list/search), `GET /api/v1/backoffice/stores/[slug]` — read-only detail.
- No create/edit/delete on either — matches the plan's read-only scope for this task and the project's broader no-hard-delete stance for Phase 1.

## Test plan

- [x] `eslint` / `prettier --check` — clean.
- [x] New tests (12, all passing): studios list (403 anon/non-admin, search-by-name), studio detail (returns games incl. PRIVATE, 404 on unknown slug), stores list (403s, search-by-name), store detail (200/404).
- [x] Hit a real environment bug while testing, unrelated to this PR's code: a stale `next dev`/Turbopack route cache in my local sandbox was silently 404ing several *pre-existing, untouched* nested-dynamic routes (e.g. `studios/[slug]/members/[username]`) under load. A full `.next` cache clear + clean restart fixed it — confirmed by re-running the exact same suites before/after with no code changes in between. Not a regression, just sandbox staleness; flagging in case it's useful context for reviewing CI (which builds fresh every time and won't hit this).
- [x] Ran the full `npx jest --runInBand` suite locally against real Postgres after the clean restart: 277/321 passing, same 12 pre-existing environment-gap failures as prior PRs (no SMTP/S3 in this sandbox, one Postgres minor-version assertion) — confirmed unchanged failing-suite list.
- [x] Full `npm run test` integration suite: confirmed green via CI's "Jest Ubuntu" check on this PR.
