### PR TITLE
feat: rebrand "Store" to "Outlets" in user-facing copy

### DIFF
--- a/components/ConceptDiagram.tsx
+++ b/components/ConceptDiagram.tsx
@@ -117,7 +117,7 @@ function StoreNode({
           ))
         ) : (
           <span className="text-xs text-[rgba(53,34,89,0.3)] text-center py-4 font-bold uppercase tracking-widest">
-            Store Empty
+            Outlet Empty
           </span>
         )}
       </div>
@@ -332,26 +332,26 @@ export default function ConceptDiagram() {
         {/* TIER 2 */}
         <div className="flex flex-col items-center w-full mt-4 md:mt-0">
           <h2 className="text-sm md:text-base uppercase tracking-[0.2em] font-bold mb-8 text-[rgba(53,34,89,0.5)] text-center px-4">
-            2. Games are distributed across hundreds of Manifold stores. (Anyone
-            can create a store)
+            2. Games are distributed across hundreds of Manifold outlets.
+            (Anyone can create an outlet)
           </h2>
 
           <div className="flex flex-row md:grid md:grid-cols-3 overflow-x-auto md:overflow-visible snap-x snap-mandatory gap-6 md:gap-10 w-screen max-w-[100vw] -mx-4 px-8 md:w-full md:mx-0 md:px-0 place-items-stretch relative z-10 pb-8 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
             <div className="min-w-[1vw] md:hidden"></div>
             <StoreNode
-              name="Cozy Streamer Store"
+              name="Cozy Streamer Outlet"
               description="A curated selection of the best relaxing and wholesome games."
               games={[games[1]]}
               storeIcon="🎙️"
             />
             <StoreNode
-              name="Games Curator Store"
+              name="Games Curator Outlet"
               description="The uncompromised catalog of top-tier independent games."
               games={games}
               storeIcon="🔎"
             />
             <StoreNode
-              name="RPG Gamers Store"
+              name="RPG Gamers Outlet"
               description="Everything for the hardcore story-driven role-playing enthusiast."
               games={[games[0]]}
               storeIcon="🎲"
@@ -436,9 +436,9 @@ export default function ConceptDiagram() {
             </h3>
 
             <div className="flex flex-col justify-center gap-4 md:gap-5 bg-[rgba(214,205,255,0.4)] p-4 md:p-6 rounded-[2.5rem] w-full border border-white/50 shadow-inner text-left">
-              <LibraryCard game={games[0]} purchasedAt="RPG Gamers Store" />
-              <LibraryCard game={games[1]} purchasedAt="Cozy Streamer Store" />
-              <LibraryCard game={games[2]} purchasedAt="Games Curator Store" />
+              <LibraryCard game={games[0]} purchasedAt="RPG Gamers Outlet" />
+              <LibraryCard game={games[1]} purchasedAt="Cozy Streamer Outlet" />
+              <LibraryCard game={games[2]} purchasedAt="Games Curator Outlet" />
             </div>
 
             <p className="mt-8 text-[rgba(53,34,89,0.7)] text-lg max-w-2xl leading-relaxed">

--- a/components/store/StoreTopNav.tsx
+++ b/components/store/StoreTopNav.tsx
@@ -90,7 +90,7 @@ export function StoreTopNav({ store }: { store?: StoreNavContext }) {
               className="flex items-center gap-2 px-4 py-2 rounded-xl text-white/60 hover:text-white hover:bg-white/5 transition-all font-bold text-sm tracking-wide"
             >
               <Store size={18} />
-              Store
+              Outlets
             </Link>
             <Link
               href="/library"
@@ -113,7 +113,7 @@ export function StoreTopNav({ store }: { store?: StoreNavContext }) {
             </div>
             <input
               type="text"
-              placeholder="Search store..."
+              placeholder="Search outlets..."
               className="w-full rounded-2xl border border-white/10 bg-white/5 backdrop-blur-xl pl-11 pr-5 py-2 md:py-3 text-sm md:text-base font-bold text-white placeholder:text-white/30 outline-none transition-all duration-300 focus:bg-white/10 focus:shadow-[0_0_20px_rgba(255,255,255,0.05)] focus:border-white/20"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}

--- a/components/store/UserMenu.tsx
+++ b/components/store/UserMenu.tsx
@@ -110,7 +110,7 @@ export function UserMenu() {
               className="flex items-center gap-3 px-4 py-2.5 text-sm font-bold text-white/80 hover:text-white hover:bg-white/5 transition-colors"
             >
               <Store size={16} className="text-indigo-400" />
-              My Stores
+              My Outlets
             </Link>
 
             <button

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -66,7 +66,7 @@ const audiences: Record<
       "Manifold gives the gaming community the power to distribute games on their own terms.",
     features: [
       {
-        title: "Your Community, Your Store",
+        title: "Your Community, Your Outlet",
         description:
           "Stop sending your audience away to Steam. With Manifold, you open a verified, branded storefront in minutes. Handpick the catalog that fits your community's vibe perfectly.",
       },
@@ -94,7 +94,7 @@ const audiences: Record<
     hero: "Support creators directly without fracturing your game collection. One login, one library, endless storefronts.",
     manifestoLead: "",
     manifestoStrong:
-      "When you buy a game through a Manifold-powered store, your money goes to the people who actually made it and the community who championed it.",
+      "When you buy a game through a Manifold-powered outlet, your money goes to the people who actually made it and the community who championed it.",
     features: [
       {
         title: "One Epic Library",

--- a/pages/item/[slug].tsx
+++ b/pages/item/[slug].tsx
@@ -295,7 +295,7 @@ export default function GameDetailsPage({ game }: { game: GameApi }) {
   return (
     <div className="min-h-screen bg-[#1D0F3B] text-white pb-24 overflow-x-hidden selection:bg-white selection:text-black">
       <Head>
-        <title>{game.title} | Manifold Store</title>
+        <title>{game.title} | Manifold Outlets</title>
         <meta name="description" content={game.description} />
         <meta name="theme-color" content="#1D0F3B" />
       </Head>
@@ -379,7 +379,7 @@ export default function GameDetailsPage({ game }: { game: GameApi }) {
                   size={16}
                   className="group-hover:-translate-x-1 transition-transform"
                 />
-                Back to Store
+                Back to Outlets
               </Link>
 
               <div className="flex flex-wrap items-center gap-3">

--- a/pages/library/index.tsx
+++ b/pages/library/index.tsx
@@ -29,7 +29,7 @@ export default function LibraryPage() {
   return (
     <div className="min-h-screen bg-[#1D0F3B] text-white pb-24 overflow-x-hidden selection:bg-white selection:text-black">
       <Head>
-        <title>My Library | Manifold Store</title>
+        <title>My Library | Manifold Outlets</title>
         <meta name="theme-color" content="#1D0F3B" />
       </Head>
 
@@ -113,13 +113,13 @@ export default function LibraryPage() {
               </h2>
               <p className="text-white/40 font-bold max-w-md mb-8">
                 You haven&apos;t added any games to your library yet. Discover
-                your next adventure in the store.
+                your next adventure in the outlets.
               </p>
               <Link
                 href="/store"
                 className="px-8 py-4 rounded-xl border border-white/20 text-white font-black uppercase tracking-wider hover:bg-white hover:text-black transition-all"
               >
-                Browse Store
+                Browse Outlets
               </Link>
             </div>
           )}

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -52,7 +52,7 @@ export default function SearchPage() {
   return (
     <div className="min-h-screen bg-[#1D0F3B] text-white pb-24 overflow-x-hidden selection:bg-white selection:text-black">
       <Head>
-        <title>Search Results | Manifold Store</title>
+        <title>Search Results | Manifold Outlets</title>
         <meta name="theme-color" content="#1D0F3B" />
       </Head>
 

--- a/pages/store/[slug].tsx
+++ b/pages/store/[slug].tsx
@@ -58,7 +58,7 @@ export default function StorePage() {
   if (error || !store) {
     return (
       <div className="min-h-screen bg-[#1D0F3B] flex items-center justify-center">
-        <p className="text-rose-300 font-bold">Store not found.</p>
+        <p className="text-rose-300 font-bold">Outlet not found.</p>
       </div>
     );
   }
@@ -76,7 +76,7 @@ export default function StorePage() {
         listEndpoint={`/api/v1/stores/${store.slug}/search`}
         browsePath={`/store/${store.slug}`}
         searchPagePath={`/store/${store.slug}`}
-        pageTitle={`${store.name} | Manifold Store`}
+        pageTitle={`${store.name} | Manifold Outlets`}
         metaDescription={
           store.description ||
           `Explore ${store.name}'s curated catalog on Manifold.`
@@ -91,7 +91,7 @@ export default function StorePage() {
           className="fixed bottom-6 right-6 z-40 flex items-center gap-2 px-5 py-3 rounded-2xl bg-white text-black font-black text-sm uppercase tracking-wider shadow-2xl hover:bg-white/90 transition-colors"
         >
           <Settings size={16} />
-          Manage Store
+          Manage Outlet
         </Link>
       )}
     </StoreLayout>

--- a/pages/store/[slug]/manage.tsx
+++ b/pages/store/[slug]/manage.tsx
@@ -77,7 +77,7 @@ export default function StoreManagePage() {
   if (storeError || !storeData) {
     return (
       <div className="min-h-screen bg-[#1D0F3B] flex items-center justify-center">
-        <p className="text-rose-300 font-bold">Store not found.</p>
+        <p className="text-rose-300 font-bold">Outlet not found.</p>
       </div>
     );
   }
@@ -86,7 +86,7 @@ export default function StoreManagePage() {
     return (
       <div className="min-h-screen bg-[#1D0F3B] flex items-center justify-center px-4 text-center">
         <p className="text-rose-300 font-bold">
-          You do not have permission to manage this store.
+          You do not have permission to manage this outlet.
         </p>
       </div>
     );
@@ -216,7 +216,7 @@ function CurationTab({
           <h2 className="text-lg font-black">Tag Filters</h2>
           <p className="text-white/50 text-sm font-bold mt-1">
             Whitelist tags to show only matching games, or blacklist tags to
-            hide them. With no filters, your store shows the full catalog.
+            hide them. With no filters, your outlet shows the full catalog.
           </p>
         </div>
 
@@ -451,7 +451,7 @@ function SettingsTab({ store }: { store: StoreApi }) {
       });
       const body = await response.json().catch(() => null);
       if (!response.ok) {
-        setError(body?.message || "Failed to update store.");
+        setError(body?.message || "Failed to update outlet.");
         return;
       }
       setSuccess(true);
@@ -465,7 +465,7 @@ function SettingsTab({ store }: { store: StoreApi }) {
     <form onSubmit={handleSubmit} className="flex flex-col gap-4 max-w-md">
       <label className="flex flex-col gap-2">
         <span className="text-xs font-black uppercase tracking-wider text-white/40">
-          Store name
+          Outlet name
         </span>
         <input
           type="text"
@@ -544,7 +544,7 @@ function SalesTab({ storeSlug }: { storeSlug: string }) {
     <div className="flex flex-col gap-4">
       <p className="text-white/50 text-sm font-bold">
         {data?.pagination.total ?? 0} sale
-        {data?.pagination.total === 1 ? "" : "s"} attributed to this store.
+        {data?.pagination.total === 1 ? "" : "s"} attributed to this outlet.
       </p>
 
       {sales.length === 0 ? (

--- a/pages/store/index.tsx
+++ b/pages/store/index.tsx
@@ -9,7 +9,7 @@ export default function StoreOption2() {
       listEndpoint="/api/v1/games"
       browsePath="/store"
       searchPagePath="/search"
-      pageTitle="Discover (Dark) | Manifold Store"
+      pageTitle="Discover (Dark) | Manifold Outlets"
       metaDescription="Explore the best games curated by the community in premium dark mode."
     />
   );

--- a/pages/store/mine.tsx
+++ b/pages/store/mine.tsx
@@ -52,7 +52,7 @@ export default function MyStoresPage() {
   return (
     <>
       <Head>
-        <title>My Stores | Manifold</title>
+        <title>My Outlets | Manifold</title>
       </Head>
 
       <div className="min-h-screen bg-[#1D0F3B] text-white flex items-center justify-center px-4">
@@ -60,7 +60,7 @@ export default function MyStoresPage() {
           <Loader2 className="animate-spin text-white/30" />
         ) : (
           <div className="w-full max-w-md flex flex-col gap-4">
-            <h1 className="text-2xl font-black">My Stores</h1>
+            <h1 className="text-2xl font-black">My Outlets</h1>
             {stores.map((storeItem) => (
               <Link
                 key={storeItem.id}

--- a/pages/store/new.tsx
+++ b/pages/store/new.tsx
@@ -55,7 +55,7 @@ export default function StoreCreatePage() {
       const body = await response.json().catch(() => null);
 
       if (!response.ok) {
-        setFormError(body?.message || "Failed to create store.");
+        setFormError(body?.message || "Failed to create outlet.");
         return;
       }
 
@@ -68,15 +68,15 @@ export default function StoreCreatePage() {
   return (
     <>
       <Head>
-        <title>Create Your Store | Manifold</title>
+        <title>Create Your Outlet | Manifold</title>
       </Head>
 
       <div className="min-h-screen bg-[#1D0F3B] text-white flex items-center justify-center px-4">
         <div className="w-full max-w-md flex flex-col gap-6">
           <div>
-            <h1 className="text-2xl font-black">Create Your Store</h1>
+            <h1 className="text-2xl font-black">Create Your Outlet</h1>
             <p className="text-white/50 text-sm font-bold mt-1">
-              A store is your own curated storefront on Manifold.
+              An Outlet is your own curated storefront on Manifold.
             </p>
           </div>
 
@@ -86,7 +86,7 @@ export default function StoreCreatePage() {
             <form onSubmit={handleSubmit} className="flex flex-col gap-4">
               <label className="flex flex-col gap-2">
                 <span className="text-xs font-black uppercase tracking-wider text-white/40">
-                  Store name
+                  Outlet name
                 </span>
                 <input
                   type="text"
@@ -105,7 +105,7 @@ export default function StoreCreatePage() {
                   value={description}
                   onChange={(e) => setDescription(e.target.value)}
                   rows={3}
-                  placeholder="Tell players what your store is about."
+                  placeholder="Tell players what your outlet is about."
                   className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-bold text-white placeholder:text-white/30 outline-none focus:bg-white/10 focus:border-white/20 resize-none"
                 />
               </label>
@@ -124,7 +124,7 @@ export default function StoreCreatePage() {
               </label>
 
               <p className="text-xs font-bold text-white/40">
-                Your store shows the full Manifold catalog by default. You can
+                Your outlet shows the full Manifold catalog by default. You can
                 curate what it shows after creating it.
               </p>
 
@@ -139,7 +139,7 @@ export default function StoreCreatePage() {
                 disabled={isSubmitting || !name.trim()}
                 className="px-4 py-3 rounded-xl bg-emerald-500 text-black font-black text-sm uppercase tracking-wider hover:bg-emerald-400 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
               >
-                {isSubmitting ? "Creating..." : "Create Store"}
+                {isSubmitting ? "Creating..." : "Create Outlet"}
               </button>
             </form>
           )}


### PR DESCRIPTION
Closes #151.

## Summary
Renames the consumer-facing product from **"Manifold Store" → "Manifold Outlets"** (an individual storefront is now **"an Outlet"**). Copy-only.

Visible strings updated across: page `<title>`/meta, headings, nav & menu labels (`StoreTopNav`, `UserMenu`), buttons, empty-state and helper copy, the `ConceptDiagram` (tier text + example outlet names), the create/manage outlet pages, and two `/about` mentions.

## Copy-only boundary (nothing below was touched)
- No routes, file names, components, props, variables, models, DB tables/columns, or API paths (`/api/v1/stores`) renamed.
- The generic word **"storefront"** is kept (matches approved copy: "every storefront, one catalog").
- **Backoffice/admin pages (`pages/backoffice/**`, `BackofficeTopNav`) intentionally keep internal "Store" naming** — they map to the `store` model and are covered by the separate responsiveness pass (#155). This leaves one "Back to Store" link inside the admin nav on purpose.

## Tests
No tests assert this copy (verified), so none needed changing. ESLint/Prettier clean locally; full Jest suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wb9H8h2atku1TG6rVn4mGc)_