### PR TITLE
feat: add post-signup onboarding hub (Studio vs Outlet)

### DIFF
--- a/components/onboarding/StudioValueProp.tsx
+++ b/components/onboarding/StudioValueProp.tsx
@@ -1,0 +1,45 @@
+import { UploadCloud, Search, Users } from "lucide-react";
+
+// CEO-approved Studio value proposition. Shown on the Studio-creation flow so
+// developers understand the distribution/discovery upside before committing.
+const BENEFITS = [
+  {
+    icon: UploadCloud,
+    text: "Publish once and appear on every Outlet on the platform",
+  },
+  {
+    icon: Search,
+    text: "Get discovered by curators actively looking for games to sell",
+  },
+  {
+    icon: Users,
+    text: "Reach players everywhere, with purchases, downloads, and progress synced",
+  },
+];
+
+export function StudioValueProp() {
+  return (
+    <div className="flex flex-col gap-6">
+      <div>
+        <h2 className="text-3xl md:text-4xl font-black leading-tight">
+          Ship once. Reach every Outlet.
+        </h2>
+        <p className="mt-3 text-white/60 font-bold">
+          Create a Studio to distribute your games and get discovered across the
+          whole Manifold network.
+        </p>
+      </div>
+
+      <ul className="flex flex-col gap-3">
+        {BENEFITS.map(({ icon: Icon, text }) => (
+          <li key={text} className="flex items-start gap-3">
+            <span className="mt-0.5 shrink-0 p-1.5 rounded-lg bg-indigo-500/15 text-indigo-300">
+              <Icon size={16} />
+            </span>
+            <span className="text-sm font-bold text-white/80">{text}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/pages/onboarding/create.tsx
+++ b/pages/onboarding/create.tsx
@@ -3,6 +3,7 @@ import { useRouter } from "next/router";
 import Head from "next/head";
 import useSWR from "swr";
 import { Loader2 } from "lucide-react";
+import { StudioValueProp } from "components/onboarding/StudioValueProp";
 
 interface CurrentUser {
   id: string;
@@ -73,88 +74,89 @@ export default function OnboardingCreatePage() {
         <title>Create Your Studio | Manifold</title>
       </Head>
 
-      <div className="min-h-screen bg-[#1D0F3B] text-white flex items-center justify-center px-4">
-        <div className="w-full max-w-md flex flex-col gap-6">
-          <div>
-            <h1 className="text-2xl font-black">Create Your Studio</h1>
-            <p className="text-white/50 text-sm font-bold mt-1">
-              A studio is how you publish games on Manifold.
-            </p>
+      <div className="min-h-screen bg-[#1D0F3B] text-white flex items-center justify-center px-4 py-16">
+        <div className="w-full max-w-4xl grid lg:grid-cols-2 gap-10 lg:gap-14 items-start">
+          <div className="lg:pt-4">
+            <StudioValueProp />
           </div>
 
-          {isUserLoading ? (
-            <Loader2 className="animate-spin text-white/30" />
-          ) : (
-            <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-              <label className="flex flex-col gap-2">
-                <span className="text-xs font-black uppercase tracking-wider text-white/40">
-                  Studio name
-                </span>
-                <input
-                  type="text"
-                  value={name}
-                  onChange={(e) => setName(e.target.value)}
-                  placeholder="Hibernian Workshop"
-                  className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-bold text-white placeholder:text-white/30 outline-none focus:bg-white/10 focus:border-white/20"
-                />
-              </label>
+          <div className="w-full flex flex-col gap-6">
+            <h1 className="text-2xl font-black">Create Your Studio</h1>
 
-              <label className="flex flex-col gap-2">
-                <span className="text-xs font-black uppercase tracking-wider text-white/40">
-                  Description (optional)
-                </span>
-                <textarea
-                  value={description}
-                  onChange={(e) => setDescription(e.target.value)}
-                  rows={3}
-                  placeholder="Tell players what your studio makes."
-                  className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-bold text-white placeholder:text-white/30 outline-none focus:bg-white/10 focus:border-white/20 resize-none"
-                />
-              </label>
-
-              <label className="flex flex-col gap-2">
-                <span className="text-xs font-black uppercase tracking-wider text-white/40">
-                  Logo URL (optional)
-                </span>
-                <input
-                  type="text"
-                  value={logoUrl}
-                  onChange={(e) => setLogoUrl(e.target.value)}
-                  placeholder="https://example.com/logo.png"
-                  className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-bold text-white placeholder:text-white/30 outline-none focus:bg-white/10 focus:border-white/20"
-                />
-              </label>
-
-              <label className="flex items-start gap-3">
-                <input
-                  type="checkbox"
-                  checked={isPublisher}
-                  onChange={(e) => setIsPublisher(e.target.checked)}
-                  className="mt-1"
-                />
-                <span className="text-sm font-bold text-white/70">
-                  This studio also publishes other studios&apos; games
-                  <span className="block text-xs font-normal text-white/40 mt-0.5">
-                    You can change this later.
+            {isUserLoading ? (
+              <Loader2 className="animate-spin text-white/30" />
+            ) : (
+              <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+                <label className="flex flex-col gap-2">
+                  <span className="text-xs font-black uppercase tracking-wider text-white/40">
+                    Studio name
                   </span>
-                </span>
-              </label>
+                  <input
+                    type="text"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    placeholder="Hibernian Workshop"
+                    className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-bold text-white placeholder:text-white/30 outline-none focus:bg-white/10 focus:border-white/20"
+                  />
+                </label>
 
-              {formError && (
-                <div className="px-4 py-3 rounded-xl bg-rose-500/10 border border-rose-500/30 text-rose-300 text-sm font-bold">
-                  {formError}
-                </div>
-              )}
+                <label className="flex flex-col gap-2">
+                  <span className="text-xs font-black uppercase tracking-wider text-white/40">
+                    Description (optional)
+                  </span>
+                  <textarea
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    rows={3}
+                    placeholder="Tell players what your studio makes."
+                    className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-bold text-white placeholder:text-white/30 outline-none focus:bg-white/10 focus:border-white/20 resize-none"
+                  />
+                </label>
 
-              <button
-                type="submit"
-                disabled={isSubmitting || !name.trim()}
-                className="px-4 py-3 rounded-xl bg-emerald-500 text-black font-black text-sm uppercase tracking-wider hover:bg-emerald-400 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-              >
-                {isSubmitting ? "Creating..." : "Create Studio"}
-              </button>
-            </form>
-          )}
+                <label className="flex flex-col gap-2">
+                  <span className="text-xs font-black uppercase tracking-wider text-white/40">
+                    Logo URL (optional)
+                  </span>
+                  <input
+                    type="text"
+                    value={logoUrl}
+                    onChange={(e) => setLogoUrl(e.target.value)}
+                    placeholder="https://example.com/logo.png"
+                    className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-bold text-white placeholder:text-white/30 outline-none focus:bg-white/10 focus:border-white/20"
+                  />
+                </label>
+
+                <label className="flex items-start gap-3">
+                  <input
+                    type="checkbox"
+                    checked={isPublisher}
+                    onChange={(e) => setIsPublisher(e.target.checked)}
+                    className="mt-1"
+                  />
+                  <span className="text-sm font-bold text-white/70">
+                    This studio also publishes other studios&apos; games
+                    <span className="block text-xs font-normal text-white/40 mt-0.5">
+                      You can change this later.
+                    </span>
+                  </span>
+                </label>
+
+                {formError && (
+                  <div className="px-4 py-3 rounded-xl bg-rose-500/10 border border-rose-500/30 text-rose-300 text-sm font-bold">
+                    {formError}
+                  </div>
+                )}
+
+                <button
+                  type="submit"
+                  disabled={isSubmitting || !name.trim()}
+                  className="px-4 py-3 rounded-xl bg-emerald-500 text-black font-black text-sm uppercase tracking-wider hover:bg-emerald-400 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                  {isSubmitting ? "Creating..." : "Create Studio"}
+                </button>
+              </form>
+            )}
+          </div>
         </div>
       </div>
     </>

--- a/pages/onboarding/index.tsx
+++ b/pages/onboarding/index.tsx
@@ -1,0 +1,69 @@
+import Head from "next/head";
+import Link from "next/link";
+import { Gamepad2, Store } from "lucide-react";
+
+// Post-signup hub: an informational fork that routes new users to the right
+// creation flow. Intentionally requires no auth and no account data to view —
+// the CTAs point at /onboarding/create and /store/new, which each handle their
+// own auth redirect. Linked from the signup success screen.
+export default function OnboardingHubPage() {
+  return (
+    <>
+      <Head>
+        <title>Get started | Manifold</title>
+      </Head>
+
+      <div className="min-h-screen bg-[#1D0F3B] text-white flex items-center justify-center px-4 py-16">
+        <div className="w-full max-w-4xl flex flex-col gap-10">
+          <h1 className="text-3xl md:text-5xl font-black leading-tight text-center">
+            Welcome to Manifold. What do you want to build?
+          </h1>
+
+          <div className="grid gap-6 md:grid-cols-2">
+            <div className="flex flex-col gap-4 rounded-2xl border border-white/10 bg-white/5 p-6 md:p-8">
+              <span className="w-fit p-3 rounded-xl bg-indigo-500/15 text-indigo-300">
+                <Gamepad2 size={24} />
+              </span>
+              <h2 className="text-2xl font-black">I make games</h2>
+              <p className="text-white/60 font-bold flex-1">
+                Distribute your games and get discovered across every Outlet on
+                Manifold.
+              </p>
+              <Link
+                href="/onboarding/create"
+                className="w-full text-center px-4 py-3 rounded-xl bg-white text-black font-black text-sm uppercase tracking-wider hover:bg-white/90 transition-colors"
+              >
+                Create a Studio
+              </Link>
+            </div>
+
+            <div className="flex flex-col gap-4 rounded-2xl border border-white/10 bg-white/5 p-6 md:p-8">
+              <span className="w-fit p-3 rounded-xl bg-emerald-500/15 text-emerald-300">
+                <Store size={24} />
+              </span>
+              <h2 className="text-2xl font-black">I sell games</h2>
+              <p className="text-white/60 font-bold flex-1">
+                Open an Outlet and earn by curating games for your audience.
+              </p>
+              <Link
+                href="/store/new"
+                className="w-full text-center px-4 py-3 rounded-xl bg-emerald-500 text-black font-black text-sm uppercase tracking-wider hover:bg-emerald-400 transition-colors"
+              >
+                Create an Outlet
+              </Link>
+            </div>
+          </div>
+
+          <div className="text-center">
+            <Link
+              href="/store"
+              className="text-sm font-bold text-white/50 hover:text-white transition-colors underline underline-offset-4"
+            >
+              I&apos;ll decide later, take me to Manifold
+            </Link>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -117,7 +117,10 @@ export default function SignupPage() {
         <div className="modal-success" role="status">
           <h2 id="early-access-title">Check your inbox</h2>
           <p>{successMessage}</p>
-          <Link href="/store" className="submit-button back-link">
+          <Link href="/onboarding" className="submit-button back-link">
+            See what you can build
+          </Link>
+          <Link href="/store" className="submit-button ghost-link">
             Browse games while you wait
           </Link>
         </div>
@@ -279,6 +282,16 @@ export default function SignupPage() {
           justify-content: center;
           text-decoration: none;
           margin-top: 1.5rem;
+        }
+
+        .ghost-link {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          text-decoration: none;
+          background: transparent;
+          color: var(--color-purple-dark);
+          border: 1px solid rgba(53, 34, 89, 0.24);
         }
 
         @media (max-width: 520px) {


### PR DESCRIPTION
Closes #159.

## Summary
Adds the post-signup fork that routes new users to the right creation flow.

- **`pages/onboarding/index.tsx`** (new): hub with heading "Welcome to Manifold. What do you want to build?" and two cards — **"I make games" → Create a Studio** (`/onboarding/create`) and **"I sell games" → Create an Outlet** (`/store/new`) — plus the skip link "I'll decide later, take me to Manifold" → `/store`. All copy verbatim.
- **`components/onboarding/StudioValueProp.tsx`** (new) + **`pages/onboarding/create.tsx`**: the Studio value prop ("Ship once. Reach every Outlet.") now sits beside the create-studio form in the same responsive two-column layout introduced for Outlet creation in #156.
- **`pages/signup/index.tsx`**: the success screen's primary CTA now links to the hub ("See what you can build"); "Browse games while you wait" is demoted to a secondary ghost button.

## Entry point (decision)
Linked from the **signup success screen**, chosen over a first-login redirect because that would require checking whether the user already has studios/outlets — the issue explicitly says not to gate the hub behind data the user may not have yet. The hub itself requires no auth to view; its CTAs (`/onboarding/create`, `/store/new`) already redirect to login when needed.

## Responsiveness / tests
Cards stack on mobile; two-column layouts collapse to single-column. No redirect/API logic with existing test coverage was added, so no test changes were needed.

Verified: ESLint/Prettier clean, no type errors. Full Jest suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wb9H8h2atku1TG6rVn4mGc)_