### PR TITLE
feat: allow login by username or email

### DIFF
--- a/models/otp.ts
+++ b/models/otp.ts
@@ -63,7 +63,7 @@ manifoldpowered.com`,
   });
 }
 
-async function validateAndConsume(providedEmail: string, providedCode: string) {
+async function validateAndConsume(providedLogin: string, providedCode: string) {
   const invalidOrExpiredError = new UnauthorizedError({
     message: "Invalid or expired code",
     action: "Request a new code and try again",
@@ -71,7 +71,7 @@ async function validateAndConsume(providedEmail: string, providedCode: string) {
 
   let userFound: User;
   try {
-    userFound = await user.findOneByEmail(providedEmail);
+    userFound = await user.findOneByLogin(providedLogin);
   } catch {
     throw invalidOrExpiredError;
   }

--- a/models/user.ts
+++ b/models/user.ts
@@ -129,6 +129,20 @@ const findOneByEmail = async (email: string) => {
   return user;
 };
 
+// Resolves a login identifier to a user: treated as an email when it contains
+// "@", otherwise as a username. Reuses the existing finders, so it throws the
+// same NotFoundError they do when nothing matches. Used by the passwordless
+// login flow so users can sign in with either their username or their email.
+const findOneByLogin = async (login: string) => {
+  const normalizedLogin = login.trim();
+
+  if (normalizedLogin.includes("@")) {
+    return findOneByEmail(normalizedLogin);
+  }
+
+  return findOneByUsername(normalizedLogin);
+};
+
 const findOneById = async (id: string) => {
   const user = await prisma.user.findUnique({
     where: {
@@ -272,6 +286,7 @@ const user = {
   findOneById,
   findOneByUsername,
   findOneByEmail,
+  findOneByLogin,
   findAllPaginated,
   updateByUsername,
   update,

--- a/pages/api/v1/otp/index.ts
+++ b/pages/api/v1/otp/index.ts
@@ -7,7 +7,7 @@ import { ValidationError } from "infra/errors";
 import { z } from "zod";
 
 const requestOtpSchema = z.object({
-  email: z.email(),
+  login: z.string().trim().min(1),
 });
 
 export default createRouter<NextApiRequest, NextApiResponse>()
@@ -26,7 +26,7 @@ async function postHandler(req: NextApiRequest, res: NextApiResponse) {
     });
   }
 
-  const userRequestingCode = await user.findOneByEmail(result.data.email);
+  const userRequestingCode = await user.findOneByLogin(result.data.login);
 
   const { code } = await otp.create(userRequestingCode.id);
   await otp.sendEmailToUser(userRequestingCode, code);

--- a/pages/api/v1/otp/sessions/index.ts
+++ b/pages/api/v1/otp/sessions/index.ts
@@ -8,7 +8,7 @@ import { ForbiddenError, ValidationError } from "infra/errors";
 import { z } from "zod";
 
 const verifyOtpSchema = z.object({
-  email: z.email(),
+  login: z.string().trim().min(1),
   code: z.string().length(6),
 });
 
@@ -29,7 +29,7 @@ async function postHandler(req: NextApiRequest, res: NextApiResponse) {
   }
 
   const authUser = await otp.validateAndConsume(
-    result.data.email,
+    result.data.login,
     result.data.code,
   );
 

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -3,12 +3,12 @@ import { useRouter } from "next/router";
 import Link from "next/link";
 import AuthLayout from "../../components/AuthLayout";
 
-type Step = "email" | "code";
+type Step = "login" | "code";
 
 export default function LoginPage() {
   const router = useRouter();
-  const [step, setStep] = useState<Step>("email");
-  const [email, setEmail] = useState("");
+  const [step, setStep] = useState<Step>("login");
+  const [login, setLogin] = useState("");
   const [code, setCode] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -54,7 +54,7 @@ export default function LoginPage() {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          email: email.trim(),
+          login: login.trim(),
         }),
       });
 
@@ -91,7 +91,7 @@ export default function LoginPage() {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          email: email.trim(),
+          login: login.trim(),
           code: code.trim(),
         }),
       });
@@ -119,8 +119,8 @@ export default function LoginPage() {
     }
   }
 
-  function handleUseDifferentEmail() {
-    setStep("email");
+  function handleUseDifferentAccount() {
+    setStep("login");
     setCode("");
     setErrorMessage("");
   }
@@ -143,26 +143,26 @@ export default function LoginPage() {
     >
       <form
         className="auth-form"
-        onSubmit={step === "email" ? handleRequestCode : handleVerifyCode}
+        onSubmit={step === "login" ? handleRequestCode : handleVerifyCode}
       >
         <div className="modal-heading">
           <h2 id="login-title">Log In</h2>
           <p>
-            {step === "email"
+            {step === "login"
               ? "Welcome back to Manifold."
-              : `Enter the code we sent to ${email.trim()}.`}
+              : "Enter the 6-digit code we sent to your email."}
           </p>
         </div>
 
-        {step === "email" ? (
+        {step === "login" ? (
           <label className="field">
-            <span>Email</span>
+            <span>Username or email</span>
             <input
-              autoComplete="email"
+              autoComplete="username"
               required
-              type="email"
-              value={email}
-              onChange={(event) => setEmail(event.target.value)}
+              type="text"
+              value={login}
+              onChange={(event) => setLogin(event.target.value)}
             />
           </label>
         ) : (
@@ -190,10 +190,10 @@ export default function LoginPage() {
 
         <button className="submit-button" disabled={isSubmitting} type="submit">
           {isSubmitting
-            ? step === "email"
+            ? step === "login"
               ? "Sending..."
               : "Verifying..."
-            : step === "email"
+            : step === "login"
               ? "Send Code"
               : "Log In"}
         </button>
@@ -203,9 +203,9 @@ export default function LoginPage() {
             className="submit-button"
             type="button"
             disabled={isSubmitting}
-            onClick={handleUseDifferentEmail}
+            onClick={handleUseDifferentAccount}
           >
-            Use a different email
+            Use a different account
           </button>
         ) : null}
 

--- a/tests/integration/_use-cases/passwordless-login-flow.test.ts
+++ b/tests/integration/_use-cases/passwordless-login-flow.test.ts
@@ -23,7 +23,7 @@ describe("Use case: Passwordless login flow via OTP (all successful)", () => {
     const response = await fetch(`${webserver.getOrigin()}/api/v1/otp`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ email: newUser.email }),
+      body: JSON.stringify({ login: newUser.email }),
     });
 
     expect(response.status).toBe(201);
@@ -45,7 +45,7 @@ describe("Use case: Passwordless login flow via OTP (all successful)", () => {
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email: newUser.email, code }),
+        body: JSON.stringify({ login: newUser.email, code }),
       },
     );
 
@@ -80,7 +80,7 @@ describe("Use case: Passwordless login flow via OTP (all successful)", () => {
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email: newUser.email, code }),
+        body: JSON.stringify({ login: newUser.email, code }),
       },
     );
 

--- a/tests/integration/api/v1/otp/post.test.ts
+++ b/tests/integration/api/v1/otp/post.test.ts
@@ -9,7 +9,7 @@ beforeAll(async () => {
 
 describe("POST /api/v1/otp", () => {
   describe("Anonymous user", () => {
-    test("With existing email should send a code and return 201", async () => {
+    test("With an existing email should send a code and return 201", async () => {
       const user = await orchestrator.createUser({
         email: "otp-request@pedro.tec.br",
       });
@@ -17,7 +17,7 @@ describe("POST /api/v1/otp", () => {
       const response = await fetch(`${webserver.getOrigin()}/api/v1/otp`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email: user.email }),
+        body: JSON.stringify({ login: user.email }),
       });
 
       expect(response.status).toBe(201);
@@ -34,11 +34,35 @@ describe("POST /api/v1/otp", () => {
       expect(code).toMatch(/^\d{6}$/);
     });
 
-    test("With non-existent email should return 404", async () => {
+    test("With an existing username should send a code to that user's email and return 201", async () => {
+      const user = await orchestrator.createUser({
+        username: "otpbyusername",
+        email: "otp-by-username@pedro.tec.br",
+      });
+
       const response = await fetch(`${webserver.getOrigin()}/api/v1/otp`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email: "non-existent@pedro.tec.br" }),
+        body: JSON.stringify({ login: user.username }),
+      });
+
+      expect(response.status).toBe(201);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({ message: "OTP code sent to your email" });
+
+      const lastEmail = await orchestrator.getLastEmail();
+      expect(lastEmail.recipients[0]).toBe("<otp-by-username@pedro.tec.br>");
+
+      const code = orchestrator.extractOtpCode(lastEmail.text);
+      expect(code).toMatch(/^\d{6}$/);
+    });
+
+    test("With a non-existent email should return 404", async () => {
+      const response = await fetch(`${webserver.getOrigin()}/api/v1/otp`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ login: "non-existent@pedro.tec.br" }),
       });
 
       expect(response.status).toBe(404);
@@ -52,11 +76,29 @@ describe("POST /api/v1/otp", () => {
       });
     });
 
-    test("With invalid email format should return 400", async () => {
+    test("With a non-existent username should return 404", async () => {
       const response = await fetch(`${webserver.getOrigin()}/api/v1/otp`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email: "not-an-email" }),
+        body: JSON.stringify({ login: "nonexistentuser" }),
+      });
+
+      expect(response.status).toBe(404);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        message: "User with username nonexistentuser not found",
+        name: "NotFoundError",
+        action: "Try another username",
+        status_code: 404,
+      });
+    });
+
+    test("With a missing login should return 400", async () => {
+      const response = await fetch(`${webserver.getOrigin()}/api/v1/otp`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
       });
 
       expect(response.status).toBe(400);

--- a/tests/integration/api/v1/otp/sessions/post.test.ts
+++ b/tests/integration/api/v1/otp/sessions/post.test.ts
@@ -11,7 +11,7 @@ beforeAll(async () => {
 
 describe("POST /api/v1/otp/sessions", () => {
   describe("Anonymous user", () => {
-    test("With valid and unexpired code should create a session and return 201", async () => {
+    test("With a valid and unexpired code (by email) should create a session and return 201", async () => {
       const user = await orchestrator.createUser();
       await orchestrator.activateUser(user.id);
 
@@ -22,7 +22,7 @@ describe("POST /api/v1/otp/sessions", () => {
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ email: user.email, code }),
+          body: JSON.stringify({ login: user.email, code }),
         },
       );
 
@@ -49,6 +49,27 @@ describe("POST /api/v1/otp/sessions", () => {
       });
     });
 
+    test("With a valid and unexpired code (by username) should create a session and return 201", async () => {
+      const user = await orchestrator.createUser();
+      await orchestrator.activateUser(user.id);
+
+      const { code } = await otp.create(user.id);
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/otp/sessions`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ login: user.username, code }),
+        },
+      );
+
+      expect(response.status).toBe(201);
+
+      const responseBody = await response.json();
+      expect(responseBody.user_id).toBe(user.id);
+    });
+
     test("With invalid code should return 401", async () => {
       const user = await orchestrator.createUser();
       await orchestrator.activateUser(user.id);
@@ -59,7 +80,7 @@ describe("POST /api/v1/otp/sessions", () => {
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ email: user.email, code: "000000" }),
+          body: JSON.stringify({ login: user.email, code: "000000" }),
         },
       );
 
@@ -74,14 +95,14 @@ describe("POST /api/v1/otp/sessions", () => {
       });
     });
 
-    test("With non-existent email should return 401", async () => {
+    test("With non-existent login should return 401", async () => {
       const response = await fetch(
         `${webserver.getOrigin()}/api/v1/otp/sessions`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            email: "non-existent@pedro.tec.br",
+            login: "non-existent@pedro.tec.br",
             code: "123456",
           }),
         },
@@ -116,7 +137,7 @@ describe("POST /api/v1/otp/sessions", () => {
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ email: user.email, code }),
+          body: JSON.stringify({ login: user.email, code }),
         },
       );
 
@@ -141,7 +162,7 @@ describe("POST /api/v1/otp/sessions", () => {
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ email: user.email, code }),
+          body: JSON.stringify({ login: user.email, code }),
         },
       );
       expect(firstResponse.status).toBe(201);
@@ -151,7 +172,7 @@ describe("POST /api/v1/otp/sessions", () => {
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ email: user.email, code }),
+          body: JSON.stringify({ login: user.email, code }),
         },
       );
 
@@ -175,7 +196,7 @@ describe("POST /api/v1/otp/sessions", () => {
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ email: user.email, code }),
+          body: JSON.stringify({ login: user.email, code }),
         },
       );
 
@@ -196,7 +217,7 @@ describe("POST /api/v1/otp/sessions", () => {
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ email: "not-an-email", code: "1" }),
+          body: JSON.stringify({ login: "someone", code: "1" }),
         },
       );
 


### PR DESCRIPTION
Closes #150.

## Summary
Passwordless login previously accepted only an email. Users can now sign in with **either their username or their email**. The OTP is always delivered to the resolved user's email regardless of which identifier they typed.

- `models/user.ts`: new `findOneByLogin` resolves a login string to a user by email when it contains `@`, otherwise by username — reusing the existing `findOneByEmail`/`findOneByUsername`, so unknown identifiers throw the same `NotFoundError`.
- `POST /api/v1/otp` and `POST /api/v1/otp/sessions` now accept a `login` field instead of `email`; `otp.validateAndConsume` resolves the login internally, preserving the existing **401 non-leak** on the verify step.
- `pages/login/index.tsx`: single "Username or email" field (`type="text"`, `autoComplete="username"`), posting `login` to both endpoints; confirmation copy and the "Use a different account" reset updated to read sensibly for either identifier.

## Behavior notes
- The OTP **request** endpoint preserves the repo's existing (enumerable) behavior: unknown identifier → `404 NotFoundError`, matching the prior email-only behavior. The **verify** endpoint remains non-enumerable (`401` for unknown login).

## Tests
- `tests/integration/api/v1/otp/post.test.ts`: login by email (201 + code emailed), login by username (201 + code sent to that user's email), non-existent email (404), non-existent username (404), missing login (400).
- `tests/integration/api/v1/otp/sessions/post.test.ts`: verify by email and by username (201), plus the existing invalid/expired/used/unactivated/non-existent paths switched to `login`.
- `tests/integration/_use-cases/passwordless-login-flow.test.ts`: switched to `login`.

Verified locally: ESLint, Prettier clean. Full Jest suite runs in CI (Docker unavailable in my sandbox).

## Out of scope
Password auth, OTP delivery channel, session model — untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wb9H8h2atku1TG6rVn4mGc)_