### PR TITLE
feat: studio logo_url field + owner-scoped studio listing

### DIFF
--- a/models/authorization.ts
+++ b/models/authorization.ts
@@ -530,6 +530,7 @@ function filterOutput(user: Partial<User>, feature: string, resource: unknown) {
       slug: studioOutput.slug,
       name: studioOutput.name,
       description: studioOutput.description,
+      logo_url: studioOutput.logo_url,
       is_publisher: studioOutput.is_publisher,
       owner_id: studioOutput.owner_id,
       created_at: studioOutput.created_at,

--- a/models/studio.ts
+++ b/models/studio.ts
@@ -7,6 +7,7 @@ import userModel from "models/user";
 export const studioSchema = z.object({
   name: z.string().min(1).max(255),
   description: z.string().max(1000).optional(),
+  logo_url: z.string().url().max(2048).optional(),
   is_publisher: z.boolean().default(false),
 });
 
@@ -71,6 +72,7 @@ async function create(studioData: StudioCreateDto) {
     data: {
       name: studioData.name,
       description: studioData.description,
+      logo_url: studioData.logo_url,
       is_publisher: studioData.is_publisher,
       owner_id: studioData.owner_id,
       slug,
@@ -82,10 +84,12 @@ async function findAllPaginated({
   page = 1,
   limit = 20,
   q,
+  owner_id,
 }: {
   page?: number;
   limit?: number;
   q?: string;
+  owner_id?: string;
 }) {
   const where: Prisma.StudioWhereInput = {};
 
@@ -94,6 +98,10 @@ async function findAllPaginated({
       { name: { contains: q, mode: "insensitive" } },
       { slug: { contains: q, mode: "insensitive" } },
     ];
+  }
+
+  if (owner_id) {
+    where.owner_id = owner_id;
   }
 
   const [studios, total] = await Promise.all([

--- a/pages/api/v1/studios/index.ts
+++ b/pages/api/v1/studios/index.ts
@@ -7,8 +7,24 @@ import { ValidationError } from "infra/errors";
 
 export default createRouter<NextApiRequest, NextApiResponse>()
   .use(controller.injectAnonymousOrUser)
+  .get(controller.canRequest("create:studio"), getHandler)
   .post(controller.canRequest("create:studio"), postHandler)
   .handler(controller.errorHandlers);
+
+async function getHandler(req: NextApiRequest, res: NextApiResponse) {
+  const { studios, pagination } = await studio.findAllPaginated({
+    owner_id: req.context.user.id,
+  });
+
+  const secureOutputValues = studios.map((studioItem) =>
+    authorization.filterOutput(req.context.user, "create:studio", studioItem),
+  );
+
+  return res.status(200).json({
+    studios: secureOutputValues,
+    pagination,
+  });
+}
 
 async function postHandler(req: NextApiRequest, res: NextApiResponse) {
   const result = studioSchema.safeParse(req.body);

--- a/prisma/migrations/20260722025307_add_studio_logo_url/migration.sql
+++ b/prisma/migrations/20260722025307_add_studio_logo_url/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "studios" ADD COLUMN "logo_url" VARCHAR(2048);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -246,6 +246,7 @@ model Studio {
   name         String   @db.VarChar(255)
   slug         String   @unique @db.VarChar(255)
   description  String?  @db.Text
+  logo_url     String?  @db.VarChar(2048)
   is_publisher Boolean  @default(false)
   owner_id     String // Logical reference to User.id (creator/owner)
   created_at   DateTime @default(now())

--- a/tests/integration/api/v1/studios/[slug]/get.test.ts
+++ b/tests/integration/api/v1/studios/[slug]/get.test.ts
@@ -27,6 +27,7 @@ describe("GET /api/v1/studios/[slug]", () => {
         slug: createdStudio.slug,
         name: createdStudio.name,
         description: createdStudio.description,
+        logo_url: createdStudio.logo_url,
         is_publisher: createdStudio.is_publisher,
         owner_id: owner.id,
         created_at: createdStudio.created_at.toISOString(),

--- a/tests/integration/api/v1/studios/get.test.ts
+++ b/tests/integration/api/v1/studios/get.test.ts
@@ -1,0 +1,70 @@
+import orchestrator from "tests/orchestrator";
+import webserver from "infra/webserver";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+describe("GET /api/v1/studios", () => {
+  describe("Anonymous user", () => {
+    test("Should return 403 Forbidden", async () => {
+      const response = await fetch(`${webserver.getOrigin()}/api/v1/studios`);
+
+      expect(response.status).toBe(403);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        name: "ForbiddenError",
+        message: "You do not have permission to perform this action",
+        action: "Verify your user has the following features: create:studio",
+        status_code: 403,
+      });
+    });
+  });
+
+  describe("Authenticated user", () => {
+    test("Should return only the requesting user's own studios", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const ownerSession = await orchestrator.createSession(owner.id);
+      const ownedStudio = await orchestrator.createStudio(owner.id, {
+        name: "My Owned Studio",
+      });
+
+      const otherUser = await orchestrator.createUser();
+      await orchestrator.activateUser(otherUser.id);
+      await orchestrator.createStudio(otherUser.id, {
+        name: "Someone Elses Studio",
+      });
+
+      const response = await fetch(`${webserver.getOrigin()}/api/v1/studios`, {
+        headers: { Cookie: `session_id=${ownerSession.token}` },
+      });
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+      expect(responseBody.studios).toHaveLength(1);
+      expect(responseBody.studios[0].id).toBe(ownedStudio.id);
+      expect(responseBody.studios[0].name).toBe("My Owned Studio");
+      expect(responseBody.pagination.total).toBe(1);
+    });
+
+    test("With zero studios should return an empty list", async () => {
+      const user = await orchestrator.createUser();
+      await orchestrator.activateUser(user.id);
+      const session = await orchestrator.createSession(user.id);
+
+      const response = await fetch(`${webserver.getOrigin()}/api/v1/studios`, {
+        headers: { Cookie: `session_id=${session.token}` },
+      });
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+      expect(responseBody.studios).toEqual([]);
+      expect(responseBody.pagination.total).toBe(0);
+    });
+  });
+});

--- a/tests/integration/api/v1/studios/post.test.ts
+++ b/tests/integration/api/v1/studios/post.test.ts
@@ -54,11 +54,35 @@ describe("POST /api/v1/studios", () => {
         slug: "pixel-forge-studio",
         name: "Pixel Forge Studio",
         description: "Indie game developer",
+        logo_url: null,
         is_publisher: true,
         owner_id: user.id,
         created_at: responseBody.created_at,
         updated_at: responseBody.updated_at,
       });
+    });
+
+    test("With a logo_url should persist and return it", async () => {
+      const user = await orchestrator.createUser();
+      await orchestrator.activateUser(user.id);
+      const session = await orchestrator.createSession(user.id);
+
+      const response = await fetch(`${webserver.getOrigin()}/api/v1/studios`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: `session_id=${session.token}`,
+        },
+        body: JSON.stringify({
+          name: "Logo Studio",
+          logo_url: "https://example.com/logo.png",
+        }),
+      });
+
+      expect(response.status).toBe(201);
+
+      const responseBody = await response.json();
+      expect(responseBody.logo_url).toBe("https://example.com/logo.png");
     });
 
     test("With is_publisher omitted should default to false", async () => {


### PR DESCRIPTION
## Summary

Closes #134. Backend half of the slim studio-creation onboarding flow — the frontend (#135) depends on this merging first.

- `prisma/schema.prisma` + migration: new nullable `logo_url` column on `Studio`.
- `models/studio.ts`: `logo_url` added to `studioSchema`; explicitly added to `create()`'s `prisma.studio.create()` call (this function lists fields explicitly rather than spreading, unlike `update()` which already spreads `...validatedData` and needed no change); `findAllPaginated()` gains an optional `owner_id` filter.
- `models/authorization.ts`: `logo_url` added to the shared studio `filterOutput` branch (covers `create:studio`/`read:public_studio`/`update:studio`/`read:studio:any` in one block).
- `pages/api/v1/studios/index.ts`: new `GET` handler, scoped to `owner_id: req.context.user.id`, gated on `create:studio`. There was previously no way to fetch "studios I own" at all (`findAllPaginated` only supported text search). Deliberately **not** gated on the anonymous-accessible `read:public_studio` — this is an authenticated-only "list my studios" concern, and gating it that way while scoping by `req.context.user.id` would break/leak for logged-out requests.

Store creation is intentionally out of scope here (and for the whole onboarding initiative) — the `Store` entity has no public frontend surface anywhere in the app today (no storefront page, no directory), so pushing new users through a form to create one would be a dead end with no way to verify it worked. It stays API-only.

## Test plan

- [x] `eslint` / `prettier --check` on the whole repo — clean.
- [x] New `tests/integration/api/v1/studios/get.test.ts`: anonymous → 403, only-own-studios scoping, empty list for a fresh user.
- [x] Updated two existing tests (`studios/post.test.ts`, `studios/[slug]/get.test.ts`) whose exact-payload `toEqual` assertions would otherwise break now that `logo_url` is in the output — same regression class caught in the previous Steam-import PR.
- [x] Targeted regression run: `tests/integration/api/v1/studios` (32/32 passing), `tests/integration/api/v1/backoffice/studios` + `tests/integration/api/v1/items/games` + `tests/unit/models/authorization.test.ts` (50/52 passing — the only 2 failures are the pre-existing, sandbox-network-blocked Steam-import tests from the prior PR, unrelated to this change).
- [ ] Full `npm run test` integration suite: this sandbox's Docker daemon isn't reachable after a container restart (no MinIO/mailcatcher SMTP services running), so ~13 unrelated suites (email sending, file upload/download, purchase flows) fail here on infrastructure grounds rather than code. Will confirm via CI's "Jest Ubuntu" check, which runs with real Docker services.

---
_Generated by [Claude Code](https://claude.ai/code/session_012vLvvWicRpfBfWwt1ZBVwy)_