### PR TITLE
feat: make outlet (store) tag filters case-insensitive

### DIFF
--- a/models/store_curation.ts
+++ b/models/store_curation.ts
@@ -28,16 +28,27 @@ export const gameOverrideVisibilitySchema = gameOverrideSchema.pick({
   visibility: true,
 });
 
+// Tag filters are stored and matched case-insensitively: "RPG" and "rpg" are
+// the same filter. We canonicalize to lowercase on write and on every lookup
+// so the (store_id, tag) unique constraint dedupes case variants, and resolve
+// back to the catalog's actual tag casing at match time (see
+// getCurationWhereClause) rather than mutating how game tags are stored.
+function normalizeTag(tag: string): string {
+  return tag.trim().toLowerCase();
+}
+
 async function addTagFilter(
   storeId: string,
   tag: string,
   mode: (typeof TAG_FILTER_MODES)[number],
 ) {
+  const normalizedTag = normalizeTag(tag);
+
   try {
     return await prisma.storeTagFilter.create({
       data: {
         store_id: storeId,
-        tag,
+        tag: normalizedTag,
         mode,
       },
     });
@@ -47,7 +58,7 @@ async function addTagFilter(
       error.code === "P2002"
     ) {
       throw new ValidationError({
-        message: `Tag "${tag}" already has a filter configured for this store.`,
+        message: `Tag "${normalizedTag}" already has a filter configured for this store.`,
         action: "Update the existing filter instead of creating a new one.",
       });
     }
@@ -56,18 +67,20 @@ async function addTagFilter(
 }
 
 async function findOneTagFilterByTag(storeId: string, tag: string) {
+  const normalizedTag = normalizeTag(tag);
+
   const filter = await prisma.storeTagFilter.findUnique({
     where: {
       store_id_tag: {
         store_id: storeId,
-        tag,
+        tag: normalizedTag,
       },
     },
   });
 
   if (!filter) {
     throw new NotFoundError({
-      message: `No filter configured for tag "${tag}" in this store.`,
+      message: `No filter configured for tag "${normalizedTag}" in this store.`,
       action: "Check the tag and try again.",
     });
   }
@@ -250,10 +263,10 @@ async function getCurationWhereClause(
 
   const whitelist = filters
     .filter((filter) => filter.mode === "WHITELIST")
-    .map((filter) => filter.tag);
+    .map((filter) => filter.tag.toLowerCase());
   const blacklist = filters
     .filter((filter) => filter.mode === "BLACKLIST")
-    .map((filter) => filter.tag);
+    .map((filter) => filter.tag.toLowerCase());
   const forceShowIds = overrides
     .filter((override) => override.visibility === "SHOW")
     .map((override) => override.game_id);
@@ -274,11 +287,27 @@ async function getCurationWhereClause(
   // even if it matches the whitelist, and a force-shown game is included even
   // if it carries a blacklisted tag or doesn't match the whitelist.
   const tagRuleWhere: Prisma.GameWhereInput = {};
-  if (whitelist.length > 0) {
-    tagRuleWhere.tags = { hasSome: whitelist };
-  }
-  if (blacklist.length > 0) {
-    tagRuleWhere.NOT = { tags: { hasSome: blacklist } };
+
+  if (whitelist.length > 0 || blacklist.length > 0) {
+    // Filter tags are stored lowercase, but game tags keep their original
+    // casing (e.g. "RPG", "Story-Rich"). Resolve each lowercase filter tag to
+    // the actual casing(s) present in the catalog so matching is
+    // case-insensitive without mutating how game tags are stored. This only
+    // runs when a store actually has tag filters configured.
+    const casingsByLowerTag = await getGameTagCasings();
+    const toGameTagCasings = (lowerTags: string[]) =>
+      lowerTags.flatMap((lowerTag) => casingsByLowerTag.get(lowerTag) ?? []);
+
+    if (whitelist.length > 0) {
+      // If the whitelist resolves to no catalog casing, hasSome:[] matches no
+      // games — the correct result for whitelisting a tag nothing carries.
+      tagRuleWhere.tags = { hasSome: toGameTagCasings(whitelist) };
+    }
+
+    const blacklistCasings = toGameTagCasings(blacklist);
+    if (blacklistCasings.length > 0) {
+      tagRuleWhere.NOT = { tags: { hasSome: blacklistCasings } };
+    }
   }
 
   return {
@@ -287,6 +316,25 @@ async function getCurationWhereClause(
       { OR: [{ id: { in: forceShowIds } }, tagRuleWhere] },
     ],
   };
+}
+
+// Returns a map of lowercased tag -> the actual casing(s) that tag appears
+// under across the games catalog, from a single DISTINCT unnest query so the
+// result stays small regardless of catalog size.
+async function getGameTagCasings(): Promise<Map<string, string[]>> {
+  const rows = await prisma.$queryRaw<{ tag: string }[]>`
+    SELECT DISTINCT unnest(tags) AS tag FROM games
+  `;
+
+  const casingsByLowerTag = new Map<string, string[]>();
+  for (const row of rows) {
+    const lowerTag = row.tag.toLowerCase();
+    const casings = casingsByLowerTag.get(lowerTag) ?? [];
+    casings.push(row.tag);
+    casingsByLowerTag.set(lowerTag, casings);
+  }
+
+  return casingsByLowerTag;
 }
 
 const storeCuration = {

--- a/prisma/migrations/20260723060000_lowercase_store_tag_filters/migration.sql
+++ b/prisma/migrations/20260723060000_lowercase_store_tag_filters/migration.sql
@@ -1,0 +1,15 @@
+-- Tag filters are now case-insensitive (stored lowercase). Collapse any
+-- existing case-variant duplicates within the same store before lowercasing,
+-- keeping the earliest row per (store_id, lower(tag)) so the (store_id, tag)
+-- unique constraint is not violated. Tie-break on id when created_at matches.
+DELETE FROM "store_tag_filters" a
+USING "store_tag_filters" b
+WHERE a."store_id" = b."store_id"
+  AND lower(a."tag") = lower(b."tag")
+  AND (
+    a."created_at" > b."created_at"
+    OR (a."created_at" = b."created_at" AND a."id" > b."id")
+  );
+
+-- Normalize the surviving rows to lowercase.
+UPDATE "store_tag_filters" SET "tag" = lower("tag") WHERE "tag" <> lower("tag");

--- a/tests/integration/api/v1/stores/[slug]/tag-filters/post.test.ts
+++ b/tests/integration/api/v1/stores/[slug]/tag-filters/post.test.ts
@@ -92,6 +92,45 @@ describe("POST /api/v1/stores/[slug]/tag-filters", () => {
       expect(responseBody.name).toBe("ValidationError");
     });
 
+    test("Adding the same tag in a different case is a duplicate (400), and tags are stored lowercase", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const ownerSession = await orchestrator.createSession(owner.id);
+      const createdStore = await orchestrator.createStore(owner.id);
+
+      const firstResponse = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/tag-filters`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${ownerSession.token}`,
+          },
+          body: JSON.stringify({ tag: "RPG", mode: "WHITELIST" }),
+        },
+      );
+
+      expect(firstResponse.status).toBe(201);
+      const firstBody = await firstResponse.json();
+      expect(firstBody.tag).toBe("rpg");
+
+      const secondResponse = await fetch(
+        `${webserver.getOrigin()}/api/v1/stores/${createdStore.slug}/tag-filters`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${ownerSession.token}`,
+          },
+          body: JSON.stringify({ tag: "rpg", mode: "BLACKLIST" }),
+        },
+      );
+
+      expect(secondResponse.status).toBe(400);
+      const secondBody = await secondResponse.json();
+      expect(secondBody.name).toBe("ValidationError");
+    });
+
     test("With invalid mode should return 400", async () => {
       const owner = await orchestrator.createUser();
       await orchestrator.activateUser(owner.id);

--- a/tests/integration/models/store_curation.test.ts
+++ b/tests/integration/models/store_curation.test.ts
@@ -145,4 +145,52 @@ describe("models/store_curation.ts curation rules", () => {
     expect(titles).toContain("Still Visible RPG");
     expect(titles).not.toContain("Force Hide RPG");
   });
+
+  test("A filter matches games case-insensitively, regardless of the case the curator typed", async () => {
+    const owner = await orchestrator.createUser();
+    await orchestrator.activateUser(owner.id);
+    const createdStore = await orchestrator.createStore(owner.id);
+
+    // Games carry mixed-case catalog tags (as CATEGORIES / Steam produce them).
+    const rpgGame = await orchestrator.createGame(owner.id, {
+      title: "CaseInsensitive RPG",
+      tags: ["RPG"],
+    });
+    await gameModel.makePublic(rpgGame.id);
+
+    const horrorGame = await orchestrator.createGame(owner.id, {
+      title: "CaseInsensitive Horror",
+      tags: ["Horror"],
+    });
+    await gameModel.makePublic(horrorGame.id);
+
+    // Curator whitelists with a different case than the game's tag.
+    await orchestrator.addStoreTagFilter(createdStore.id, "rpg", "WHITELIST");
+
+    const titles = await findCuratedTitles(createdStore.id);
+    expect(titles).toContain("CaseInsensitive RPG");
+    expect(titles).not.toContain("CaseInsensitive Horror");
+  });
+
+  test("The same tag in a different case is the same filter: stored lowercase, deduped, and resolvable by any case", async () => {
+    const owner = await orchestrator.createUser();
+    await orchestrator.activateUser(owner.id);
+    const createdStore = await orchestrator.createStore(owner.id);
+
+    const created = await orchestrator.addStoreTagFilter(
+      createdStore.id,
+      "RPG",
+      "WHITELIST",
+    );
+    expect(created.tag).toBe("rpg");
+
+    await expect(
+      orchestrator.addStoreTagFilter(createdStore.id, "rpg", "BLACKLIST"),
+    ).rejects.toThrow();
+
+    // Removing by yet another case resolves the same lowercase row.
+    await storeCuration.removeTagFilter(createdStore.id, "rPg");
+    const remaining = await storeCuration.listTagFilters(createdStore.id);
+    expect(remaining).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
Closes #152.

## Summary
"RPG" and "rpg" are now the same tag filter.

- **Write/lookup normalization**: filter tags are lowercased on write and on every lookup in `models/store_curation.ts` (`addTagFilter`, `findOneTagFilterByTag`, and thus `updateTagFilterMode`/`removeTagFilter`). The `(store_id, tag)` unique constraint now dedupes case variants, and add/update/remove resolve the same row regardless of the case typed.
- **Matching stays correct without changing game tags**: game tags keep their original casing ("RPG", "Story-Rich" from `CATEGORIES`/Steam — there's no uniform transform). `getCurationWhereClause` resolves each lowercase filter tag back to the actual casing(s) present in the catalog before matching, via a single `SELECT DISTINCT unnest(tags) FROM games` — so a filter typed as `rpg` still matches a game tagged `RPG`. That query runs only when a store actually has tag filters configured.
- **Migration** (`20260723060000_lowercase_store_tag_filters`): lowercases existing `store_tag_filters` rows, first collapsing any case-variant duplicates within a store (keeping the earliest, tie-broken on id) so the unique constraint holds. Data-only, no schema change.

## Game-tag casing finding
`game.tags` are stored mixed-case (from `lib/games.ts` `CATEGORIES` like "RPG"/"Action" and Steam genre/category names). Rather than rewrite/display-break every game tag, this PR keeps game tags untouched and does case-insensitive resolution at match time.

## Tests
- `tests/integration/models/store_curation.test.ts`: a filter typed `rpg` matches a game tagged `RPG` (and doesn't match `Horror`); the same tag in different cases is one filter — stored lowercase, deduped on re-add, and resolvable/removable by any case.
- `tests/integration/api/v1/stores/[slug]/tag-filters/post.test.ts`: POSTing `RPG` then `rpg` returns 201 then 400, and the stored `tag` comes back lowercase.

## Out of scope
No game-override changes; no change to the tag-filter API shape beyond casing; no user-facing copy changes.

Verified: `prisma validate`, ESLint, Prettier clean. Full Jest suite (incl. the migration) runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wb9H8h2atku1TG6rVn4mGc)_