### PR TITLE
feat: backoffice task 9 — UI shell

### DIFF
--- a/components/backoffice/BackofficeLayout.tsx
+++ b/components/backoffice/BackofficeLayout.tsx
@@ -1,0 +1,70 @@
+import { ReactNode, useEffect } from "react";
+import { useRouter } from "next/router";
+import useSWR from "swr";
+import { BackofficeTopNav } from "./BackofficeTopNav";
+
+interface BackofficeUser {
+  id: string;
+  username: string;
+  email: string;
+  features: string[];
+}
+
+const fetcher = (url: string) =>
+  fetch(url).then(async (res) => {
+    if (!res.ok) throw new Error("Not logged in");
+    return res.json();
+  });
+
+// Any admin has read:dashboard:any (part of ADMIN_ONLY_FEATURES, granted as
+// a whole - see models/authorization.ts). Cheap enough as a client-side
+// "am I an admin" signal; the actual gate is server-side on every route.
+const ADMIN_SIGNAL_FEATURE = "read:dashboard:any";
+
+export function useBackofficeAccess() {
+  const { data, error, isLoading } = useSWR<BackofficeUser>(
+    "/api/v1/user",
+    fetcher,
+    { shouldRetryOnError: false },
+  );
+
+  const isLoggedOut = !!error;
+  const isAdmin = !!data?.features?.includes(ADMIN_SIGNAL_FEATURE);
+
+  return { user: data, isLoading, isLoggedOut, isAdmin };
+}
+
+export function BackofficeLayout({ children }: { children: ReactNode }) {
+  const router = useRouter();
+  const { user, isLoading, isLoggedOut, isAdmin } = useBackofficeAccess();
+
+  useEffect(() => {
+    if (isLoading) return;
+
+    if (isLoggedOut) {
+      router.replace(`/login?callbackUrl=${encodeURIComponent(router.asPath)}`);
+      return;
+    }
+
+    if (!isAdmin) {
+      router.replace("/store");
+    }
+  }, [isLoading, isLoggedOut, isAdmin, router]);
+
+  if (isLoading || isLoggedOut || !isAdmin) {
+    return (
+      <div className="min-h-screen bg-[#1D0F3B] flex items-center justify-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-t-4 border-b-4 border-white/20" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-[#1D0F3B] text-white">
+      <BackofficeTopNav username={user.username} />
+      <main className="pt-24 pb-16 px-4 md:px-10 max-w-7xl mx-auto">
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/components/backoffice/BackofficeTopNav.tsx
+++ b/components/backoffice/BackofficeTopNav.tsx
@@ -1,0 +1,87 @@
+import Link from "next/link";
+import { useRouter } from "next/router";
+import {
+  LayoutDashboard,
+  Gamepad2,
+  Users,
+  Building2,
+  Store as StoreIcon,
+  LogOut,
+  ArrowLeft,
+  ShieldCheck,
+} from "lucide-react";
+
+const NAV_ITEMS = [
+  { href: "/backoffice", label: "Dashboard", icon: LayoutDashboard },
+  { href: "/backoffice/games", label: "Games", icon: Gamepad2 },
+  { href: "/backoffice/users", label: "Users", icon: Users },
+  { href: "/backoffice/studios", label: "Studios", icon: Building2 },
+  { href: "/backoffice/stores", label: "Stores", icon: StoreIcon },
+];
+
+export function BackofficeTopNav({ username }: { username: string }) {
+  const router = useRouter();
+
+  async function handleSignOut() {
+    await fetch("/api/v1/sessions", { method: "DELETE" });
+    router.push("/store");
+  }
+
+  return (
+    <header className="fixed top-0 inset-x-0 z-50 bg-[#130b25]/90 backdrop-blur-xl border-b border-white/10 py-3 px-4 md:px-10">
+      <div className="max-w-7xl mx-auto flex items-center justify-between gap-4">
+        <div className="flex items-center gap-6 min-w-0">
+          <Link
+            href="/backoffice"
+            className="flex items-center gap-2 font-black text-lg tracking-tight text-white shrink-0"
+          >
+            <ShieldCheck size={20} className="text-indigo-400" />
+            <span className="hidden sm:inline">Manifold Admin</span>
+          </Link>
+
+          <nav className="hidden md:flex items-center gap-1">
+            {NAV_ITEMS.map(({ href, label, icon: Icon }) => {
+              const isActive =
+                router.pathname === href ||
+                (href !== "/backoffice" && router.pathname.startsWith(href));
+              return (
+                <Link
+                  key={href}
+                  href={href}
+                  className={`flex items-center gap-2 px-3 py-2 rounded-xl text-sm font-bold tracking-wide transition-all ${
+                    isActive
+                      ? "bg-white/10 text-white"
+                      : "text-white/60 hover:text-white hover:bg-white/5"
+                  }`}
+                >
+                  <Icon size={16} />
+                  {label}
+                </Link>
+              );
+            })}
+          </nav>
+        </div>
+
+        <div className="flex items-center gap-3 shrink-0">
+          <Link
+            href="/store"
+            className="hidden sm:flex items-center gap-2 px-3 py-2 rounded-xl text-white/50 hover:text-white hover:bg-white/5 text-xs font-bold uppercase tracking-wider transition-colors"
+          >
+            <ArrowLeft size={14} />
+            Back to Store
+          </Link>
+          <span className="hidden lg:inline text-sm font-bold text-white/70">
+            {username}
+          </span>
+          <button
+            onClick={handleSignOut}
+            aria-label="Sign out"
+            className="flex items-center gap-2 px-3 py-2 rounded-xl text-white/60 hover:text-rose-400 hover:bg-rose-500/10 text-sm font-bold transition-colors"
+          >
+            <LogOut size={16} />
+          </button>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/pages/backoffice/index.tsx
+++ b/pages/backoffice/index.tsx
@@ -1,0 +1,22 @@
+import Head from "next/head";
+import { BackofficeLayout } from "components/backoffice/BackofficeLayout";
+
+export default function BackofficeIndexPage() {
+  return (
+    <>
+      <Head>
+        <title>Backoffice | Manifold</title>
+        <meta name="theme-color" content="#1D0F3B" />
+      </Head>
+
+      <h1 className="text-3xl font-black mb-2">Dashboard</h1>
+      <p className="text-white/50 font-bold">
+        Metrics land here in a follow-up task.
+      </p>
+    </>
+  );
+}
+
+BackofficeIndexPage.getLayout = function getLayout(page: React.ReactElement) {
+  return <BackofficeLayout>{page}</BackofficeLayout>;
+};


### PR DESCRIPTION
## Summary

Ninth PR in the admin backoffice sequence (see `docs/backoffice-tasks.md`, task 9; depends on task 1/#105, merged). **Not auto-merging** — leaving open for manual review per your instruction. This is the layout/shell task 10-13's UI will all build on.

- `components/backoffice/BackofficeTopNav.tsx` — fixed top nav with links to Dashboard/Games/Users/Studios/Stores, active-route highlighting, username + sign-out, "Back to Store" link. Same visual language and structure as `components/store/StoreTopNav.tsx`/`StoreLayout.tsx` (dark theme, Tailwind utilities, `lucide-react` icons).
- `components/backoffice/BackofficeLayout.tsx` — wraps page content, fetches `/api/v1/user` via SWR, and **client-side redirects**: anonymous → `/login?callbackUrl=...`, logged-in-but-not-admin → `/store`. This is a UX nicety only — every backoffice API route already enforces the real check server-side (`controller.canRequest("...:any")`), unaffected by this PR. "Admin" is signaled by the presence of `read:dashboard:any` in the user's `features` (part of the `ADMIN_ONLY_FEATURES` bundle granted as a whole).
- `pages/backoffice/index.tsx` — minimal placeholder using the layout, just so the shell is actually visitable end-to-end rather than shipping as dead code. Task 13 fills in real dashboard content on this same route/file.

## Test plan

- [x] `eslint` / `prettier --check` — clean.
- [x] No backend/model changes in this PR, so no new integration tests — full `npx jest --runInBand` suite locally: 281/325 passing, same 12 pre-existing environment-gap suites as prior PRs, unchanged.
- [x] **Manually verified in a real headless-Chromium browser** (installed `playwright-core` temporarily for this, not added to `package.json`) against the actual running app + local Postgres, all three states:
  - Anonymous visitor → redirected to `/login?callbackUrl=%2Fbackoffice`.
  - Logged-in non-admin → redirected to `/store`.
  - Logged-in admin → stays on `/backoffice`, sees the full nav shell with "Dashboard" active and the placeholder content. Screenshot confirms styling matches the existing dark theme.
- [x] Full `npm run test` integration suite: confirmed green via CI's "Jest Ubuntu" check on this PR.
