### PR TITLE
feat: add public paginated outlet (store) listing endpoint

### DIFF
--- a/pages/api/v1/public/stores/index.ts
+++ b/pages/api/v1/public/stores/index.ts
@@ -1,0 +1,43 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { createRouter } from "next-connect";
+import controller from "infra/controller";
+import store, { storeAdminQuerySchema } from "models/store";
+import authorization from "models/authorization";
+import { ValidationError } from "infra/errors";
+
+export default createRouter<NextApiRequest, NextApiResponse>()
+  .use(controller.injectAnonymousOrUser)
+  .get(controller.canRequest("read:public_store"), getHandler)
+  .handler(controller.errorHandlers);
+
+async function getHandler(req: NextApiRequest, res: NextApiResponse) {
+  const result = storeAdminQuerySchema.safeParse(req.query);
+
+  if (!result.success) {
+    throw new ValidationError({
+      message: "One or more query parameters are invalid",
+      action: "Check the query parameters and try again",
+      context: result.error.issues,
+    });
+  }
+
+  const { page, limit, q } = result.data;
+
+  // No owner_id filter: this returns every outlet, unlike the owner-scoped
+  // GET /api/v1/stores. Powers the public "Discover other Outlets" browse.
+  const { stores, pagination } = await store.findAllPaginated({
+    page,
+    limit,
+    q,
+  });
+
+  const secureOutputValues = stores.map((storeItem) =>
+    authorization.filterOutput(
+      req.context.user,
+      "read:public_store",
+      storeItem,
+    ),
+  );
+
+  return res.status(200).json({ stores: secureOutputValues, pagination });
+}

--- a/tests/integration/api/v1/public/stores/get.test.ts
+++ b/tests/integration/api/v1/public/stores/get.test.ts
@@ -1,0 +1,120 @@
+import orchestrator from "tests/orchestrator";
+import webserver from "infra/webserver";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+const PUBLIC_STORE_FIELDS = [
+  "id",
+  "slug",
+  "name",
+  "description",
+  "logo_url",
+  "owner_id",
+  "created_at",
+  "updated_at",
+].sort();
+
+describe("GET /api/v1/public/stores", () => {
+  describe("Anonymous user", () => {
+    test("Returns a paginated list of all outlets, not scoped to one owner", async () => {
+      const ownerA = await orchestrator.createUser();
+      await orchestrator.activateUser(ownerA.id);
+      const storeA = await orchestrator.createStore(ownerA.id, {
+        name: "Public Directory Alpha",
+      });
+
+      const ownerB = await orchestrator.createUser();
+      await orchestrator.activateUser(ownerB.id);
+      const storeB = await orchestrator.createStore(ownerB.id, {
+        name: "Public Directory Beta",
+      });
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/public/stores`,
+      );
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+      const slugs = responseBody.stores.map(
+        (item: { slug: string }) => item.slug,
+      );
+      expect(slugs).toContain(storeA.slug);
+      expect(slugs).toContain(storeB.slug);
+
+      expect(responseBody.pagination).toEqual({
+        page: 1,
+        limit: 20,
+        total: expect.any(Number),
+        pages: expect.any(Number),
+      });
+      expect(responseBody.pagination.total).toBeGreaterThanOrEqual(2);
+    });
+
+    test("Each item exposes only the read:public_store fields", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      await orchestrator.createStore(owner.id, { name: "ShapeCheckOutlet" });
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/public/stores?q=ShapeCheckOutlet`,
+      );
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+      expect(responseBody.stores.length).toBeGreaterThanOrEqual(1);
+      for (const item of responseBody.stores) {
+        expect(Object.keys(item).sort()).toEqual(PUBLIC_STORE_FIELDS);
+      }
+    });
+
+    test("Supports the q search filter", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const target = await orchestrator.createStore(owner.id, {
+        name: "Zzyzx Unique Outlet",
+      });
+      await orchestrator.createStore(owner.id, { name: "Unrelated Outlet" });
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/public/stores?q=Zzyzx`,
+      );
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+      const slugs = responseBody.stores.map(
+        (item: { slug: string }) => item.slug,
+      );
+      expect(slugs).toContain(target.slug);
+      expect(
+        responseBody.stores.every((item: { name: string }) =>
+          item.name.toLowerCase().includes("zzyzx"),
+        ),
+      ).toBe(true);
+    });
+
+    test("Supports pagination via limit", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      await orchestrator.createStore(owner.id);
+      await orchestrator.createStore(owner.id);
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/public/stores?limit=1`,
+      );
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+      expect(responseBody.stores).toHaveLength(1);
+      expect(responseBody.pagination.limit).toBe(1);
+      expect(responseBody.pagination.total).toBeGreaterThanOrEqual(2);
+      expect(responseBody.pagination.pages).toBeGreaterThanOrEqual(2);
+    });
+  });
+});


### PR DESCRIPTION
Closes #153.

## Summary
Adds `GET /api/v1/public/stores` — a public, anonymous-accessible, paginated list of **all** outlets, to power the upcoming "Discover other Outlets" section.

- Gated on `read:public_store` (anonymous users already hold it via `injectAnonymousUser`).
- Passes **no** `owner_id` to `store.findAllPaginated`, so it returns every outlet — unlike the owner-scoped `GET /api/v1/stores`, which is untouched.
- Every item runs through `authorization.filterOutput(user, "read:public_store", ...)` (id, slug, name, description, logo_url, owner_id, created_at, updated_at).
- `page`/`limit`/`q` Zod-validated via the existing pagination schema.

## Tests
`tests/integration/api/v1/public/stores/get.test.ts`: anonymous gets a paginated list spanning multiple owners (not owner-scoped); each item exposes only the `read:public_store` fields; the `q` search filter works; `limit` pagination works.

## Out of scope
No frontend (Discover UI is #157). No write methods on this route; `read:public_store` output shape unchanged.

Verified: ESLint/Prettier clean, no type errors. Full Jest suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wb9H8h2atku1TG6rVn4mGc)_