### PR TITLE
fix: harden studio management pages for small screens

### DIFF
--- a/pages/studio/[slug]/games/steam-import.tsx
+++ b/pages/studio/[slug]/games/steam-import.tsx
@@ -98,7 +98,7 @@ export default function StudioSteamImportPage() {
           <div>
             <h1 className="text-2xl font-black">Import from Steam</h1>
             {studio && (
-              <p className="text-white/50 text-sm font-bold mt-1">
+              <p className="text-white/50 text-sm font-bold mt-1 break-words">
                 Importing into {studio.name}
               </p>
             )}

--- a/pages/studio/[slug]/index.tsx
+++ b/pages/studio/[slug]/index.tsx
@@ -46,16 +46,18 @@ export default function StudioPage() {
                 <img
                   src={studio.logo_url}
                   alt={`${studio.name} logo`}
-                  className="w-16 h-16 rounded-2xl object-cover border border-white/10 bg-white/5"
+                  className="w-16 h-16 shrink-0 rounded-2xl object-cover border border-white/10 bg-white/5"
                 />
               ) : (
-                <div className="w-16 h-16 rounded-2xl flex items-center justify-center border border-white/10 bg-white/5 text-white/30">
+                <div className="w-16 h-16 shrink-0 rounded-2xl flex items-center justify-center border border-white/10 bg-white/5 text-white/30">
                   <Building2 size={28} />
                 </div>
               )}
 
-              <div>
-                <h1 className="text-2xl font-black">{studio.name}</h1>
+              <div className="min-w-0">
+                <h1 className="text-2xl font-black break-words">
+                  {studio.name}
+                </h1>
                 {studio.is_publisher && (
                   <span className="inline-block mt-1 px-2 py-0.5 rounded-lg bg-white/10 text-white/60 text-xs font-black uppercase tracking-wider">
                     Publisher

--- a/pages/studio/index.tsx
+++ b/pages/studio/index.tsx
@@ -65,7 +65,7 @@ export default function MyStudiosPage() {
               <Link
                 key={studio.id}
                 href={`/studio/${studio.slug}`}
-                className="px-4 py-3 rounded-xl border border-white/10 bg-white/5 font-bold text-white hover:bg-white/10 transition-colors"
+                className="px-4 py-3 rounded-xl border border-white/10 bg-white/5 font-bold text-white hover:bg-white/10 transition-colors break-words"
               >
                 {studio.name}
               </Link>


### PR DESCRIPTION
Closes #154.

## Summary
Audited the three studio-management pages at ~320px. They were **already responsive** — centered `max-w-md` card layouts, `px-4` padding, full-width inputs, `py-3` touch targets, and no wide/overflowing tables (the Steam import screen is a single-input form, not a table). The one remaining ~320px overflow risk was a long studio name, which this PR hardens:

- **`studio/[slug]/index.tsx`**: the logo is `shrink-0` and the name column is `min-w-0` with `break-words`, so a long name wraps instead of pushing the header past the viewport.
- **`studio/index.tsx`** and **`studio/[slug]/games/steam-import.tsx`**: studio-name displays get `break-words` for the same reason.

## Verification
Reasoned through mobile / tablet / desktop breakpoints. No functional or copy changes. ESLint/Prettier clean; full Jest suite runs in CI.

## Out of scope
Backoffice responsiveness is #155 (the last of the responsiveness slices).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wb9H8h2atku1TG6rVn4mGc)_