### PR TITLE
feat: backoffice task 11 — users admin UI

### DIFF
--- a/pages/backoffice/users/[id].tsx
+++ b/pages/backoffice/users/[id].tsx
@@ -1,0 +1,253 @@
+import { useState } from "react";
+import Head from "next/head";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import useSWR, { mutate } from "swr";
+import { ArrowLeft, Ban, CheckCircle2, Loader2 } from "lucide-react";
+import {
+  BackofficeLayout,
+  useBackofficeAccess,
+} from "components/backoffice/BackofficeLayout";
+
+interface BackofficeUser {
+  id: string;
+  username: string;
+  email: string;
+  features: string[];
+  created_at: string;
+  updated_at: string;
+}
+
+const fetcher = (url: string) =>
+  fetch(url).then(async (res) => {
+    if (!res.ok) throw new Error("Not found");
+    return res.json();
+  });
+
+// Mirrors models/user.ts's isDisabled() - see pages/backoffice/users/index.tsx.
+function isDisabled(user: BackofficeUser) {
+  return !user.features.includes("read:session");
+}
+
+export default function BackofficeUserDetailPage() {
+  const router = useRouter();
+  const { id } = router.query;
+  const { user: currentAdmin } = useBackofficeAccess();
+  const [showDisableModal, setShowDisableModal] = useState(false);
+  const [disableReason, setDisableReason] = useState("");
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const key = id ? `/api/v1/backoffice/users/${id}` : null;
+  const {
+    data: targetUser,
+    isLoading,
+    error,
+  } = useSWR<BackofficeUser>(key, fetcher);
+
+  const disabled = targetUser ? isDisabled(targetUser) : false;
+  const isSelf = targetUser?.id === currentAdmin?.id;
+
+  async function submitDisable() {
+    if (!key) return;
+    setActionError(null);
+    const response = await fetch(`${key}/disable`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(
+        disableReason.trim() ? { reason: disableReason.trim() } : {},
+      ),
+    });
+    if (!response.ok) {
+      const body = await response.json().catch(() => null);
+      setActionError(body?.message || "Failed to disable user.");
+      return;
+    }
+    setShowDisableModal(false);
+    setDisableReason("");
+    mutate(key);
+  }
+
+  async function enableUser() {
+    if (!key || !targetUser) return;
+    const confirmed = window.confirm(
+      `Re-enable "${targetUser.username}"? They'll get back exactly the access they had before being disabled.`,
+    );
+    if (!confirmed) return;
+
+    setActionError(null);
+    const response = await fetch(`${key}/enable`, { method: "PATCH" });
+    if (!response.ok) {
+      const body = await response.json().catch(() => null);
+      setActionError(body?.message || "Failed to enable user.");
+      return;
+    }
+    mutate(key);
+  }
+
+  return (
+    <>
+      <Head>
+        <title>
+          {targetUser
+            ? `${targetUser.username} | Manifold Admin`
+            : "User | Manifold Admin"}
+        </title>
+      </Head>
+
+      <div className="flex flex-col gap-6 max-w-2xl">
+        <Link
+          href="/backoffice/users"
+          className="flex items-center gap-2 text-sm font-bold text-white/50 hover:text-white transition-colors w-fit"
+        >
+          <ArrowLeft size={14} />
+          Back to Users
+        </Link>
+
+        {actionError && (
+          <div className="px-4 py-3 rounded-xl bg-rose-500/10 border border-rose-500/30 text-rose-300 text-sm font-bold">
+            {actionError}
+          </div>
+        )}
+
+        {isLoading ? (
+          <Loader2 className="animate-spin text-white/30" />
+        ) : error || !targetUser ? (
+          <p className="text-rose-300 font-bold">User not found.</p>
+        ) : (
+          <div className="rounded-2xl border border-white/10 bg-white/5 p-6 flex flex-col gap-5">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h1 className="text-3xl font-black">{targetUser.username}</h1>
+                <p className="text-white/50 font-bold">{targetUser.email}</p>
+              </div>
+              <span
+                className={`px-3 py-1 rounded-md text-xs font-black uppercase tracking-wider ${
+                  disabled
+                    ? "bg-rose-500/20 text-rose-300"
+                    : "bg-emerald-500/20 text-emerald-300"
+                }`}
+              >
+                {disabled ? "Disabled" : "Active"}
+              </span>
+            </div>
+
+            <div className="grid grid-cols-2 gap-4 text-sm">
+              <div>
+                <div className="text-white/40 font-bold uppercase text-xs tracking-wider mb-1">
+                  User ID
+                </div>
+                <div className="text-white/70 font-mono text-xs break-all">
+                  {targetUser.id}
+                </div>
+              </div>
+              <div>
+                <div className="text-white/40 font-bold uppercase text-xs tracking-wider mb-1">
+                  Joined
+                </div>
+                <div className="text-white/70 font-bold">
+                  {new Date(targetUser.created_at).toLocaleString()}
+                </div>
+              </div>
+              <div>
+                <div className="text-white/40 font-bold uppercase text-xs tracking-wider mb-1">
+                  Features
+                </div>
+                <div className="text-white/70 font-bold">
+                  {targetUser.features.length}
+                </div>
+              </div>
+              <div>
+                <div className="text-white/40 font-bold uppercase text-xs tracking-wider mb-1">
+                  Last Updated
+                </div>
+                <div className="text-white/70 font-bold">
+                  {new Date(targetUser.updated_at).toLocaleString()}
+                </div>
+              </div>
+            </div>
+
+            <div className="flex flex-wrap gap-1.5">
+              {targetUser.features.map((feature) => (
+                <span
+                  key={feature}
+                  className="px-2 py-1 rounded-md bg-white/5 border border-white/10 text-xs font-mono text-white/50"
+                >
+                  {feature}
+                </span>
+              ))}
+            </div>
+
+            <div className="border-t border-white/10 pt-5">
+              {isSelf ? (
+                <p className="text-sm text-white/40 font-bold">
+                  This is your own account - you can&apos;t disable it.
+                </p>
+              ) : disabled ? (
+                <button
+                  onClick={enableUser}
+                  className="flex items-center gap-2 px-4 py-2 rounded-xl bg-emerald-500 text-black font-black text-sm uppercase tracking-wider hover:bg-emerald-400 transition-colors"
+                >
+                  <CheckCircle2 size={16} />
+                  Enable User
+                </button>
+              ) : (
+                <button
+                  onClick={() => setShowDisableModal(true)}
+                  className="flex items-center gap-2 px-4 py-2 rounded-xl bg-rose-500 text-black font-black text-sm uppercase tracking-wider hover:bg-rose-400 transition-colors"
+                >
+                  <Ban size={16} />
+                  Disable User
+                </button>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {showDisableModal && targetUser && (
+        <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 backdrop-blur-sm px-4">
+          <div className="w-full max-w-md rounded-2xl border border-white/10 bg-[#1D0F3B] p-6 shadow-2xl">
+            <h2 className="text-xl font-black mb-1">
+              Disable &quot;{targetUser.username}&quot;?
+            </h2>
+            <p className="text-sm text-white/50 font-bold mb-4">
+              They&apos;ll be signed out of any real access immediately -
+              existing sessions degrade to logged-out-visitor level and they
+              can&apos;t log back in. This can be undone at any time.
+            </p>
+            <textarea
+              value={disableReason}
+              onChange={(e) => setDisableReason(e.target.value)}
+              placeholder="Reason (optional)"
+              rows={3}
+              className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-bold text-white placeholder:text-white/30 outline-none focus:bg-white/10 focus:border-white/20 resize-none"
+            />
+            <div className="flex justify-end gap-3 mt-4">
+              <button
+                onClick={() => {
+                  setShowDisableModal(false);
+                  setDisableReason("");
+                }}
+                className="px-4 py-2 rounded-xl text-white/60 hover:text-white font-bold text-sm"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={submitDisable}
+                className="px-4 py-2 rounded-xl bg-rose-500 text-black font-black text-sm uppercase tracking-wider hover:bg-rose-400 transition-colors"
+              >
+                Disable User
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+BackofficeUserDetailPage.getLayout = function getLayout(
+  page: React.ReactElement,
+) {
+  return <BackofficeLayout>{page}</BackofficeLayout>;
+};

--- a/pages/backoffice/users/index.tsx
+++ b/pages/backoffice/users/index.tsx
@@ -1,0 +1,296 @@
+import { useState } from "react";
+import Head from "next/head";
+import Link from "next/link";
+import useSWR, { mutate } from "swr";
+import { Ban, CheckCircle2, Loader2, Search } from "lucide-react";
+import {
+  BackofficeLayout,
+  useBackofficeAccess,
+} from "components/backoffice/BackofficeLayout";
+
+interface BackofficeUser {
+  id: string;
+  username: string;
+  email: string;
+  features: string[];
+  created_at: string;
+  updated_at: string;
+}
+
+interface UsersResponse {
+  users: BackofficeUser[];
+  pagination: { page: number; limit: number; total: number; pages: number };
+}
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+// Mirrors models/user.ts's isDisabled(): a disabled user's features never
+// include read:session (part of the activated set, stripped on disable).
+// Purely a display heuristic - the real gate is server-side.
+function isDisabled(user: BackofficeUser) {
+  return !user.features.includes("read:session");
+}
+
+export default function BackofficeUsersPage() {
+  const { user: currentAdmin } = useBackofficeAccess();
+  const [query, setQuery] = useState("");
+  const [page, setPage] = useState(1);
+  const [disableTarget, setDisableTarget] = useState<BackofficeUser | null>(
+    null,
+  );
+  const [disableReason, setDisableReason] = useState("");
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const queryParams = new URLSearchParams();
+  if (query.trim()) queryParams.set("q", query.trim());
+  queryParams.set("page", String(page));
+  queryParams.set("limit", "20");
+
+  const key = `/api/v1/backoffice/users?${queryParams.toString()}`;
+  const { data, isLoading, error } = useSWR<UsersResponse>(key, fetcher);
+
+  const users = data?.users ?? [];
+  const pagination = data?.pagination;
+
+  async function submitDisable() {
+    if (!disableTarget) return;
+    setActionError(null);
+    const response = await fetch(
+      `/api/v1/backoffice/users/${disableTarget.id}/disable`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(
+          disableReason.trim() ? { reason: disableReason.trim() } : {},
+        ),
+      },
+    );
+    if (!response.ok) {
+      const body = await response.json().catch(() => null);
+      setActionError(body?.message || "Failed to disable user.");
+      return;
+    }
+    setDisableTarget(null);
+    setDisableReason("");
+    mutate(key);
+  }
+
+  async function enableUser(targetUser: BackofficeUser) {
+    const confirmed = window.confirm(
+      `Re-enable "${targetUser.username}"? They'll get back exactly the access they had before being disabled.`,
+    );
+    if (!confirmed) return;
+
+    setActionError(null);
+    const response = await fetch(
+      `/api/v1/backoffice/users/${targetUser.id}/enable`,
+      { method: "PATCH" },
+    );
+    if (!response.ok) {
+      const body = await response.json().catch(() => null);
+      setActionError(body?.message || "Failed to enable user.");
+      return;
+    }
+    mutate(key);
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Users | Manifold Admin</title>
+      </Head>
+
+      <div className="flex flex-col gap-6">
+        <h1 className="text-3xl font-black">Users</h1>
+
+        {actionError && (
+          <div className="px-4 py-3 rounded-xl bg-rose-500/10 border border-rose-500/30 text-rose-300 text-sm font-bold">
+            {actionError}
+          </div>
+        )}
+
+        <div className="relative max-w-sm">
+          <Search
+            size={14}
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-white/30"
+          />
+          <input
+            type="text"
+            placeholder="Search by username or email..."
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setPage(1);
+            }}
+            className="w-full rounded-xl border border-white/10 bg-white/5 pl-9 pr-4 py-2 text-sm font-bold text-white placeholder:text-white/30 outline-none focus:bg-white/10 focus:border-white/20"
+          />
+        </div>
+
+        <div className="rounded-2xl border border-white/10 overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-white/5 text-white/50 text-xs uppercase tracking-wider">
+              <tr>
+                <th className="px-4 py-3 text-left">Username</th>
+                <th className="px-4 py-3 text-left">Email</th>
+                <th className="px-4 py-3 text-left">Status</th>
+                <th className="px-4 py-3 text-left">Joined</th>
+                <th className="px-4 py-3 text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {isLoading ? (
+                <tr>
+                  <td colSpan={5} className="px-4 py-12 text-center">
+                    <Loader2 className="animate-spin inline-block text-white/30" />
+                  </td>
+                </tr>
+              ) : error ? (
+                <tr>
+                  <td
+                    colSpan={5}
+                    className="px-4 py-12 text-center text-rose-300 font-bold"
+                  >
+                    Failed to load users.
+                  </td>
+                </tr>
+              ) : users.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={5}
+                    className="px-4 py-12 text-center text-white/40 font-bold"
+                  >
+                    No users found.
+                  </td>
+                </tr>
+              ) : (
+                users.map((targetUser) => {
+                  const disabled = isDisabled(targetUser);
+                  const isSelf = targetUser.id === currentAdmin?.id;
+                  return (
+                    <tr key={targetUser.id} className="border-t border-white/5">
+                      <td className="px-4 py-3 font-bold text-white">
+                        <Link
+                          href={`/backoffice/users/${targetUser.id}`}
+                          className="hover:underline"
+                        >
+                          {targetUser.username}
+                        </Link>
+                      </td>
+                      <td className="px-4 py-3 text-white/60">
+                        {targetUser.email}
+                      </td>
+                      <td className="px-4 py-3">
+                        <span
+                          className={`px-2 py-1 rounded-md text-xs font-black uppercase tracking-wider ${
+                            disabled
+                              ? "bg-rose-500/20 text-rose-300"
+                              : "bg-emerald-500/20 text-emerald-300"
+                          }`}
+                        >
+                          {disabled ? "Disabled" : "Active"}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-white/40">
+                        {new Date(targetUser.created_at).toLocaleDateString()}
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex items-center justify-end gap-2">
+                          {isSelf ? (
+                            <span className="text-xs text-white/30 font-bold uppercase tracking-wider">
+                              You
+                            </span>
+                          ) : disabled ? (
+                            <button
+                              onClick={() => enableUser(targetUser)}
+                              className="flex items-center gap-1 px-3 py-1.5 rounded-lg bg-emerald-500/10 text-emerald-300 hover:bg-emerald-500/20 text-xs font-black uppercase tracking-wider transition-colors"
+                            >
+                              <CheckCircle2 size={14} />
+                              Enable
+                            </button>
+                          ) : (
+                            <button
+                              onClick={() => setDisableTarget(targetUser)}
+                              className="flex items-center gap-1 px-3 py-1.5 rounded-lg bg-rose-500/10 text-rose-300 hover:bg-rose-500/20 text-xs font-black uppercase tracking-wider transition-colors"
+                            >
+                              <Ban size={14} />
+                              Disable
+                            </button>
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {pagination && pagination.pages > 1 && (
+          <div className="flex items-center justify-center gap-3">
+            <button
+              disabled={page <= 1}
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              className="px-3 py-1.5 rounded-lg bg-white/5 border border-white/10 text-sm font-bold text-white/70 disabled:opacity-30"
+            >
+              Previous
+            </button>
+            <span className="text-sm font-bold text-white/50">
+              Page {pagination.page} of {pagination.pages}
+            </span>
+            <button
+              disabled={page >= pagination.pages}
+              onClick={() => setPage((p) => p + 1)}
+              className="px-3 py-1.5 rounded-lg bg-white/5 border border-white/10 text-sm font-bold text-white/70 disabled:opacity-30"
+            >
+              Next
+            </button>
+          </div>
+        )}
+      </div>
+
+      {disableTarget && (
+        <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 backdrop-blur-sm px-4">
+          <div className="w-full max-w-md rounded-2xl border border-white/10 bg-[#1D0F3B] p-6 shadow-2xl">
+            <h2 className="text-xl font-black mb-1">
+              Disable &quot;{disableTarget.username}&quot;?
+            </h2>
+            <p className="text-sm text-white/50 font-bold mb-4">
+              They&apos;ll be signed out of any real access immediately -
+              existing sessions degrade to logged-out-visitor level and they
+              can&apos;t log back in. This can be undone at any time.
+            </p>
+            <textarea
+              value={disableReason}
+              onChange={(e) => setDisableReason(e.target.value)}
+              placeholder="Reason (optional)"
+              rows={3}
+              className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-bold text-white placeholder:text-white/30 outline-none focus:bg-white/10 focus:border-white/20 resize-none"
+            />
+            <div className="flex justify-end gap-3 mt-4">
+              <button
+                onClick={() => {
+                  setDisableTarget(null);
+                  setDisableReason("");
+                }}
+                className="px-4 py-2 rounded-xl text-white/60 hover:text-white font-bold text-sm"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={submitDisable}
+                className="px-4 py-2 rounded-xl bg-rose-500 text-black font-black text-sm uppercase tracking-wider hover:bg-rose-400 transition-colors"
+              >
+                Disable User
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+BackofficeUsersPage.getLayout = function getLayout(page: React.ReactElement) {
+  return <BackofficeLayout>{page}</BackofficeLayout>;
+};


### PR DESCRIPTION
## Summary

Closes #126. Eleventh PR in the admin backoffice sequence (see `docs/backoffice-tasks.md`, task 11; depends on task 6/#110 and task 9/#113, both merged). **Not auto-merging** — leaving open for manual review per your instruction.

- `pages/backoffice/users/index.tsx`: search by username/email, a status badge derived from whether `read:session` is present in `features` (mirrors `models/user.ts`'s `isDisabled()` — purely a display heuristic, the real gate is always server-side), disable (opens a modal with an optional reason, matching the backend's optional-reason disable endpoint) / enable (simple confirm, since enable takes no reason) actions per row.
- `pages/backoffice/users/[id].tsx`: same actions on a detail view, plus the full feature list for the user.
- **Self-protection reflected in the UI**: the logged-in admin's own row shows "You" instead of a Disable button (the API already blocks this server-side; this just avoids a confusing click-then-403).

## Test plan

- [x] `eslint` / `prettier --check` on the whole repo — clean.
- [x] No backend/model changes, so no new integration tests.
- [x] **Manually verified in a real headless-Chromium browser** end-to-end against the actual running app + local Postgres:
  - List page: loads, search filters correctly (verified isolating a specific seeded user by a fragment of their username), self-row shows "You" with no action button.
  - Detail page → Disable (with a reason) → confirmed the row/detail flips to "Disabled", features drop to exactly the 5-item `DISABLED_USER_FEATURES` set, and — checked directly against the DB — the `AdminActionLog` entry has the correct `reason` and a `previous_features` snapshot in `metadata` matching the user's prior 21 features.
  - Enable → confirm dialog → features restored to the exact same 21 as before disabling; a `user:enable` audit entry recorded.
  - Anonymous request to `/backoffice/users` → redirected to `/login?callbackUrl=...`.
- [x] Full `npm run test` integration suite: confirmed green via CI's "Jest Ubuntu" check on this PR.
