### PR TITLE
feat: sale tracking foundation

### DIFF
--- a/models/library.ts
+++ b/models/library.ts
@@ -1,5 +1,68 @@
 import { prisma } from "infra/database";
 import { ItemType } from "generated/prisma/client";
+import { NotFoundError } from "infra/errors";
+import game from "models/game";
+import store from "models/store";
+
+async function acquireGame(
+  userId: string,
+  gameSlug: string,
+  storeSlug?: string,
+) {
+  const existingGame = await game.findOneBySlug(gameSlug);
+  if (!existingGame) {
+    throw new NotFoundError({
+      message: "Game not found",
+      action: "Verify the game exists",
+    });
+  }
+
+  const storeId = await resolveStoreIdLeniently(storeSlug);
+
+  return await prisma.$transaction(async (tx) => {
+    const libraryItem = await tx.libraryItem.upsert({
+      where: {
+        user_id_item_id_item_type: {
+          user_id: userId,
+          item_id: existingGame.id,
+          item_type: "GAME",
+        },
+      },
+      update: {},
+      create: {
+        user_id: userId,
+        item_id: existingGame.id,
+        item_type: "GAME",
+      },
+    });
+
+    await tx.sale.create({
+      data: {
+        user_id: userId,
+        game_id: existingGame.id,
+        store_id: storeId,
+        price_at_sale: existingGame.price,
+      },
+    });
+
+    return libraryItem;
+  });
+}
+
+// Resolve store_slug leniently: an absent or unknown store must never block
+// acquisition — it just means the sale isn't attributed to a store.
+async function resolveStoreIdLeniently(
+  storeSlug?: string,
+): Promise<string | null> {
+  if (!storeSlug) return null;
+
+  try {
+    const foundStore = await store.findOneBySlug(storeSlug);
+    return foundStore.id;
+  } catch {
+    return null;
+  }
+}
 
 async function add(
   userId: string,
@@ -102,6 +165,7 @@ const library = {
   add,
   hasItem,
   findAllPaginatedGamesByUserId,
+  acquireGame,
 };
 
 export default library;

--- a/models/sale.ts
+++ b/models/sale.ts
@@ -1,0 +1,59 @@
+import { prisma } from "infra/database";
+
+interface RecordSaleDto {
+  user_id: string;
+  game_id: string;
+  store_id: string | null;
+  price_at_sale: string;
+}
+
+async function record(saleDto: RecordSaleDto) {
+  return await prisma.sale.create({
+    data: {
+      user_id: saleDto.user_id,
+      game_id: saleDto.game_id,
+      store_id: saleDto.store_id,
+      price_at_sale: saleDto.price_at_sale,
+    },
+  });
+}
+
+async function listByStore(
+  storeId: string,
+  {
+    page = 1,
+    limit = 20,
+  }: {
+    page?: number;
+    limit?: number;
+  } = {},
+) {
+  const where = { store_id: storeId };
+
+  const [sales, total] = await Promise.all([
+    prisma.sale.findMany({
+      where,
+      orderBy: { created_at: "desc" },
+      skip: (page - 1) * limit,
+      take: limit,
+    }),
+    prisma.sale.count({ where }),
+  ]);
+
+  return {
+    sales,
+    pagination: {
+      page,
+      limit,
+      total,
+      pages: Math.ceil(total / limit),
+    },
+  };
+}
+
+const sale = {
+  record,
+  listByStore,
+};
+
+export default sale;

--- a/pages/api/v1/library/index.ts
+++ b/pages/api/v1/library/index.ts
@@ -6,6 +6,8 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 import { NotFoundError, ValidationError } from "infra/errors";
 import game from "models/game";
+import store from "models/store";
+import { prisma } from "infra/database";
 
 const querySchema = z.object({
   page: z.coerce.number().min(1).default(1),
@@ -49,6 +51,7 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
 
 const postBodySchema = z.object({
   slug: z.string().min(1).max(255),
+  store_slug: z.string().min(1).max(255).optional(),
 });
 
 async function postHandler(req: NextApiRequest, res: NextApiResponse) {
@@ -71,11 +74,48 @@ async function postHandler(req: NextApiRequest, res: NextApiResponse) {
     });
   }
 
-  const result = await library.add(
-    req.context.user.id!,
-    existingGame.id,
-    "GAME",
-  );
+  // Resolve store_slug leniently: an absent or unknown store must never
+  // block acquisition — it just means the sale isn't attributed to a store.
+  let storeId: string | null = null;
+  if (parsedBody.data.store_slug) {
+    try {
+      const foundStore = await store.findOneBySlug(parsedBody.data.store_slug);
+      storeId = foundStore.id;
+    } catch {
+      storeId = null;
+    }
+  }
+
+  const userId = req.context.user.id!;
+
+  const result = await prisma.$transaction(async (tx) => {
+    const libraryItem = await tx.libraryItem.upsert({
+      where: {
+        user_id_item_id_item_type: {
+          user_id: userId,
+          item_id: existingGame.id,
+          item_type: "GAME",
+        },
+      },
+      update: {},
+      create: {
+        user_id: userId,
+        item_id: existingGame.id,
+        item_type: "GAME",
+      },
+    });
+
+    await tx.sale.create({
+      data: {
+        user_id: userId,
+        game_id: existingGame.id,
+        store_id: storeId,
+        price_at_sale: existingGame.price,
+      },
+    });
+
+    return libraryItem;
+  });
 
   return res.status(201).json({
     id: result.id,

--- a/pages/api/v1/library/index.ts
+++ b/pages/api/v1/library/index.ts
@@ -4,10 +4,7 @@ import library from "models/library";
 import authorization from "models/authorization";
 import { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
-import { NotFoundError, ValidationError } from "infra/errors";
-import game from "models/game";
-import store from "models/store";
-import { prisma } from "infra/database";
+import { ValidationError } from "infra/errors";
 
 const querySchema = z.object({
   page: z.coerce.number().min(1).default(1),
@@ -66,56 +63,11 @@ async function postHandler(req: NextApiRequest, res: NextApiResponse) {
     });
   }
 
-  const existingGame = await game.findOneBySlug(parsedBody.data.slug);
-  if (!existingGame) {
-    throw new NotFoundError({
-      message: "Game not found",
-      action: "Verify the game exists",
-    });
-  }
-
-  // Resolve store_slug leniently: an absent or unknown store must never
-  // block acquisition — it just means the sale isn't attributed to a store.
-  let storeId: string | null = null;
-  if (parsedBody.data.store_slug) {
-    try {
-      const foundStore = await store.findOneBySlug(parsedBody.data.store_slug);
-      storeId = foundStore.id;
-    } catch {
-      storeId = null;
-    }
-  }
-
-  const userId = req.context.user.id!;
-
-  const result = await prisma.$transaction(async (tx) => {
-    const libraryItem = await tx.libraryItem.upsert({
-      where: {
-        user_id_item_id_item_type: {
-          user_id: userId,
-          item_id: existingGame.id,
-          item_type: "GAME",
-        },
-      },
-      update: {},
-      create: {
-        user_id: userId,
-        item_id: existingGame.id,
-        item_type: "GAME",
-      },
-    });
-
-    await tx.sale.create({
-      data: {
-        user_id: userId,
-        game_id: existingGame.id,
-        store_id: storeId,
-        price_at_sale: existingGame.price,
-      },
-    });
-
-    return libraryItem;
-  });
+  const result = await library.acquireGame(
+    req.context.user.id!,
+    parsedBody.data.slug,
+    parsedBody.data.store_slug,
+  );
 
   return res.status(201).json({
     id: result.id,

--- a/prisma/migrations/20260722102850_create_sales/migration.sql
+++ b/prisma/migrations/20260722102850_create_sales/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "sales" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "game_id" TEXT NOT NULL,
+    "store_id" TEXT,
+    "price_at_sale" VARCHAR(20) NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "sales_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "sales_store_id_created_at_idx" ON "sales"("store_id", "created_at");
+
+-- CreateIndex
+CREATE INDEX "sales_user_id_idx" ON "sales"("user_id");
+
+-- CreateIndex
+CREATE INDEX "sales_game_id_idx" ON "sales"("game_id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -213,6 +213,27 @@ model LibraryItem {
   @@map("library_items")
 }
 
+// Append-only record of each acquisition event, separate from LibraryItem
+// (which is an idempotent entitlement — a no-op on re-acquire). A Sale is
+// written on every acquisition, letting the same user acquire the same game
+// through multiple stores over time without losing any of those events.
+// store_id is nullable: null means the acquisition happened through the
+// global storefront (no store attribution), not through a specific store.
+model Sale {
+  id            String   @id @default(uuid())
+  user_id       String // Logical reference to User.id (who acquired)
+  game_id       String // Logical reference to Game.id (what was acquired)
+  store_id      String? // Logical reference to Store.id; null = platform/global acquisition
+  price_at_sale String   @db.VarChar(20) // Snapshot of Game.price at acquisition time
+  // No updated_at: sale records are append-only and never modified.
+  created_at    DateTime @default(now())
+
+  @@index([store_id, created_at])
+  @@index([user_id])
+  @@index([game_id])
+  @@map("sales")
+}
+
 model Store {
   id          String   @id @default(uuid())
   name        String   @db.VarChar(255)

--- a/tests/integration/api/v1/library/post.test.ts
+++ b/tests/integration/api/v1/library/post.test.ts
@@ -1,6 +1,7 @@
 import orchestrator from "tests/orchestrator";
 import webserver from "infra/webserver";
 import { version as uuidVersion } from "uuid";
+import { prisma } from "infra/database";
 
 beforeAll(async () => {
   await orchestrator.waitForAllServices();
@@ -120,6 +121,135 @@ describe("POST /api/v1/library", () => {
       expect(uuidVersion(responseBody.user_id)).toBe(4);
 
       expect(Date.parse(responseBody.acquired_at)).not.toBeNaN();
+    });
+
+    test("Without store_slug should record a Sale with a null store_id", async () => {
+      const creator = await orchestrator.createUser();
+      await orchestrator.activateUser(creator.id);
+      const game = await orchestrator.createGame(creator.id);
+
+      const buyer = await orchestrator.createUser();
+      await orchestrator.activateUser(buyer.id);
+      const buyerSession = await orchestrator.createSession(buyer.id);
+
+      const response = await fetch(`${webserver.getOrigin()}/api/v1/library`, {
+        method: "POST",
+        headers: {
+          Cookie: `session_id=${buyerSession.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          slug: game.slug,
+        }),
+      });
+
+      expect(response.status).toBe(201);
+
+      const sales = await prisma.sale.findMany({
+        where: { user_id: buyer.id, game_id: game.id },
+      });
+      expect(sales).toHaveLength(1);
+      expect(sales[0].store_id).toBeNull();
+      expect(sales[0].price_at_sale).toBe(game.price);
+    });
+
+    test("With a valid store_slug should record a Sale attributed to that store", async () => {
+      const creator = await orchestrator.createUser();
+      await orchestrator.activateUser(creator.id);
+      const game = await orchestrator.createGame(creator.id);
+
+      const storeOwner = await orchestrator.createUser();
+      await orchestrator.activateUser(storeOwner.id);
+      const createdStore = await orchestrator.createStore(storeOwner.id);
+
+      const buyer = await orchestrator.createUser();
+      await orchestrator.activateUser(buyer.id);
+      const buyerSession = await orchestrator.createSession(buyer.id);
+
+      const response = await fetch(`${webserver.getOrigin()}/api/v1/library`, {
+        method: "POST",
+        headers: {
+          Cookie: `session_id=${buyerSession.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          slug: game.slug,
+          store_slug: createdStore.slug,
+        }),
+      });
+
+      expect(response.status).toBe(201);
+
+      const sales = await prisma.sale.findMany({
+        where: { user_id: buyer.id, game_id: game.id },
+      });
+      expect(sales).toHaveLength(1);
+      expect(sales[0].store_id).toBe(createdStore.id);
+    });
+
+    test("With an unknown store_slug should still return 201 and record a Sale with a null store_id", async () => {
+      const creator = await orchestrator.createUser();
+      await orchestrator.activateUser(creator.id);
+      const game = await orchestrator.createGame(creator.id);
+
+      const buyer = await orchestrator.createUser();
+      await orchestrator.activateUser(buyer.id);
+      const buyerSession = await orchestrator.createSession(buyer.id);
+
+      const response = await fetch(`${webserver.getOrigin()}/api/v1/library`, {
+        method: "POST",
+        headers: {
+          Cookie: `session_id=${buyerSession.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          slug: game.slug,
+          store_slug: "does-not-exist-store",
+        }),
+      });
+
+      expect(response.status).toBe(201);
+
+      const sales = await prisma.sale.findMany({
+        where: { user_id: buyer.id, game_id: game.id },
+      });
+      expect(sales).toHaveLength(1);
+      expect(sales[0].store_id).toBeNull();
+    });
+
+    test("Re-acquiring an owned game should record a new Sale each time while LibraryItem stays a single row", async () => {
+      const creator = await orchestrator.createUser();
+      await orchestrator.activateUser(creator.id);
+      const game = await orchestrator.createGame(creator.id);
+
+      const buyer = await orchestrator.createUser();
+      await orchestrator.activateUser(buyer.id);
+      const buyerSession = await orchestrator.createSession(buyer.id);
+
+      for (let i = 0; i < 2; i++) {
+        const response = await fetch(
+          `${webserver.getOrigin()}/api/v1/library`,
+          {
+            method: "POST",
+            headers: {
+              Cookie: `session_id=${buyerSession.token}`,
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ slug: game.slug }),
+          },
+        );
+        expect(response.status).toBe(201);
+      }
+
+      const sales = await prisma.sale.findMany({
+        where: { user_id: buyer.id, game_id: game.id },
+      });
+      expect(sales).toHaveLength(2);
+
+      const libraryItems = await prisma.libraryItem.findMany({
+        where: { user_id: buyer.id, item_id: game.id, item_type: "GAME" },
+      });
+      expect(libraryItems).toHaveLength(1);
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes #138. First of 5 PRs building the store-owner feature. Backend-only, isolated first since it touches the single acquisition path for the entire platform.

Every game acquisition now records an append-only `Sale` event (`user_id, game_id, store_id?, price_at_sale, created_at`), separate from the existing `LibraryItem` entitlement row (which is an idempotent upsert — a no-op on re-acquire, so it can't represent repeat sale events). This is the foundation store owners will need to see per-store revenue and, later, a selling dashboard.

- `prisma/schema.prisma` + migration: new `Sale` model, `store_id` nullable (`null` = acquired via the global storefront, no store attribution — no sentinel "platform store" row).
- `models/sale.ts` (new): `record(...)` (append-only `create`, never upsert), `listByStore(...)` for a later PR's sales-list route.
- `pages/api/v1/library/index.ts`: `POST` body gains optional `store_slug`. It resolves **leniently** — absent or unknown slug → `store_id: null`, and it must never throw, so a bad value can never block a purchase. The `Sale` write and the existing `library.add()` upsert run inside one transaction, so a sale is never recorded without the entitlement.

## Test plan

- [x] `eslint` / `prettier --check` on the whole repo — clean.
- [x] Added integration tests to `tests/integration/api/v1/library/post.test.ts`: acquiring without `store_slug` records a `Sale` with `store_id: null`; with a valid `store_slug` records the resolved `store_id`; with an unknown `store_slug` still returns `201` with `store_id: null` (never a 4xx/5xx from a bad slug); re-acquiring an already-owned game writes a new `Sale` each time while `LibraryItem` stays a single row.
- [x] Manually verified the exact same scenarios end-to-end against the running app + real Postgres via a direct script (this sandbox's Docker daemon isn't reachable, so `tests/integration/api/v1/library/post.test.ts`'s `beforeAll` — which needs MinIO for `clearStorage()`, pre-existing, unrelated to this change — can't run to completion here). All four scenarios confirmed correct: 3 sequential POSTs (no store / valid store / unknown store) produced exactly 3 `Sale` rows with `store_id` `[null, <resolved id>, null]`, `price_at_sale` matching the game's price, and exactly 1 `LibraryItem` row (idempotent).
- [x] Regression check: `tests/integration/api/v1/library/get.test.ts`, `stores/*`, `studios/*`, `items/games/*`, and the authorization unit tests — 148/150 passing; the only 2 failures are the pre-existing, sandbox-network-blocked Steam-import tests (unrelated to this PR).
- [ ] Full `npm run test` integration suite: will confirm via CI's "Jest Ubuntu" check, which has real Docker services.

---
_Generated by [Claude Code](https://claude.ai/code/session_012vLvvWicRpfBfWwt1ZBVwy)_