### PR TITLE
feat: backoffice task 12 — studios and stores admin UI

### DIFF
--- a/pages/backoffice/stores/[slug].tsx
+++ b/pages/backoffice/stores/[slug].tsx
@@ -1,0 +1,96 @@
+import Head from "next/head";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import useSWR from "swr";
+import { ArrowLeft, Loader2 } from "lucide-react";
+import { BackofficeLayout } from "components/backoffice/BackofficeLayout";
+
+interface BackofficeStore {
+  id: string;
+  slug: string;
+  name: string;
+  description: string | null;
+  owner_id: string;
+  created_at: string;
+  updated_at: string;
+}
+
+const fetcher = (url: string) =>
+  fetch(url).then(async (res) => {
+    if (!res.ok) throw new Error("Not found");
+    return res.json();
+  });
+
+export default function BackofficeStoreDetailPage() {
+  const router = useRouter();
+  const { slug } = router.query;
+
+  const key = slug ? `/api/v1/backoffice/stores/${slug}` : null;
+  const {
+    data: store,
+    isLoading,
+    error,
+  } = useSWR<BackofficeStore>(key, fetcher);
+
+  return (
+    <>
+      <Head>
+        <title>
+          {store ? `${store.name} | Manifold Admin` : "Store | Manifold Admin"}
+        </title>
+      </Head>
+
+      <div className="flex flex-col gap-6 max-w-2xl">
+        <Link
+          href="/backoffice/stores"
+          className="flex items-center gap-2 text-sm font-bold text-white/50 hover:text-white transition-colors w-fit"
+        >
+          <ArrowLeft size={14} />
+          Back to Stores
+        </Link>
+
+        {isLoading ? (
+          <Loader2 className="animate-spin text-white/30" />
+        ) : error || !store ? (
+          <p className="text-rose-300 font-bold">Store not found.</p>
+        ) : (
+          <div className="rounded-2xl border border-white/10 bg-white/5 p-6 flex flex-col gap-4">
+            <div>
+              <h1 className="text-3xl font-black">{store.name}</h1>
+              {store.description && (
+                <p className="text-white/50 font-bold mt-1">
+                  {store.description}
+                </p>
+              )}
+            </div>
+
+            <div className="grid grid-cols-2 gap-4 text-sm">
+              <div>
+                <div className="text-white/40 font-bold uppercase text-xs tracking-wider mb-1">
+                  Store ID
+                </div>
+                <div className="text-white/70 font-mono text-xs break-all">
+                  {store.id}
+                </div>
+              </div>
+              <div>
+                <div className="text-white/40 font-bold uppercase text-xs tracking-wider mb-1">
+                  Created
+                </div>
+                <div className="text-white/70 font-bold">
+                  {new Date(store.created_at).toLocaleString()}
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}
+
+BackofficeStoreDetailPage.getLayout = function getLayout(
+  page: React.ReactElement,
+) {
+  return <BackofficeLayout>{page}</BackofficeLayout>;
+};

--- a/pages/backoffice/stores/index.tsx
+++ b/pages/backoffice/stores/index.tsx
@@ -1,0 +1,147 @@
+import { useState } from "react";
+import Head from "next/head";
+import Link from "next/link";
+import useSWR from "swr";
+import { Loader2, Search } from "lucide-react";
+import { BackofficeLayout } from "components/backoffice/BackofficeLayout";
+
+interface BackofficeStore {
+  id: string;
+  slug: string;
+  name: string;
+  description: string | null;
+  owner_id: string;
+  created_at: string;
+}
+
+interface StoresResponse {
+  stores: BackofficeStore[];
+  pagination: { page: number; limit: number; total: number; pages: number };
+}
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+export default function BackofficeStoresPage() {
+  const [query, setQuery] = useState("");
+  const [page, setPage] = useState(1);
+
+  const queryParams = new URLSearchParams();
+  if (query.trim()) queryParams.set("q", query.trim());
+  queryParams.set("page", String(page));
+  queryParams.set("limit", "20");
+
+  const key = `/api/v1/backoffice/stores?${queryParams.toString()}`;
+  const { data, isLoading, error } = useSWR<StoresResponse>(key, fetcher);
+
+  const stores = data?.stores ?? [];
+  const pagination = data?.pagination;
+
+  return (
+    <>
+      <Head>
+        <title>Stores | Manifold Admin</title>
+      </Head>
+
+      <div className="flex flex-col gap-6">
+        <h1 className="text-3xl font-black">Stores</h1>
+
+        <div className="relative max-w-sm">
+          <Search
+            size={14}
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-white/30"
+          />
+          <input
+            type="text"
+            placeholder="Search by name..."
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setPage(1);
+            }}
+            className="w-full rounded-xl border border-white/10 bg-white/5 pl-9 pr-4 py-2 text-sm font-bold text-white placeholder:text-white/30 outline-none focus:bg-white/10 focus:border-white/20"
+          />
+        </div>
+
+        <div className="rounded-2xl border border-white/10 overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-white/5 text-white/50 text-xs uppercase tracking-wider">
+              <tr>
+                <th className="px-4 py-3 text-left">Name</th>
+                <th className="px-4 py-3 text-left">Created</th>
+              </tr>
+            </thead>
+            <tbody>
+              {isLoading ? (
+                <tr>
+                  <td colSpan={2} className="px-4 py-12 text-center">
+                    <Loader2 className="animate-spin inline-block text-white/30" />
+                  </td>
+                </tr>
+              ) : error ? (
+                <tr>
+                  <td
+                    colSpan={2}
+                    className="px-4 py-12 text-center text-rose-300 font-bold"
+                  >
+                    Failed to load stores.
+                  </td>
+                </tr>
+              ) : stores.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={2}
+                    className="px-4 py-12 text-center text-white/40 font-bold"
+                  >
+                    No stores found.
+                  </td>
+                </tr>
+              ) : (
+                stores.map((storeItem) => (
+                  <tr key={storeItem.id} className="border-t border-white/5">
+                    <td className="px-4 py-3 font-bold text-white">
+                      <Link
+                        href={`/backoffice/stores/${storeItem.slug}`}
+                        className="hover:underline"
+                      >
+                        {storeItem.name}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-3 text-white/40">
+                      {new Date(storeItem.created_at).toLocaleDateString()}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {pagination && pagination.pages > 1 && (
+          <div className="flex items-center justify-center gap-3">
+            <button
+              disabled={page <= 1}
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              className="px-3 py-1.5 rounded-lg bg-white/5 border border-white/10 text-sm font-bold text-white/70 disabled:opacity-30"
+            >
+              Previous
+            </button>
+            <span className="text-sm font-bold text-white/50">
+              Page {pagination.page} of {pagination.pages}
+            </span>
+            <button
+              disabled={page >= pagination.pages}
+              onClick={() => setPage((p) => p + 1)}
+              className="px-3 py-1.5 rounded-lg bg-white/5 border border-white/10 text-sm font-bold text-white/70 disabled:opacity-30"
+            >
+              Next
+            </button>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}
+
+BackofficeStoresPage.getLayout = function getLayout(page: React.ReactElement) {
+  return <BackofficeLayout>{page}</BackofficeLayout>;
+};

--- a/pages/backoffice/studios/[slug].tsx
+++ b/pages/backoffice/studios/[slug].tsx
@@ -1,0 +1,180 @@
+import Head from "next/head";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import useSWR from "swr";
+import { ArrowLeft, Loader2 } from "lucide-react";
+import { BackofficeLayout } from "components/backoffice/BackofficeLayout";
+
+interface BackofficeStudio {
+  id: string;
+  slug: string;
+  name: string;
+  description: string | null;
+  is_publisher: boolean;
+  owner_id: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface BackofficeGame {
+  id: string;
+  slug: string;
+  title: string;
+  status: "ACTIVE" | "INACTIVE" | "PRIVATE";
+  created_at: string;
+}
+
+interface StudioDetailResponse {
+  studio: BackofficeStudio;
+  games: BackofficeGame[];
+}
+
+const fetcher = (url: string) =>
+  fetch(url).then(async (res) => {
+    if (!res.ok) throw new Error("Not found");
+    return res.json();
+  });
+
+export default function BackofficeStudioDetailPage() {
+  const router = useRouter();
+  const { slug } = router.query;
+
+  const key = slug ? `/api/v1/backoffice/studios/${slug}` : null;
+  const { data, isLoading, error } = useSWR<StudioDetailResponse>(key, fetcher);
+
+  const studio = data?.studio;
+  const games = data?.games ?? [];
+
+  return (
+    <>
+      <Head>
+        <title>
+          {studio
+            ? `${studio.name} | Manifold Admin`
+            : "Studio | Manifold Admin"}
+        </title>
+      </Head>
+
+      <div className="flex flex-col gap-6 max-w-3xl">
+        <Link
+          href="/backoffice/studios"
+          className="flex items-center gap-2 text-sm font-bold text-white/50 hover:text-white transition-colors w-fit"
+        >
+          <ArrowLeft size={14} />
+          Back to Studios
+        </Link>
+
+        {isLoading ? (
+          <Loader2 className="animate-spin text-white/30" />
+        ) : error || !studio ? (
+          <p className="text-rose-300 font-bold">Studio not found.</p>
+        ) : (
+          <>
+            <div className="rounded-2xl border border-white/10 bg-white/5 p-6 flex flex-col gap-4">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h1 className="text-3xl font-black">{studio.name}</h1>
+                  {studio.description && (
+                    <p className="text-white/50 font-bold mt-1">
+                      {studio.description}
+                    </p>
+                  )}
+                </div>
+                <span
+                  className={`px-3 py-1 rounded-md text-xs font-black uppercase tracking-wider ${
+                    studio.is_publisher
+                      ? "bg-indigo-500/20 text-indigo-300"
+                      : "bg-white/10 text-white/50"
+                  }`}
+                >
+                  {studio.is_publisher ? "Publisher" : "Developer"}
+                </span>
+              </div>
+
+              <div className="grid grid-cols-2 gap-4 text-sm">
+                <div>
+                  <div className="text-white/40 font-bold uppercase text-xs tracking-wider mb-1">
+                    Studio ID
+                  </div>
+                  <div className="text-white/70 font-mono text-xs break-all">
+                    {studio.id}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-white/40 font-bold uppercase text-xs tracking-wider mb-1">
+                    Created
+                  </div>
+                  <div className="text-white/70 font-bold">
+                    {new Date(studio.created_at).toLocaleString()}
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-3">
+              <h2 className="text-xl font-black">Games ({games.length})</h2>
+              <div className="rounded-2xl border border-white/10 overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead className="bg-white/5 text-white/50 text-xs uppercase tracking-wider">
+                    <tr>
+                      <th className="px-4 py-3 text-left">Title</th>
+                      <th className="px-4 py-3 text-left">Status</th>
+                      <th className="px-4 py-3 text-left">Submitted</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {games.length === 0 ? (
+                      <tr>
+                        <td
+                          colSpan={3}
+                          className="px-4 py-8 text-center text-white/40 font-bold"
+                        >
+                          No games yet.
+                        </td>
+                      </tr>
+                    ) : (
+                      games.map((game) => (
+                        <tr key={game.id} className="border-t border-white/5">
+                          <td className="px-4 py-3 font-bold text-white">
+                            <Link
+                              href={`/backoffice/games?q=${encodeURIComponent(game.title)}`}
+                              className="hover:underline"
+                            >
+                              {game.title}
+                            </Link>
+                          </td>
+                          <td className="px-4 py-3">
+                            <span
+                              className={`px-2 py-1 rounded-md text-xs font-black uppercase tracking-wider ${
+                                game.status === "ACTIVE"
+                                  ? "bg-emerald-500/20 text-emerald-300"
+                                  : game.status === "PRIVATE"
+                                    ? "bg-amber-500/20 text-amber-300"
+                                    : "bg-white/10 text-white/50"
+                              }`}
+                            >
+                              {game.status}
+                            </span>
+                          </td>
+                          <td className="px-4 py-3 text-white/40">
+                            {new Date(game.created_at).toLocaleDateString()}
+                          </td>
+                        </tr>
+                      ))
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </>
+  );
+}
+
+BackofficeStudioDetailPage.getLayout = function getLayout(
+  page: React.ReactElement,
+) {
+  return <BackofficeLayout>{page}</BackofficeLayout>;
+};

--- a/pages/backoffice/studios/index.tsx
+++ b/pages/backoffice/studios/index.tsx
@@ -1,0 +1,160 @@
+import { useState } from "react";
+import Head from "next/head";
+import Link from "next/link";
+import useSWR from "swr";
+import { Loader2, Search } from "lucide-react";
+import { BackofficeLayout } from "components/backoffice/BackofficeLayout";
+
+interface BackofficeStudio {
+  id: string;
+  slug: string;
+  name: string;
+  description: string | null;
+  is_publisher: boolean;
+  owner_id: string;
+  created_at: string;
+}
+
+interface StudiosResponse {
+  studios: BackofficeStudio[];
+  pagination: { page: number; limit: number; total: number; pages: number };
+}
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+export default function BackofficeStudiosPage() {
+  const [query, setQuery] = useState("");
+  const [page, setPage] = useState(1);
+
+  const queryParams = new URLSearchParams();
+  if (query.trim()) queryParams.set("q", query.trim());
+  queryParams.set("page", String(page));
+  queryParams.set("limit", "20");
+
+  const key = `/api/v1/backoffice/studios?${queryParams.toString()}`;
+  const { data, isLoading, error } = useSWR<StudiosResponse>(key, fetcher);
+
+  const studios = data?.studios ?? [];
+  const pagination = data?.pagination;
+
+  return (
+    <>
+      <Head>
+        <title>Studios | Manifold Admin</title>
+      </Head>
+
+      <div className="flex flex-col gap-6">
+        <h1 className="text-3xl font-black">Studios</h1>
+
+        <div className="relative max-w-sm">
+          <Search
+            size={14}
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-white/30"
+          />
+          <input
+            type="text"
+            placeholder="Search by name..."
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setPage(1);
+            }}
+            className="w-full rounded-xl border border-white/10 bg-white/5 pl-9 pr-4 py-2 text-sm font-bold text-white placeholder:text-white/30 outline-none focus:bg-white/10 focus:border-white/20"
+          />
+        </div>
+
+        <div className="rounded-2xl border border-white/10 overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-white/5 text-white/50 text-xs uppercase tracking-wider">
+              <tr>
+                <th className="px-4 py-3 text-left">Name</th>
+                <th className="px-4 py-3 text-left">Type</th>
+                <th className="px-4 py-3 text-left">Created</th>
+              </tr>
+            </thead>
+            <tbody>
+              {isLoading ? (
+                <tr>
+                  <td colSpan={3} className="px-4 py-12 text-center">
+                    <Loader2 className="animate-spin inline-block text-white/30" />
+                  </td>
+                </tr>
+              ) : error ? (
+                <tr>
+                  <td
+                    colSpan={3}
+                    className="px-4 py-12 text-center text-rose-300 font-bold"
+                  >
+                    Failed to load studios.
+                  </td>
+                </tr>
+              ) : studios.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={3}
+                    className="px-4 py-12 text-center text-white/40 font-bold"
+                  >
+                    No studios found.
+                  </td>
+                </tr>
+              ) : (
+                studios.map((studioItem) => (
+                  <tr key={studioItem.id} className="border-t border-white/5">
+                    <td className="px-4 py-3 font-bold text-white">
+                      <Link
+                        href={`/backoffice/studios/${studioItem.slug}`}
+                        className="hover:underline"
+                      >
+                        {studioItem.name}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={`px-2 py-1 rounded-md text-xs font-black uppercase tracking-wider ${
+                          studioItem.is_publisher
+                            ? "bg-indigo-500/20 text-indigo-300"
+                            : "bg-white/10 text-white/50"
+                        }`}
+                      >
+                        {studioItem.is_publisher ? "Publisher" : "Developer"}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-white/40">
+                      {new Date(studioItem.created_at).toLocaleDateString()}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {pagination && pagination.pages > 1 && (
+          <div className="flex items-center justify-center gap-3">
+            <button
+              disabled={page <= 1}
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              className="px-3 py-1.5 rounded-lg bg-white/5 border border-white/10 text-sm font-bold text-white/70 disabled:opacity-30"
+            >
+              Previous
+            </button>
+            <span className="text-sm font-bold text-white/50">
+              Page {pagination.page} of {pagination.pages}
+            </span>
+            <button
+              disabled={page >= pagination.pages}
+              onClick={() => setPage((p) => p + 1)}
+              className="px-3 py-1.5 rounded-lg bg-white/5 border border-white/10 text-sm font-bold text-white/70 disabled:opacity-30"
+            >
+              Next
+            </button>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}
+
+BackofficeStudiosPage.getLayout = function getLayout(page: React.ReactElement) {
+  return <BackofficeLayout>{page}</BackofficeLayout>;
+};


### PR DESCRIPTION
## Summary

Closes #127. Twelfth PR in the admin backoffice sequence (see `docs/backoffice-tasks.md`, task 12; depends on task 7/#111 and task 9/#113, both merged). **Not auto-merging** — leaving open for manual review per your instruction.

- `pages/backoffice/studios/index.tsx` + `[slug].tsx`: search/list, detail view showing the studio's games (including `PRIVATE` ones the public studio page wouldn't show — reuses `GET /api/v1/backoffice/studios/[slug]`'s combined studio+games payload from task 7). Each game row links to `/backoffice/games?q=<title>` for a quick jump into the review queue.
- `pages/backoffice/stores/index.tsx` + `[slug].tsx`: search/list, read-only detail.
- No mutating actions on either — matches the read-only backend from task 7 and the project's broader no-hard-delete-in-Phase-1 stance.

## Test plan

- [x] `eslint` / `prettier --check` on the whole repo — clean.
- [x] No backend/model changes, so no new integration tests.
- [x] **Manually verified in a real headless-Chromium browser** end-to-end against the actual running app + local Postgres, with a seeded studio (publisher, one `ACTIVE` game) and store:
  - Studios list → correct name/type/created columns, existing seed-data studios also render correctly alongside the test one.
  - Studio detail → shows the studio's game with its real status (`ACTIVE`), confirming the `studio_id` filter and games payload wiring.
  - Stores list → detail navigation works.
  - Store detail → correct fields.
- [x] Full `npm run test` integration suite: no backend changes in this PR, so no new risk there; will confirm CI's "Jest Ubuntu" check stays green on this PR, same as every prior one.


---
_Generated by [Claude Code](https://claude.ai/code/session_012vLvvWicRpfBfWwt1ZBVwy)_