### PR TITLE
feat: add Outlet-creation guidance and value prop to /store/new

### DIFF
--- a/components/store/OutletValueProp.tsx
+++ b/components/store/OutletValueProp.tsx
@@ -1,0 +1,53 @@
+import { TrendingUp, Users, Sparkles } from "lucide-react";
+
+// CEO-approved Outlet value proposition. Reused on the Outlet-creation flow
+// (and available for the post-signup onboarding hub) so new sellers see why
+// an Outlet is worth opening before they fill out the form.
+const BENEFITS = [
+  {
+    icon: TrendingUp,
+    text: "Earn on every sale you drive, across the entire Manifold catalog",
+  },
+  {
+    icon: Users,
+    text: "Curate a storefront that matches your audience, no inventory required",
+  },
+  {
+    icon: Sparkles,
+    text: "Get paid for discovery — your picks become your revenue",
+  },
+];
+
+export function OutletValueProp() {
+  return (
+    <div className="flex flex-col gap-6">
+      <div>
+        <h2 className="text-3xl md:text-4xl font-black leading-tight">
+          Turn your taste into income.
+        </h2>
+        <p className="mt-3 text-white/60 font-bold">
+          Launch an Outlet and earn by selling and curating games to the
+          audience you already have.
+        </p>
+      </div>
+
+      <ul className="flex flex-col gap-3">
+        {BENEFITS.map(({ icon: Icon, text }) => (
+          <li key={text} className="flex items-start gap-3">
+            <span className="mt-0.5 shrink-0 p-1.5 rounded-lg bg-emerald-500/15 text-emerald-300">
+              <Icon size={16} />
+            </span>
+            <span className="text-sm font-bold text-white/80">{text}</span>
+          </li>
+        ))}
+      </ul>
+
+      <p className="text-sm font-bold text-white/50 leading-relaxed border-t border-white/10 pt-6">
+        An Outlet is your own storefront on Manifold. You choose the games, you
+        build the audience, and you earn on what you sell — no inventory and no
+        upfront cost. Every Outlet is powered by the shared Manifold catalog, so
+        you can start selling in minutes.
+      </p>
+    </div>
+  );
+}

--- a/pages/store/new.tsx
+++ b/pages/store/new.tsx
@@ -3,6 +3,7 @@ import { useRouter } from "next/router";
 import Head from "next/head";
 import useSWR from "swr";
 import { Loader2 } from "lucide-react";
+import { OutletValueProp } from "components/store/OutletValueProp";
 
 interface CurrentUser {
   id: string;
@@ -71,78 +72,79 @@ export default function StoreCreatePage() {
         <title>Create Your Outlet | Manifold</title>
       </Head>
 
-      <div className="min-h-screen bg-[#1D0F3B] text-white flex items-center justify-center px-4">
-        <div className="w-full max-w-md flex flex-col gap-6">
-          <div>
-            <h1 className="text-2xl font-black">Create Your Outlet</h1>
-            <p className="text-white/50 text-sm font-bold mt-1">
-              An Outlet is your own curated storefront on Manifold.
-            </p>
+      <div className="min-h-screen bg-[#1D0F3B] text-white flex items-center justify-center px-4 py-16">
+        <div className="w-full max-w-4xl grid lg:grid-cols-2 gap-10 lg:gap-14 items-start">
+          <div className="lg:pt-4">
+            <OutletValueProp />
           </div>
 
-          {isUserLoading ? (
-            <Loader2 className="animate-spin text-white/30" />
-          ) : (
-            <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-              <label className="flex flex-col gap-2">
-                <span className="text-xs font-black uppercase tracking-wider text-white/40">
-                  Outlet name
-                </span>
-                <input
-                  type="text"
-                  value={name}
-                  onChange={(e) => setName(e.target.value)}
-                  placeholder="Pixel Arcade"
-                  className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-bold text-white placeholder:text-white/30 outline-none focus:bg-white/10 focus:border-white/20"
-                />
-              </label>
+          <div className="w-full flex flex-col gap-6">
+            <h1 className="text-2xl font-black">Create Your Outlet</h1>
 
-              <label className="flex flex-col gap-2">
-                <span className="text-xs font-black uppercase tracking-wider text-white/40">
-                  Description (optional)
-                </span>
-                <textarea
-                  value={description}
-                  onChange={(e) => setDescription(e.target.value)}
-                  rows={3}
-                  placeholder="Tell players what your outlet is about."
-                  className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-bold text-white placeholder:text-white/30 outline-none focus:bg-white/10 focus:border-white/20 resize-none"
-                />
-              </label>
+            {isUserLoading ? (
+              <Loader2 className="animate-spin text-white/30" />
+            ) : (
+              <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+                <label className="flex flex-col gap-2">
+                  <span className="text-xs font-black uppercase tracking-wider text-white/40">
+                    Outlet name
+                  </span>
+                  <input
+                    type="text"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    placeholder="Pixel Arcade"
+                    className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-bold text-white placeholder:text-white/30 outline-none focus:bg-white/10 focus:border-white/20"
+                  />
+                </label>
 
-              <label className="flex flex-col gap-2">
-                <span className="text-xs font-black uppercase tracking-wider text-white/40">
-                  Logo URL (optional)
-                </span>
-                <input
-                  type="text"
-                  value={logoUrl}
-                  onChange={(e) => setLogoUrl(e.target.value)}
-                  placeholder="https://example.com/logo.png"
-                  className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-bold text-white placeholder:text-white/30 outline-none focus:bg-white/10 focus:border-white/20"
-                />
-              </label>
+                <label className="flex flex-col gap-2">
+                  <span className="text-xs font-black uppercase tracking-wider text-white/40">
+                    Description (optional)
+                  </span>
+                  <textarea
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    rows={3}
+                    placeholder="Tell players what your outlet is about."
+                    className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-bold text-white placeholder:text-white/30 outline-none focus:bg-white/10 focus:border-white/20 resize-none"
+                  />
+                </label>
 
-              <p className="text-xs font-bold text-white/40">
-                Your outlet shows the full Manifold catalog by default. You can
-                curate what it shows after creating it.
-              </p>
+                <label className="flex flex-col gap-2">
+                  <span className="text-xs font-black uppercase tracking-wider text-white/40">
+                    Logo URL (optional)
+                  </span>
+                  <input
+                    type="text"
+                    value={logoUrl}
+                    onChange={(e) => setLogoUrl(e.target.value)}
+                    placeholder="https://example.com/logo.png"
+                    className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-bold text-white placeholder:text-white/30 outline-none focus:bg-white/10 focus:border-white/20"
+                  />
+                </label>
 
-              {formError && (
-                <div className="px-4 py-3 rounded-xl bg-rose-500/10 border border-rose-500/30 text-rose-300 text-sm font-bold">
-                  {formError}
-                </div>
-              )}
+                <p className="text-xs font-bold text-white/40">
+                  Your outlet shows the full Manifold catalog by default. You
+                  can curate what it shows after creating it.
+                </p>
 
-              <button
-                type="submit"
-                disabled={isSubmitting || !name.trim()}
-                className="px-4 py-3 rounded-xl bg-emerald-500 text-black font-black text-sm uppercase tracking-wider hover:bg-emerald-400 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-              >
-                {isSubmitting ? "Creating..." : "Create Outlet"}
-              </button>
-            </form>
-          )}
+                {formError && (
+                  <div className="px-4 py-3 rounded-xl bg-rose-500/10 border border-rose-500/30 text-rose-300 text-sm font-bold">
+                    {formError}
+                  </div>
+                )}
+
+                <button
+                  type="submit"
+                  disabled={isSubmitting || !name.trim()}
+                  className="px-4 py-3 rounded-xl bg-emerald-500 text-black font-black text-sm uppercase tracking-wider hover:bg-emerald-400 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                  {isSubmitting ? "Creating..." : "Create Outlet"}
+                </button>
+              </form>
+            )}
+          </div>
         </div>
       </div>
     </>


### PR DESCRIPTION
Closes #156.

## Summary
The Outlet creation form was a bare form with no explanation of what an Outlet is or why to open one. New sellers now see the CEO-approved value proposition before filling anything out.

- **`components/store/OutletValueProp.tsx`** (new): reusable block — headline "Turn your taste into income.", subhead, three income-focused benefit bullets, and the full Outlet explainer, all verbatim.
- **`pages/store/new.tsx`**: responsive two-column layout — value prop + explainer alongside the form on desktop, **stacked (value prop first) on mobile**. The redundant one-line subtitle is replaced by the fuller explainer.

## Empty-state coverage
`/store/mine` already redirects users with zero Outlets to `/store/new`, so that zero-Outlet empty-state path now surfaces the explainer too — no separate empty-state screen needed.

## Out of scope
No backend/API/model changes; POST to `/api/v1/stores` is untouched. The onboarding hub (Studio vs Outlet) is #159.

Verified: ESLint/Prettier clean, no type errors. Full Jest suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wb9H8h2atku1TG6rVn4mGc)_