### PR TITLE
fix: make the backoffice navigable and usable on small screens

### DIFF
--- a/components/backoffice/BackofficeLayout.tsx
+++ b/components/backoffice/BackofficeLayout.tsx
@@ -62,7 +62,7 @@ export function BackofficeLayout({ children }: { children: ReactNode }) {
   return (
     <div className="min-h-screen bg-[#1D0F3B] text-white">
       <BackofficeTopNav username={user.username} />
-      <main className="pt-24 pb-16 px-4 md:px-10 max-w-7xl mx-auto">
+      <main className="pt-32 md:pt-24 pb-16 px-4 md:px-10 max-w-7xl mx-auto">
         {children}
       </main>
     </div>

--- a/components/backoffice/BackofficeTopNav.tsx
+++ b/components/backoffice/BackofficeTopNav.tsx
@@ -27,60 +27,72 @@ export function BackofficeTopNav({ username }: { username: string }) {
     router.push("/store");
   }
 
+  const renderNavLinks = () =>
+    NAV_ITEMS.map(({ href, label, icon: Icon }) => {
+      const isActive =
+        router.pathname === href ||
+        (href !== "/backoffice" && router.pathname.startsWith(href));
+      return (
+        <Link
+          key={href}
+          href={href}
+          className={`flex shrink-0 items-center gap-2 px-3 py-2 rounded-xl text-sm font-bold tracking-wide transition-all ${
+            isActive
+              ? "bg-white/10 text-white"
+              : "text-white/60 hover:text-white hover:bg-white/5"
+          }`}
+        >
+          <Icon size={16} />
+          {label}
+        </Link>
+      );
+    });
+
   return (
     <header className="fixed top-0 inset-x-0 z-50 bg-[#130b25]/90 backdrop-blur-xl border-b border-white/10 py-3 px-4 md:px-10">
-      <div className="max-w-7xl mx-auto flex items-center justify-between gap-4">
-        <div className="flex items-center gap-6 min-w-0">
-          <Link
-            href="/backoffice"
-            className="flex items-center gap-2 font-black text-lg tracking-tight text-white shrink-0"
-          >
-            <ShieldCheck size={20} className="text-indigo-400" />
-            <span className="hidden sm:inline">Manifold Admin</span>
-          </Link>
+      <div className="max-w-7xl mx-auto flex flex-col gap-3">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-6 min-w-0">
+            <Link
+              href="/backoffice"
+              className="flex items-center gap-2 font-black text-lg tracking-tight text-white shrink-0"
+            >
+              <ShieldCheck size={20} className="text-indigo-400" />
+              <span className="hidden sm:inline">Manifold Admin</span>
+            </Link>
 
-          <nav className="hidden md:flex items-center gap-1">
-            {NAV_ITEMS.map(({ href, label, icon: Icon }) => {
-              const isActive =
-                router.pathname === href ||
-                (href !== "/backoffice" && router.pathname.startsWith(href));
-              return (
-                <Link
-                  key={href}
-                  href={href}
-                  className={`flex items-center gap-2 px-3 py-2 rounded-xl text-sm font-bold tracking-wide transition-all ${
-                    isActive
-                      ? "bg-white/10 text-white"
-                      : "text-white/60 hover:text-white hover:bg-white/5"
-                  }`}
-                >
-                  <Icon size={16} />
-                  {label}
-                </Link>
-              );
-            })}
-          </nav>
+            <nav className="hidden md:flex items-center gap-1">
+              {renderNavLinks()}
+            </nav>
+          </div>
+
+          <div className="flex items-center gap-3 shrink-0">
+            <Link
+              href="/store"
+              className="hidden sm:flex items-center gap-2 px-3 py-2 rounded-xl text-white/50 hover:text-white hover:bg-white/5 text-xs font-bold uppercase tracking-wider transition-colors"
+            >
+              <ArrowLeft size={14} />
+              Back to Store
+            </Link>
+            <span className="hidden lg:inline text-sm font-bold text-white/70">
+              {username}
+            </span>
+            <button
+              onClick={handleSignOut}
+              aria-label="Sign out"
+              className="flex items-center gap-2 px-3 py-2 rounded-xl text-white/60 hover:text-rose-400 hover:bg-rose-500/10 text-sm font-bold transition-colors"
+            >
+              <LogOut size={16} />
+            </button>
+          </div>
         </div>
 
-        <div className="flex items-center gap-3 shrink-0">
-          <Link
-            href="/store"
-            className="hidden sm:flex items-center gap-2 px-3 py-2 rounded-xl text-white/50 hover:text-white hover:bg-white/5 text-xs font-bold uppercase tracking-wider transition-colors"
-          >
-            <ArrowLeft size={14} />
-            Back to Store
-          </Link>
-          <span className="hidden lg:inline text-sm font-bold text-white/70">
-            {username}
-          </span>
-          <button
-            onClick={handleSignOut}
-            aria-label="Sign out"
-            className="flex items-center gap-2 px-3 py-2 rounded-xl text-white/60 hover:text-rose-400 hover:bg-rose-500/10 text-sm font-bold transition-colors"
-          >
-            <LogOut size={16} />
-          </button>
-        </div>
+        {/* Mobile navigation: a horizontally scrollable strip. The inline nav
+            above is desktop-only (md+), so without this an admin on a phone
+            had no way to move between backoffice sections. */}
+        <nav className="md:hidden -mx-4 flex items-center gap-1 overflow-x-auto px-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+          {renderNavLinks()}
+        </nav>
       </div>
     </header>
   );


### PR DESCRIPTION
Closes #155.

## Summary
The backoffice **list/detail pages were already mobile-safe** — dense tables are wrapped in `overflow-x-auto` containers, toolbars use `flex-wrap`, search fields reflow, and modals are `px-4`/`max-w-md`. The real gap was navigation: `BackofficeTopNav` hid the section links entirely below `md` with no fallback, so an admin on a phone couldn't move between Dashboard / Games / Users / Studios / Stores at all.

- **`BackofficeTopNav`**: the section links now also render as a **horizontally scrollable strip** below the header on mobile (the inline nav stays desktop-only at `md+`); nav rendering is shared via a small `renderNavLinks` helper.
- **`BackofficeLayout`**: top padding is `pt-32` on mobile (accounting for the taller two-row header) and `pt-24` at `md+`.

## Verification
Reasoned through ~320px / tablet / desktop. No functional or copy changes. ESLint/Prettier clean; full Jest suite runs in CI.

This is the last of the three responsiveness slices (#158 outlet, #154 studio, #155 backoffice) and the final issue in the batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wb9H8h2atku1TG6rVn4mGc)_