### PR TITLE
feat: backoffice task 8 — dashboard backend

### DIFF
--- a/models/authorization.ts
+++ b/models/authorization.ts
@@ -578,6 +578,35 @@ function filterOutput(user: Partial<User>, feature: string, resource: unknown) {
     };
   }
 
+  if (feature === "read:dashboard:any") {
+    interface DashboardOutput {
+      games: {
+        pending_count: number;
+        oldest_pending: {
+          id: string;
+          slug: string;
+          title: string;
+          created_at: Date;
+        }[];
+        by_status: Record<string, number>;
+      };
+      users: {
+        total: number;
+        signups_last_7_days: number;
+        signups_previous_7_days: number;
+      };
+      studios: { total: number };
+      stores: { total: number };
+    }
+    const dashboardOutput = resource as DashboardOutput;
+    return {
+      games: dashboardOutput.games,
+      users: dashboardOutput.users,
+      studios: dashboardOutput.studios,
+      stores: dashboardOutput.stores,
+    };
+  }
+
   return {};
 }
 

--- a/models/dashboard.ts
+++ b/models/dashboard.ts
@@ -1,0 +1,76 @@
+import { prisma } from "infra/database";
+import { GameStatus } from "generated/prisma/client";
+
+const ONE_DAY_IN_MILLISECONDS = 1000 * 60 * 60 * 24;
+const OLDEST_PENDING_GAMES_LIMIT = 5;
+
+// Rolling 7-day windows rather than calendar weeks (Sun-Sat) - simpler,
+// timezone-agnostic, and just as meaningful for "signups this week vs last".
+async function getMetrics() {
+  const now = new Date();
+  const sevenDaysAgo = new Date(now.getTime() - 7 * ONE_DAY_IN_MILLISECONDS);
+  const fourteenDaysAgo = new Date(
+    now.getTime() - 14 * ONE_DAY_IN_MILLISECONDS,
+  );
+
+  const [
+    pendingGamesCount,
+    oldestPendingGames,
+    signupsLast7Days,
+    signupsPrevious7Days,
+    totalUsers,
+    totalStudios,
+    totalStores,
+    gamesByStatusRaw,
+  ] = await Promise.all([
+    prisma.game.count({ where: { status: "PRIVATE" } }),
+    prisma.game.findMany({
+      where: { status: "PRIVATE" },
+      orderBy: { created_at: "asc" },
+      take: OLDEST_PENDING_GAMES_LIMIT,
+      select: { id: true, slug: true, title: true, created_at: true },
+    }),
+    prisma.user.count({ where: { created_at: { gte: sevenDaysAgo } } }),
+    prisma.user.count({
+      where: { created_at: { gte: fourteenDaysAgo, lt: sevenDaysAgo } },
+    }),
+    prisma.user.count(),
+    prisma.studio.count(),
+    prisma.store.count(),
+    prisma.game.groupBy({ by: ["status"], _count: { status: true } }),
+  ]);
+
+  const gamesByStatus: Record<GameStatus, number> = {
+    ACTIVE: 0,
+    INACTIVE: 0,
+    PRIVATE: 0,
+  };
+  for (const row of gamesByStatusRaw) {
+    gamesByStatus[row.status] = row._count.status;
+  }
+
+  return {
+    games: {
+      pending_count: pendingGamesCount,
+      oldest_pending: oldestPendingGames,
+      by_status: gamesByStatus,
+    },
+    users: {
+      total: totalUsers,
+      signups_last_7_days: signupsLast7Days,
+      signups_previous_7_days: signupsPrevious7Days,
+    },
+    studios: {
+      total: totalStudios,
+    },
+    stores: {
+      total: totalStores,
+    },
+  };
+}
+
+const dashboard = {
+  getMetrics,
+};
+
+export default dashboard;

--- a/pages/api/v1/backoffice/dashboard/index.ts
+++ b/pages/api/v1/backoffice/dashboard/index.ts
@@ -1,0 +1,22 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { createRouter } from "next-connect";
+import controller from "infra/controller";
+import dashboard from "models/dashboard";
+import authorization from "models/authorization";
+
+export default createRouter<NextApiRequest, NextApiResponse>()
+  .use(controller.injectAnonymousOrUser)
+  .get(controller.canRequest("read:dashboard:any"), getHandler)
+  .handler(controller.errorHandlers);
+
+async function getHandler(req: NextApiRequest, res: NextApiResponse) {
+  const metrics = await dashboard.getMetrics();
+
+  const secureOutputValues = authorization.filterOutput(
+    req.context.user,
+    "read:dashboard:any",
+    metrics,
+  );
+
+  return res.status(200).json(secureOutputValues);
+}

--- a/tests/integration/api/v1/backoffice/dashboard/get.test.ts
+++ b/tests/integration/api/v1/backoffice/dashboard/get.test.ts
@@ -1,0 +1,112 @@
+import webserver from "infra/webserver";
+import orchestrator from "tests/orchestrator";
+import gameModel from "models/game";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+async function fetchDashboard(sessionToken?: string) {
+  return fetch(`${webserver.getOrigin()}/api/v1/backoffice/dashboard`, {
+    headers: sessionToken ? { Cookie: `session_id=${sessionToken}` } : {},
+  });
+}
+
+describe("GET /api/v1/backoffice/dashboard", () => {
+  describe("Anonymous user", () => {
+    test("Should return 403 Forbidden", async () => {
+      const response = await fetchDashboard();
+      expect(response.status).toBe(403);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        name: "ForbiddenError",
+        message: "You do not have permission to perform this action",
+        action:
+          "Verify your user has the following features: read:dashboard:any",
+        status_code: 403,
+      });
+    });
+  });
+
+  describe("Authenticated non-admin user", () => {
+    test("Should return 403 Forbidden", async () => {
+      const nonAdmin = await orchestrator.createUser();
+      await orchestrator.activateUser(nonAdmin.id);
+      const session = await orchestrator.createSession(nonAdmin.id);
+
+      const response = await fetchDashboard(session.token);
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe("Authenticated admin user", () => {
+    test("Should return games/users/studios/stores metrics", async () => {
+      await orchestrator.clearDatabaseRows();
+
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+
+      const pendingGame = await orchestrator.createGame(owner.id, {
+        title: "Pending Dashboard Game",
+      });
+      const activeGame = await orchestrator.createGame(owner.id, {
+        title: "Active Dashboard Game",
+      });
+      await gameModel.makePublic(activeGame.id);
+
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+
+      const response = await fetchDashboard(session.token);
+      expect(response.status).toBe(200);
+
+      const body = await response.json();
+
+      expect(body.games.pending_count).toBe(1);
+      expect(
+        body.games.oldest_pending.map((g: { id: string }) => g.id),
+      ).toEqual([pendingGame.id]);
+      expect(body.games.by_status).toEqual({
+        ACTIVE: 1,
+        INACTIVE: 0,
+        PRIVATE: 1,
+      });
+
+      // owner + admin were both created within the last 7 days
+      expect(body.users.total).toBe(2);
+      expect(body.users.signups_last_7_days).toBe(2);
+      expect(body.users.signups_previous_7_days).toBe(0);
+
+      expect(body.studios.total).toBeGreaterThanOrEqual(1);
+      expect(body.stores.total).toBe(0);
+    });
+
+    test("Oldest pending games are sorted oldest-first and capped at 5", async () => {
+      await orchestrator.clearDatabaseRows();
+
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+
+      const games = [];
+      for (let i = 0; i < 6; i++) {
+        games.push(
+          await orchestrator.createGame(owner.id, { title: `Pending ${i}` }),
+        );
+      }
+
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+
+      const response = await fetchDashboard(session.token);
+      const body = await response.json();
+
+      expect(body.games.pending_count).toBe(6);
+      expect(body.games.oldest_pending).toHaveLength(5);
+      expect(
+        body.games.oldest_pending.map((g: { id: string }) => g.id),
+      ).toEqual(games.slice(0, 5).map((g) => g.id));
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Eighth PR in the admin backoffice sequence (see `docs/backoffice-tasks.md`, task 8; depends on task 1/#105, merged). **Not auto-merging** — leaving open for manual review per your instruction. Branched from `main`, independent of tasks 6/#110 and 7/#111 (still open).

- `models/dashboard.ts`: single `getMetrics()` aggregation. Deliberately ordered around what the plan (from the owner-persona review) says actually matters each morning, not vanity counts:
  - `games.pending_count` + `games.oldest_pending` (5 oldest `PRIVATE` games) — the review-queue backlog.
  - `users.signups_last_7_days` vs `users.signups_previous_7_days` (rolling 7-day windows, not calendar weeks — simpler and timezone-agnostic).
  - `games.by_status`, `users.total`, `studios.total`, `stores.total` — the secondary totals.
  - No active-session metric — explicitly called out as not worth a dashboard slot in the plan.
- `GET /api/v1/backoffice/dashboard`, requires `read:dashboard:any`. New `filterOutput` case added for it in `models/authorization.ts` (this feature was registered in #105 but had no case yet since the shape didn't exist until now).

## Test plan

- [x] `eslint` / `prettier --check` — clean.
- [x] New tests (4, all passing): 403 for anon/non-admin, correct counts/by_status/signup-window math for admin, oldest-pending capped at 5 and sorted oldest-first.
- [x] Ran the full `npx jest --runInBand` suite locally against real Postgres after a clean `next dev` restart with cache cleared (hit the same stale-Turbopack-cache flakiness noted in #111 mid-session — a `rm -rf .next` + restart resolved it, confirmed by an unrelated cascade of failures disappearing on rerun with zero code changes): 284/329 passing, same 12 pre-existing environment-gap suites as prior PRs (no SMTP/S3 in this sandbox, one Postgres minor-version assertion) — confirmed unchanged failing-suite list.
- [x] Full `npm run test` integration suite: confirmed green via CI's "Jest Ubuntu" check on this PR.
