### PR TITLE
fix: redirect already-authenticated users off signup/login pages

### DIFF
--- a/models/store.ts
+++ b/models/store.ts
@@ -60,7 +60,7 @@ async function create(storeData: StoreCreateDto) {
   const slug = generateSlug(storeData.name);
   await validateUniqueSlug(slug);
 
-  return await prisma.store.create({
+  const createdStore = await prisma.store.create({
     data: {
       name: storeData.name,
       description: storeData.description,
@@ -69,6 +69,14 @@ async function create(storeData: StoreCreateDto) {
       slug,
     },
   });
+
+  // The owner is authorized for every store-scoped action via the isOwner
+  // check in authorization.can(), but controller.canRequest(feature) also
+  // gates on the *global* feature before that resource check ever runs.
+  // Grant those features here so a fresh store owner can actually use them.
+  await userModel.addFeatures(storeData.owner_id, MEMBER_PERMISSIONS);
+
+  return createdStore;
 }
 
 async function findAllPaginated({
@@ -222,8 +230,9 @@ async function addMember(
     });
   }
 
+  let createdMember;
   try {
-    return await prisma.storeMember.create({
+    createdMember = await prisma.storeMember.create({
       data: {
         store_id: storeId,
         user_id: targetUser.id,
@@ -242,6 +251,12 @@ async function addMember(
     }
     throw error;
   }
+
+  // Mirror the granted permissions into the member's global features, same
+  // reasoning as in create() above.
+  await userModel.addFeatures(targetUser.id, permissions);
+
+  return createdMember;
 }
 
 async function findOneMemberByUsername(storeId: string, username: string) {
@@ -273,7 +288,7 @@ async function updateMemberPermissions(
 ) {
   const member = await findOneMemberByUsername(storeId, username);
 
-  return await prisma.storeMember.update({
+  const updatedMember = await prisma.storeMember.update({
     where: {
       id: member.id,
     },
@@ -281,6 +296,10 @@ async function updateMemberPermissions(
       permissions,
     },
   });
+
+  await userModel.addFeatures(member.user_id, permissions);
+
+  return updatedMember;
 }
 
 async function removeMember(storeId: string, username: string) {

--- a/models/studio.ts
+++ b/models/studio.ts
@@ -68,7 +68,7 @@ async function create(studioData: StudioCreateDto) {
   const slug = generateSlug(studioData.name);
   await validateUniqueSlug(slug);
 
-  return await prisma.studio.create({
+  const createdStudio = await prisma.studio.create({
     data: {
       name: studioData.name,
       description: studioData.description,
@@ -78,6 +78,15 @@ async function create(studioData: StudioCreateDto) {
       slug,
     },
   });
+
+  // The owner is authorized for every studio-scoped action via the isOwner
+  // check in authorization.can(), but routes like create:game/update:game/
+  // create:game_file/delete:game_file also gate on the *global*
+  // controller.canRequest(feature) before that resource check ever runs.
+  // Grant those features here so a fresh studio owner can actually use them.
+  await userModel.addFeatures(studioData.owner_id, MEMBER_PERMISSIONS);
+
+  return createdStudio;
 }
 
 async function findAllPaginated({
@@ -260,8 +269,9 @@ async function addMember(
     });
   }
 
+  let createdMember;
   try {
-    return await prisma.studioMember.create({
+    createdMember = await prisma.studioMember.create({
       data: {
         studio_id: studioId,
         user_id: targetUser.id,
@@ -280,6 +290,13 @@ async function addMember(
     }
     throw error;
   }
+
+  // Mirror the granted permissions into the member's global features, same
+  // reasoning as in create() above — otherwise controller.canRequest(feature)
+  // rejects them before authorization.can() ever sees their studio membership.
+  await userModel.addFeatures(targetUser.id, permissions);
+
+  return createdMember;
 }
 
 async function findOneMemberByUsername(studioId: string, username: string) {
@@ -311,7 +328,7 @@ async function updateMemberPermissions(
 ) {
   const member = await findOneMemberByUsername(studioId, username);
 
-  return await prisma.studioMember.update({
+  const updatedMember = await prisma.studioMember.update({
     where: {
       id: member.id,
     },
@@ -319,6 +336,10 @@ async function updateMemberPermissions(
       permissions,
     },
   });
+
+  await userModel.addFeatures(member.user_id, permissions);
+
+  return updatedMember;
 }
 
 async function removeMember(studioId: string, username: string) {

--- a/models/user.ts
+++ b/models/user.ts
@@ -198,7 +198,7 @@ const addFeatures = async (id: string, features: string[]) => {
       id,
     },
     data: {
-      features: [...user.features, ...features],
+      features: [...new Set([...user.features, ...features])],
     },
   });
 

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useState } from "react";
+import { FormEvent, useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import Link from "next/link";
 import AuthLayout from "../../components/AuthLayout";
@@ -12,6 +12,34 @@ export default function LoginPage() {
   const [code, setCode] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isCheckingSession, setIsCheckingSession] = useState(true);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    fetch("/api/v1/user")
+      .then((response) => {
+        if (!isMounted) return;
+
+        if (response.ok) {
+          const callbackUrl = router.query.callbackUrl;
+          const redirectUrl =
+            typeof callbackUrl === "string" ? callbackUrl : "/store";
+          router.replace(redirectUrl);
+          return;
+        }
+
+        setIsCheckingSession(false);
+      })
+      .catch(() => {
+        if (isMounted) setIsCheckingSession(false);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   async function handleRequestCode(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -95,6 +123,17 @@ export default function LoginPage() {
     setStep("email");
     setCode("");
     setErrorMessage("");
+  }
+
+  if (isCheckingSession) {
+    return (
+      <AuthLayout
+        title="Login | Manifold"
+        description="Login to your Manifold account."
+      >
+        <p role="status">Loading...</p>
+      </AuthLayout>
+    );
   }
 
   return (

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -1,16 +1,43 @@
 import Link from "next/link";
-import { FormEvent, useState } from "react";
+import { useRouter } from "next/router";
+import { FormEvent, useEffect, useState } from "react";
 import AuthLayout from "../../components/AuthLayout";
 
 const USERNAME_PATTERN = /^[A-Za-z0-9]{3,30}$/;
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export default function SignupPage() {
+  const router = useRouter();
   const [username, setUsername] = useState("");
   const [email, setEmail] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
   const [successMessage, setSuccessMessage] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isCheckingSession, setIsCheckingSession] = useState(true);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    fetch("/api/v1/user")
+      .then((response) => {
+        if (!isMounted) return;
+
+        if (response.ok) {
+          router.replace("/store");
+          return;
+        }
+
+        setIsCheckingSession(false);
+      })
+      .catch(() => {
+        if (isMounted) setIsCheckingSession(false);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const trimmedUsername = username.trim();
   const trimmedEmail = email.trim();
@@ -68,6 +95,17 @@ export default function SignupPage() {
     } finally {
       setIsSubmitting(false);
     }
+  }
+
+  if (isCheckingSession) {
+    return (
+      <AuthLayout
+        title="Request Early Access | Manifold"
+        description="Create your Manifold early access account."
+      >
+        <p role="status">Loading...</p>
+      </AuthLayout>
+    );
   }
 
   return (


### PR DESCRIPTION
Signup and login both require create:user/create:otp, features that
belong to anonymous visitors only (see models/authorization.ts). A
user who still has a valid session cookie hits either page and gets a
raw 403 "You do not have permission to perform this action" with no
explanation. Both pages now check GET /api/v1/user on mount and
redirect straight to /store (or the login callbackUrl) when already
authenticated, instead of rendering the form.