### PR TITLE
feat: guided studio-creation onboarding flow

### DIFF
--- a/components/store/UserMenu.tsx
+++ b/components/store/UserMenu.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import useSWR from "swr";
-import { User, LogOut, Library, Loader2 } from "lucide-react";
+import { User, LogOut, Library, Building2, Loader2 } from "lucide-react";
 import { useState, useRef, useEffect } from "react";
 import { useRouter } from "next/router";
 
@@ -93,6 +93,15 @@ export function UserMenu() {
             >
               <Library size={16} className="text-indigo-400" />
               My Library
+            </Link>
+
+            <Link
+              href="/studio"
+              onClick={() => setIsOpen(false)}
+              className="flex items-center gap-3 px-4 py-2.5 text-sm font-bold text-white/80 hover:text-white hover:bg-white/5 transition-colors"
+            >
+              <Building2 size={16} className="text-indigo-400" />
+              My Studios
             </Link>
 
             <button

--- a/pages/onboarding/create.tsx
+++ b/pages/onboarding/create.tsx
@@ -1,0 +1,162 @@
+import { useState } from "react";
+import { useRouter } from "next/router";
+import Head from "next/head";
+import useSWR from "swr";
+import { Loader2 } from "lucide-react";
+
+interface CurrentUser {
+  id: string;
+  username: string;
+}
+
+const userFetcher = (url: string) =>
+  fetch(url).then(async (res) => {
+    if (!res.ok) throw new Error("Not logged in");
+    return res.json();
+  });
+
+export default function OnboardingCreatePage() {
+  const router = useRouter();
+
+  const { error: userError, isLoading: isUserLoading } = useSWR<CurrentUser>(
+    "/api/v1/user",
+    userFetcher,
+    { shouldRetryOnError: false },
+  );
+
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [logoUrl, setLogoUrl] = useState("");
+  const [isPublisher, setIsPublisher] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const isLoggedOut = !!userError;
+
+  if (!isUserLoading && isLoggedOut) {
+    router.replace(`/login?callbackUrl=${encodeURIComponent(router.asPath)}`);
+  }
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    setFormError(null);
+
+    setIsSubmitting(true);
+    try {
+      const response = await fetch("/api/v1/studios", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name,
+          description: description.trim() || undefined,
+          logo_url: logoUrl.trim() || undefined,
+          is_publisher: isPublisher,
+        }),
+      });
+
+      const body = await response.json().catch(() => null);
+
+      if (!response.ok) {
+        setFormError(body?.message || "Failed to create studio.");
+        return;
+      }
+
+      router.push(`/studio/${body.slug}`);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Create Your Studio | Manifold</title>
+      </Head>
+
+      <div className="min-h-screen bg-[#1D0F3B] text-white flex items-center justify-center px-4">
+        <div className="w-full max-w-md flex flex-col gap-6">
+          <div>
+            <h1 className="text-2xl font-black">Create Your Studio</h1>
+            <p className="text-white/50 text-sm font-bold mt-1">
+              A studio is how you publish games on Manifold.
+            </p>
+          </div>
+
+          {isUserLoading ? (
+            <Loader2 className="animate-spin text-white/30" />
+          ) : (
+            <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+              <label className="flex flex-col gap-2">
+                <span className="text-xs font-black uppercase tracking-wider text-white/40">
+                  Studio name
+                </span>
+                <input
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="Hibernian Workshop"
+                  className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-bold text-white placeholder:text-white/30 outline-none focus:bg-white/10 focus:border-white/20"
+                />
+              </label>
+
+              <label className="flex flex-col gap-2">
+                <span className="text-xs font-black uppercase tracking-wider text-white/40">
+                  Description (optional)
+                </span>
+                <textarea
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  rows={3}
+                  placeholder="Tell players what your studio makes."
+                  className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-bold text-white placeholder:text-white/30 outline-none focus:bg-white/10 focus:border-white/20 resize-none"
+                />
+              </label>
+
+              <label className="flex flex-col gap-2">
+                <span className="text-xs font-black uppercase tracking-wider text-white/40">
+                  Logo URL (optional)
+                </span>
+                <input
+                  type="text"
+                  value={logoUrl}
+                  onChange={(e) => setLogoUrl(e.target.value)}
+                  placeholder="https://example.com/logo.png"
+                  className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-bold text-white placeholder:text-white/30 outline-none focus:bg-white/10 focus:border-white/20"
+                />
+              </label>
+
+              <label className="flex items-start gap-3">
+                <input
+                  type="checkbox"
+                  checked={isPublisher}
+                  onChange={(e) => setIsPublisher(e.target.checked)}
+                  className="mt-1"
+                />
+                <span className="text-sm font-bold text-white/70">
+                  This studio also publishes other studios&apos; games
+                  <span className="block text-xs font-normal text-white/40 mt-0.5">
+                    You can change this later.
+                  </span>
+                </span>
+              </label>
+
+              {formError && (
+                <div className="px-4 py-3 rounded-xl bg-rose-500/10 border border-rose-500/30 text-rose-300 text-sm font-bold">
+                  {formError}
+                </div>
+              )}
+
+              <button
+                type="submit"
+                disabled={isSubmitting || !name.trim()}
+                className="px-4 py-3 rounded-xl bg-emerald-500 text-black font-black text-sm uppercase tracking-wider hover:bg-emerald-400 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                {isSubmitting ? "Creating..." : "Create Studio"}
+              </button>
+            </form>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/pages/signup/activate/[activation_token].tsx
+++ b/pages/signup/activate/[activation_token].tsx
@@ -77,12 +77,20 @@ export default function ActivateSignup() {
             Welcome to Manifold. We will notify you as soon as the early access
             begins.
           </p>
-          <Link
-            href="/"
-            className="mt-8 inline-flex items-center justify-center rounded-lg bg-[var(--color-purple-dark)] px-6 py-3 font-bold text-[var(--bg-primary)] transition-colors hover:bg-black"
-          >
-            Back to Manifold
-          </Link>
+          <div className="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
+            <Link
+              href="/login?callbackUrl=/store"
+              className="flex-1 inline-flex items-center justify-center rounded-lg border-2 border-[var(--color-purple-dark)] px-6 py-3 font-bold text-[var(--color-purple-dark)] transition-colors hover:bg-[var(--color-purple-dark)] hover:text-[var(--bg-primary)]"
+            >
+              I want to play
+            </Link>
+            <Link
+              href="/login?callbackUrl=/onboarding/create"
+              className="flex-1 inline-flex items-center justify-center rounded-lg bg-[var(--color-purple-dark)] px-6 py-3 font-bold text-[var(--bg-primary)] transition-colors hover:bg-black"
+            >
+              I want to publish games
+            </Link>
+          </div>
         </>
       ) : null}
 

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -79,8 +79,8 @@ export default function SignupPage() {
         <div className="modal-success" role="status">
           <h2 id="early-access-title">Check your inbox</h2>
           <p>{successMessage}</p>
-          <Link href="/" className="submit-button back-link">
-            Got it
+          <Link href="/store" className="submit-button back-link">
+            Browse games while you wait
           </Link>
         </div>
       ) : (

--- a/pages/studio/[slug]/index.tsx
+++ b/pages/studio/[slug]/index.tsx
@@ -1,0 +1,84 @@
+import Head from "next/head";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import useSWR from "swr";
+import { Loader2, Building2 } from "lucide-react";
+
+interface Studio {
+  id: string;
+  slug: string;
+  name: string;
+  description: string | null;
+  logo_url: string | null;
+  is_publisher: boolean;
+}
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+export default function StudioPage() {
+  const router = useRouter();
+  const slug = router.query.slug as string | undefined;
+
+  const {
+    data: studio,
+    isLoading,
+    error,
+  } = useSWR<Studio>(slug ? `/api/v1/studios/${slug}` : null, fetcher);
+
+  return (
+    <>
+      <Head>
+        <title>
+          {studio ? `${studio.name} | Manifold` : "Studio | Manifold"}
+        </title>
+      </Head>
+
+      <div className="min-h-screen bg-[#1D0F3B] text-white flex items-center justify-center px-4">
+        {isLoading ? (
+          <Loader2 className="animate-spin text-white/30" />
+        ) : error || !studio ? (
+          <p className="text-rose-300 font-bold">Studio not found.</p>
+        ) : (
+          <div className="w-full max-w-md flex flex-col gap-6">
+            <div className="flex items-center gap-4">
+              {studio.logo_url ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={studio.logo_url}
+                  alt={`${studio.name} logo`}
+                  className="w-16 h-16 rounded-2xl object-cover border border-white/10 bg-white/5"
+                />
+              ) : (
+                <div className="w-16 h-16 rounded-2xl flex items-center justify-center border border-white/10 bg-white/5 text-white/30">
+                  <Building2 size={28} />
+                </div>
+              )}
+
+              <div>
+                <h1 className="text-2xl font-black">{studio.name}</h1>
+                {studio.is_publisher && (
+                  <span className="inline-block mt-1 px-2 py-0.5 rounded-lg bg-white/10 text-white/60 text-xs font-black uppercase tracking-wider">
+                    Publisher
+                  </span>
+                )}
+              </div>
+            </div>
+
+            {studio.description && (
+              <p className="text-white/70 text-sm leading-relaxed">
+                {studio.description}
+              </p>
+            )}
+
+            <Link
+              href={`/studio/${studio.slug}/games/steam-import`}
+              className="px-4 py-3 rounded-xl bg-emerald-500 text-black font-black text-sm uppercase tracking-wider text-center hover:bg-emerald-400 transition-colors"
+            >
+              Import a Game from Steam
+            </Link>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/pages/studio/index.tsx
+++ b/pages/studio/index.tsx
@@ -1,0 +1,78 @@
+import Head from "next/head";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import useSWR from "swr";
+import { useEffect } from "react";
+import { Loader2 } from "lucide-react";
+
+interface Studio {
+  id: string;
+  slug: string;
+  name: string;
+}
+
+interface StudiosResponse {
+  studios: Studio[];
+}
+
+const fetcher = (url: string) =>
+  fetch(url).then(async (res) => {
+    if (!res.ok) throw new Error("Not logged in");
+    return res.json();
+  });
+
+export default function MyStudiosPage() {
+  const router = useRouter();
+
+  const { data, isLoading, error } = useSWR<StudiosResponse>(
+    "/api/v1/studios",
+    fetcher,
+    { shouldRetryOnError: false },
+  );
+
+  useEffect(() => {
+    if (isLoading) return;
+
+    if (error) {
+      router.replace(`/login?callbackUrl=${encodeURIComponent(router.asPath)}`);
+      return;
+    }
+
+    const studios = data?.studios ?? [];
+
+    if (studios.length === 0) {
+      router.replace("/onboarding/create");
+    } else if (studios.length === 1) {
+      router.replace(`/studio/${studios[0].slug}`);
+    }
+  }, [isLoading, error, data, router]);
+
+  const studios = data?.studios ?? [];
+
+  return (
+    <>
+      <Head>
+        <title>My Studios | Manifold</title>
+      </Head>
+
+      <div className="min-h-screen bg-[#1D0F3B] text-white flex items-center justify-center px-4">
+        {isLoading || (!error && studios.length <= 1) ? (
+          <Loader2 className="animate-spin text-white/30" />
+        ) : (
+          <div className="w-full max-w-md flex flex-col gap-4">
+            <h1 className="text-2xl font-black">My Studios</h1>
+            {studios.map((studio) => (
+              <Link
+                key={studio.id}
+                href={`/studio/${studio.slug}`}
+                className="px-4 py-3 rounded-xl border border-white/10 bg-white/5 font-bold text-white hover:bg-white/10 transition-colors"
+              >
+                {studio.name}
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #135. Frontend half of the slim studio-creation onboarding flow. #136 (backend) has merged, so this is now rebased onto `main` — a clean, self-contained diff.

Manifold's signup → activation → login flow works end-to-end, but both signup and activation success screens dead-end into a marketing redirect (`/` → `/about`), with no path into actually using the product. Studio creation existed only as a backend API with zero frontend entry point anywhere.

- `pages/signup/index.tsx`: success screen's link now goes to `/store` instead of `/`.
- `pages/signup/activate/[activation_token].tsx`: success state gets a soft, non-forced fork — "I want to play" (`/login?callbackUrl=/store`) and "I want to publish games" (`/login?callbackUrl=/onboarding/create`) — reusing the existing `?callbackUrl=` login-redirect pattern already used in 4+ places. No role field, nothing recorded; a user who ignores both loses nothing.
- `pages/onboarding/create.tsx` (new): slim studio-creation form (name, description, logo URL, is_publisher checkbox with plain-language copy). Posts to `POST /api/v1/studios`, redirects to `/studio/[slug]` on success.
- `pages/studio/[slug]/index.tsx` (new): minimal, public, read-only studio landing page — logo/placeholder, name, publisher badge, description, and a CTA into the existing Steam-import page. This is load-bearing: without it, a successful studio creation would 404, since no studio page existed anywhere before this.
- `pages/studio/index.tsx` (new): "My Studios" smart-redirect (not a listing page) — 0 studios → creation form, 1 studio → straight to it, 2+ → a bare link list.
- `components/store/UserMenu.tsx`: adds a "My Studios" link to the header dropdown, between "My Library" and "Sign Out".

Store creation stays out of this flow entirely — see #136 for why (no public storefront surface exists anywhere in the app today).

## Test plan

- [x] `eslint` / `prettier --check` on the whole repo — clean.
- [x] No backend/model changes beyond what #136 already covers, so no new automated tests (matches this app's established UI-only-PR pattern).
- [x] **Manually verified end-to-end in a real headless-Chromium browser** against the running app + local Postgres: seeded an activated user, confirmed the header's "My Studios" link with zero studios redirects to `/onboarding/create`; submitted the creation form (name + description + logo URL); confirmed it landed on `/studio/[slug]` showing the new studio with no 404; confirmed the "Import a Game from Steam" CTA correctly links into the existing Steam-import page; confirmed "My Studios" now redirects straight to the one existing studio instead of the create form. Also seeded a real activation token and loaded `/signup/activate/[token]` directly to confirm both fork cards render with the correct `?callbackUrl=` targets (`/store` and `/onboarding/create`). Screenshots taken during verification, seed data cleaned up afterward.
- [x] Rebased onto `main` after #136 merged; targeted `tests/integration/api/v1/studios` suite (32/32) confirmed no regressions.
- [ ] Full `npm run test` integration suite: this sandbox's Docker daemon isn't reachable after a container restart (no MinIO/mailcatcher SMTP services), so some unrelated suites (email, file storage) fail here on infrastructure grounds. Will confirm via CI's "Jest Ubuntu" check, which runs with real Docker services (already confirmed working for #136).

---
_Generated by [Claude Code](https://claude.ai/code/session_012vLvvWicRpfBfWwt1ZBVwy)_