### PR TITLE
feat: add "Discover other Outlets" section to the main storefront

### DIFF
--- a/components/store/DiscoverOutlets.tsx
+++ b/components/store/DiscoverOutlets.tsx
@@ -1,0 +1,91 @@
+import Link from "next/link";
+import useSWR from "swr";
+
+interface PublicOutlet {
+  id: string;
+  slug: string;
+  name: string;
+  description: string | null;
+  logo_url: string | null;
+}
+
+interface PublicOutletsResponse {
+  stores: PublicOutlet[];
+}
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+// Renders at the bottom of the MAIN storefront only (gated by the Storefront
+// `showDiscover` prop) so shoppers can find other creators' outlets. Data
+// comes from the public GET /api/v1/public/stores listing.
+export function DiscoverOutlets() {
+  const { data, isLoading } = useSWR<PublicOutletsResponse>(
+    "/api/v1/public/stores?limit=12",
+    fetcher,
+  );
+
+  const outlets = data?.stores ?? [];
+
+  return (
+    <section className="w-full py-12 md:py-20 border-t border-white/5">
+      <div className="max-w-7xl mx-auto px-6 md:px-10 flex flex-col gap-8">
+        <div className="flex flex-col gap-3 max-w-2xl">
+          <h2 className="text-3xl md:text-4xl font-black">
+            Discover other Outlets
+          </h2>
+          <p className="text-white/50 font-bold">
+            Browse storefronts curated by creators across Manifold — each with
+            its own taste, its own picks, and the same catalog behind it.
+          </p>
+        </div>
+
+        {isLoading ? (
+          <div className="py-10 flex justify-center">
+            <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-white/30" />
+          </div>
+        ) : outlets.length === 0 ? (
+          <p className="text-white/30 font-bold italic">
+            No other outlets to show yet.
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {outlets.map((outlet) => (
+              <Link
+                key={outlet.id}
+                href={`/store/${outlet.slug}`}
+                className="flex items-center gap-4 rounded-2xl border border-white/10 bg-white/5 p-5 hover:bg-white/10 transition-colors min-w-0"
+              >
+                <div className="shrink-0 w-12 h-12 rounded-xl bg-white/10 overflow-hidden flex items-center justify-center">
+                  {outlet.logo_url ? (
+                    // Outlet logos are arbitrary user-supplied URLs, so next/image
+                    // (host-allowlisted) can't be used here.
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={outlet.logo_url}
+                      alt={`${outlet.name} logo`}
+                      className="w-full h-full object-cover"
+                    />
+                  ) : (
+                    <span className="text-lg font-black text-white/60">
+                      {outlet.name.charAt(0).toUpperCase()}
+                    </span>
+                  )}
+                </div>
+                <div className="min-w-0">
+                  <p className="font-black text-white truncate">
+                    {outlet.name}
+                  </p>
+                  {outlet.description && (
+                    <p className="text-sm font-bold text-white/50 line-clamp-2">
+                      {outlet.description}
+                    </p>
+                  )}
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/components/store/Storefront.tsx
+++ b/components/store/Storefront.tsx
@@ -12,6 +12,7 @@ import { DiscountBadge } from "components/store/DiscountBadge";
 import { SectionDivider } from "components/store/SectionDivider";
 import { discountBadgeColor } from "components/store/constants";
 import { GameListItem, type GameApi } from "components/store/GameListItem";
+import { DiscoverOutlets } from "components/store/DiscoverOutlets";
 
 function HeroBento({
   featured,
@@ -208,6 +209,8 @@ export type StorefrontProps = {
   heading?: string;
   /** When set, item links carry `?store=` so acquisitions attribute to this store. */
   storeSlug?: string;
+  /** Renders the "Discover other Outlets" section at the bottom. Main storefront only. */
+  showDiscover?: boolean;
 };
 
 export function Storefront({
@@ -219,6 +222,7 @@ export function Storefront({
   metaDescription,
   heading = "Just Arrived at Manifold",
   storeSlug,
+  showDiscover = false,
 }: StorefrontProps) {
   const searchParams = useSearchParams();
   const q = searchParams.get("q");
@@ -348,6 +352,7 @@ export function Storefront({
             </div>
           </div>
         </div>
+        {showDiscover && <DiscoverOutlets />}
       </main>
 
       <style jsx global>{`

--- a/pages/store/index.tsx
+++ b/pages/store/index.tsx
@@ -11,6 +11,7 @@ export default function StoreOption2() {
       searchPagePath="/search"
       pageTitle="Discover (Dark) | Manifold Outlets"
       metaDescription="Explore the best games curated by the community in premium dark mode."
+      showDiscover
     />
   );
 }


### PR DESCRIPTION
Closes #157.

## Summary
A "Discover other Outlets" grid now sits at the bottom of the **main** storefront, powered by the public `GET /api/v1/public/stores` listing (#153).

- **`components/store/DiscoverOutlets.tsx`** (new): heading + intro (verbatim), then a responsive grid (1 / 2 / 3 columns) of outlet cards — logo, name, description — each linking to `/store/[slug]`. Loading and empty states handled. Outlet logos use a plain `<img>` because `logo_url` is an arbitrary user-supplied host that `next/image`'s allowlist (`next.config.ts`) doesn't cover.
- **`components/store/Storefront.tsx`**: new optional `showDiscover` prop; the section renders only when it's set.
- **`pages/store/index.tsx`**: the main storefront opts in (`showDiscover`). Per-store pages (`pages/store/[slug].tsx`) reuse `<Storefront/>` without the prop, so the section does **not** appear there.

## Tests
The project has no component/page render-test harness (all tests are API-integration tests run against the dev server; no jsdom/testing-library). The main-vs-per-store gating is therefore enforced by the `showDiscover` prop and verified by inspection rather than a new render test — flagging this as a conscious deviation from the issue's "add a render test" line.

## Out of scope
No backend changes (endpoint shipped in #153). Section never renders on individual outlet pages.

Verified: ESLint/Prettier clean, no type errors. Full Jest suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wb9H8h2atku1TG6rVn4mGc)_