### PR TITLE
fix: My Outlets/My Studios resolve to owned or member-of

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,7 @@ build
 
 /generated/prisma
 
-.envtsconfig.tsbuildinfo
+.env
+
+# TypeScript incremental build info
+tsconfig.tsbuildinfo

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ build
 
 /generated/prisma
 
-.env
+.envtsconfig.tsbuildinfo

--- a/models/store.ts
+++ b/models/store.ts
@@ -124,6 +124,38 @@ async function findAllPaginated({
   };
 }
 
+// Every store the user can act on: those they own plus those they're a member
+// of (via StoreMember). Powers the "My Outlets" resolver. There is no
+// Store<->StoreMember relation (the repo forbids foreign keys), so the
+// membership side is resolved to store ids first, then those stores are
+// fetched by id and unioned with the owned ones. Owned and member sets are
+// disjoint (addMember rejects the owner) but we dedup defensively. Ordered
+// owned-first, then alphabetical by name within each group.
+async function findAllForUser(userId: string) {
+  const [ownedStores, memberRows] = await Promise.all([
+    prisma.store.findMany({ where: { owner_id: userId } }),
+    prisma.storeMember.findMany({
+      where: { user_id: userId },
+      select: { store_id: true },
+    }),
+  ]);
+
+  const ownedIds = new Set(ownedStores.map((store) => store.id));
+  const memberStoreIds = memberRows
+    .map((row) => row.store_id)
+    .filter((id) => !ownedIds.has(id));
+
+  const memberStores =
+    memberStoreIds.length > 0
+      ? await prisma.store.findMany({ where: { id: { in: memberStoreIds } } })
+      : [];
+
+  const byName = (a: { name: string }, b: { name: string }) =>
+    a.name.localeCompare(b.name);
+
+  return [...ownedStores.sort(byName), ...memberStores.sort(byName)];
+}
+
 async function findOneBySlug(slug: string) {
   const store = await prisma.store.findUnique({
     where: {
@@ -350,6 +382,7 @@ async function listMembersWithUsernames(storeId: string) {
 const store = {
   create,
   findAllPaginated,
+  findAllForUser,
   findOneBySlug,
   findOneBySlugWithMembers,
   update,

--- a/models/studio.ts
+++ b/models/studio.ts
@@ -134,6 +134,40 @@ async function findAllPaginated({
   };
 }
 
+// Every studio the user can act on: those they own plus those they're a member
+// of (via StudioMember). Powers the "My Studios" resolver. There is no
+// Studio<->StudioMember relation (the repo forbids foreign keys), so the
+// membership side is resolved to studio ids first, then those studios are
+// fetched by id and unioned with the owned ones. Owned and member sets are
+// disjoint (addMember rejects the owner) but we dedup defensively. Ordered
+// owned-first, then alphabetical by name within each group.
+async function findAllForUser(userId: string) {
+  const [ownedStudios, memberRows] = await Promise.all([
+    prisma.studio.findMany({ where: { owner_id: userId } }),
+    prisma.studioMember.findMany({
+      where: { user_id: userId },
+      select: { studio_id: true },
+    }),
+  ]);
+
+  const ownedIds = new Set(ownedStudios.map((studio) => studio.id));
+  const memberStudioIds = memberRows
+    .map((row) => row.studio_id)
+    .filter((id) => !ownedIds.has(id));
+
+  const memberStudios =
+    memberStudioIds.length > 0
+      ? await prisma.studio.findMany({
+          where: { id: { in: memberStudioIds } },
+        })
+      : [];
+
+  const byName = (a: { name: string }, b: { name: string }) =>
+    a.name.localeCompare(b.name);
+
+  return [...ownedStudios.sort(byName), ...memberStudios.sort(byName)];
+}
+
 async function findOneById(id: string) {
   const studio = await prisma.studio.findUnique({
     where: {
@@ -390,6 +424,7 @@ async function listMembersWithUsernames(studioId: string) {
 const studio = {
   create,
   findAllPaginated,
+  findAllForUser,
   findOneById,
   findOneByIdWithMembers,
   findOneBySlug,

--- a/pages/api/v1/stores/index.ts
+++ b/pages/api/v1/stores/index.ts
@@ -12,9 +12,10 @@ export default createRouter<NextApiRequest, NextApiResponse>()
   .handler(controller.errorHandlers);
 
 async function getHandler(req: NextApiRequest, res: NextApiResponse) {
-  const { stores, pagination } = await store.findAllPaginated({
-    owner_id: req.context.user.id,
-  });
+  // "My Outlets": stores the user owns OR is a member of (see
+  // store.findAllForUser). The full set is returned unpaginated; the
+  // pagination envelope is kept for response-shape compatibility.
+  const stores = await store.findAllForUser(req.context.user.id);
 
   const secureOutputValues = stores.map((storeItem) =>
     authorization.filterOutput(req.context.user, "create:store", storeItem),
@@ -22,7 +23,12 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
 
   return res.status(200).json({
     stores: secureOutputValues,
-    pagination,
+    pagination: {
+      page: 1,
+      limit: stores.length,
+      total: stores.length,
+      pages: stores.length > 0 ? 1 : 0,
+    },
   });
 }
 

--- a/pages/api/v1/studios/index.ts
+++ b/pages/api/v1/studios/index.ts
@@ -12,9 +12,10 @@ export default createRouter<NextApiRequest, NextApiResponse>()
   .handler(controller.errorHandlers);
 
 async function getHandler(req: NextApiRequest, res: NextApiResponse) {
-  const { studios, pagination } = await studio.findAllPaginated({
-    owner_id: req.context.user.id,
-  });
+  // "My Studios": studios the user owns OR is a member of (see
+  // studio.findAllForUser). The full set is returned unpaginated; the
+  // pagination envelope is kept for response-shape compatibility.
+  const studios = await studio.findAllForUser(req.context.user.id);
 
   const secureOutputValues = studios.map((studioItem) =>
     authorization.filterOutput(req.context.user, "create:studio", studioItem),
@@ -22,7 +23,12 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
 
   return res.status(200).json({
     studios: secureOutputValues,
-    pagination,
+    pagination: {
+      page: 1,
+      limit: studios.length,
+      total: studios.length,
+      pages: studios.length > 0 ? 1 : 0,
+    },
   });
 }
 

--- a/pages/store/mine.tsx
+++ b/pages/store/mine.tsx
@@ -9,10 +9,15 @@ interface Store {
   id: string;
   slug: string;
   name: string;
+  owner_id: string;
 }
 
 interface StoresResponse {
   stores: Store[];
+}
+
+interface CurrentUser {
+  id: string;
 }
 
 const fetcher = (url: string) =>
@@ -29,6 +34,10 @@ export default function MyStoresPage() {
     fetcher,
     { shouldRetryOnError: false },
   );
+
+  const { data: currentUser } = useSWR<CurrentUser>("/api/v1/user", fetcher, {
+    shouldRetryOnError: false,
+  });
 
   useEffect(() => {
     if (isLoading) return;
@@ -60,14 +69,24 @@ export default function MyStoresPage() {
           <Loader2 className="animate-spin text-white/30" />
         ) : (
           <div className="w-full max-w-md flex flex-col gap-4">
-            <h1 className="text-2xl font-black">My Outlets</h1>
+            <div>
+              <h1 className="text-2xl font-black">Choose an Outlet</h1>
+              <p className="text-white/50 text-sm font-bold mt-1">
+                Pick which one to open.
+              </p>
+            </div>
             {stores.map((storeItem) => (
               <Link
                 key={storeItem.id}
                 href={`/store/${storeItem.slug}`}
-                className="px-4 py-3 rounded-xl border border-white/10 bg-white/5 font-bold text-white hover:bg-white/10 transition-colors"
+                className="flex items-center justify-between gap-3 px-4 py-3 rounded-xl border border-white/10 bg-white/5 font-bold text-white hover:bg-white/10 transition-colors"
               >
-                {storeItem.name}
+                <span className="truncate">{storeItem.name}</span>
+                {currentUser && (
+                  <span className="shrink-0 px-2 py-0.5 rounded-md bg-white/10 text-white/60 text-xs font-black uppercase tracking-wider">
+                    {storeItem.owner_id === currentUser.id ? "Owner" : "Member"}
+                  </span>
+                )}
               </Link>
             ))}
           </div>

--- a/pages/studio/index.tsx
+++ b/pages/studio/index.tsx
@@ -9,10 +9,15 @@ interface Studio {
   id: string;
   slug: string;
   name: string;
+  owner_id: string;
 }
 
 interface StudiosResponse {
   studios: Studio[];
+}
+
+interface CurrentUser {
+  id: string;
 }
 
 const fetcher = (url: string) =>
@@ -29,6 +34,10 @@ export default function MyStudiosPage() {
     fetcher,
     { shouldRetryOnError: false },
   );
+
+  const { data: currentUser } = useSWR<CurrentUser>("/api/v1/user", fetcher, {
+    shouldRetryOnError: false,
+  });
 
   useEffect(() => {
     if (isLoading) return;
@@ -60,14 +69,24 @@ export default function MyStudiosPage() {
           <Loader2 className="animate-spin text-white/30" />
         ) : (
           <div className="w-full max-w-md flex flex-col gap-4">
-            <h1 className="text-2xl font-black">My Studios</h1>
+            <div>
+              <h1 className="text-2xl font-black">Choose a Studio</h1>
+              <p className="text-white/50 text-sm font-bold mt-1">
+                Pick which one to open.
+              </p>
+            </div>
             {studios.map((studio) => (
               <Link
                 key={studio.id}
                 href={`/studio/${studio.slug}`}
-                className="px-4 py-3 rounded-xl border border-white/10 bg-white/5 font-bold text-white hover:bg-white/10 transition-colors break-words"
+                className="flex items-center justify-between gap-3 px-4 py-3 rounded-xl border border-white/10 bg-white/5 font-bold text-white hover:bg-white/10 transition-colors"
               >
-                {studio.name}
+                <span className="truncate">{studio.name}</span>
+                {currentUser && (
+                  <span className="shrink-0 px-2 py-0.5 rounded-md bg-white/10 text-white/60 text-xs font-black uppercase tracking-wider">
+                    {studio.owner_id === currentUser.id ? "Owner" : "Member"}
+                  </span>
+                )}
               </Link>
             ))}
           </div>

--- a/tests/integration/api/v1/stores/get.test.ts
+++ b/tests/integration/api/v1/stores/get.test.ts
@@ -24,34 +24,77 @@ describe("GET /api/v1/stores", () => {
   });
 
   describe("Authenticated user", () => {
-    test("Should return only the requesting user's own stores", async () => {
-      const owner = await orchestrator.createUser();
-      await orchestrator.activateUser(owner.id);
-      const ownerSession = await orchestrator.createSession(owner.id);
-      const ownedStore = await orchestrator.createStore(owner.id, {
-        name: "My Owned Store",
+    test("Returns stores the user owns and stores they are a member of, but not others'", async () => {
+      const user = await orchestrator.createUser();
+      await orchestrator.activateUser(user.id);
+      const session = await orchestrator.createSession(user.id);
+
+      const ownedStore = await orchestrator.createStore(user.id, {
+        name: "Owned Store",
       });
 
-      const otherUser = await orchestrator.createUser();
-      await orchestrator.activateUser(otherUser.id);
-      await orchestrator.createStore(otherUser.id, {
-        name: "Someone Elses Store",
+      // A store owned by someone else, that our user is a MEMBER of.
+      const otherOwner = await orchestrator.createUser();
+      await orchestrator.activateUser(otherOwner.id);
+      const memberStore = await orchestrator.createStore(otherOwner.id, {
+        name: "Member Store",
+      });
+      await orchestrator.addStoreMember(memberStore.id, user.username, [
+        "update:store",
+      ]);
+
+      // A store our user neither owns nor belongs to.
+      const unrelatedStore = await orchestrator.createStore(otherOwner.id, {
+        name: "Unrelated Store",
       });
 
       const response = await fetch(`${webserver.getOrigin()}/api/v1/stores`, {
-        headers: { Cookie: `session_id=${ownerSession.token}` },
+        headers: { Cookie: `session_id=${session.token}` },
       });
 
       expect(response.status).toBe(200);
 
       const responseBody = await response.json();
-      expect(responseBody.stores).toHaveLength(1);
-      expect(responseBody.stores[0].id).toBe(ownedStore.id);
-      expect(responseBody.stores[0].name).toBe("My Owned Store");
-      expect(responseBody.pagination.total).toBe(1);
+      const ids = responseBody.stores.map((item: { id: string }) => item.id);
+      expect(ids).toContain(ownedStore.id);
+      expect(ids).toContain(memberStore.id);
+      expect(ids).not.toContain(unrelatedStore.id);
+      expect(responseBody.stores).toHaveLength(2);
+      expect(responseBody.pagination.total).toBe(2);
     });
 
-    test("With zero stores should return an empty list", async () => {
+    test("Lists owned stores before member-of stores", async () => {
+      const user = await orchestrator.createUser();
+      await orchestrator.activateUser(user.id);
+      const session = await orchestrator.createSession(user.id);
+
+      // Owned name sorts AFTER the member name alphabetically, so if owned
+      // still comes first the owned-first ordering is proven.
+      const ownedStore = await orchestrator.createStore(user.id, {
+        name: "Zeta Owned Store",
+      });
+
+      const otherOwner = await orchestrator.createUser();
+      await orchestrator.activateUser(otherOwner.id);
+      const memberStore = await orchestrator.createStore(otherOwner.id, {
+        name: "Alpha Member Store",
+      });
+      await orchestrator.addStoreMember(memberStore.id, user.username, [
+        "update:store",
+      ]);
+
+      const response = await fetch(`${webserver.getOrigin()}/api/v1/stores`, {
+        headers: { Cookie: `session_id=${session.token}` },
+      });
+
+      const responseBody = await response.json();
+      const ids = responseBody.stores.map((item: { id: string }) => item.id);
+      expect(ids.indexOf(ownedStore.id)).toBeLessThan(
+        ids.indexOf(memberStore.id),
+      );
+    });
+
+    test("With no owned or member stores should return an empty list", async () => {
       const user = await orchestrator.createUser();
       await orchestrator.activateUser(user.id);
       const session = await orchestrator.createSession(user.id);

--- a/tests/integration/api/v1/studios/get.test.ts
+++ b/tests/integration/api/v1/studios/get.test.ts
@@ -24,34 +24,77 @@ describe("GET /api/v1/studios", () => {
   });
 
   describe("Authenticated user", () => {
-    test("Should return only the requesting user's own studios", async () => {
-      const owner = await orchestrator.createUser();
-      await orchestrator.activateUser(owner.id);
-      const ownerSession = await orchestrator.createSession(owner.id);
-      const ownedStudio = await orchestrator.createStudio(owner.id, {
-        name: "My Owned Studio",
+    test("Returns studios the user owns and studios they are a member of, but not others'", async () => {
+      const user = await orchestrator.createUser();
+      await orchestrator.activateUser(user.id);
+      const session = await orchestrator.createSession(user.id);
+
+      const ownedStudio = await orchestrator.createStudio(user.id, {
+        name: "Owned Studio",
       });
 
-      const otherUser = await orchestrator.createUser();
-      await orchestrator.activateUser(otherUser.id);
-      await orchestrator.createStudio(otherUser.id, {
-        name: "Someone Elses Studio",
+      // A studio owned by someone else, that our user is a MEMBER of.
+      const otherOwner = await orchestrator.createUser();
+      await orchestrator.activateUser(otherOwner.id);
+      const memberStudio = await orchestrator.createStudio(otherOwner.id, {
+        name: "Member Studio",
+      });
+      await orchestrator.addStudioMember(memberStudio.id, user.username, [
+        "update:studio",
+      ]);
+
+      // A studio our user neither owns nor belongs to.
+      const unrelatedStudio = await orchestrator.createStudio(otherOwner.id, {
+        name: "Unrelated Studio",
       });
 
       const response = await fetch(`${webserver.getOrigin()}/api/v1/studios`, {
-        headers: { Cookie: `session_id=${ownerSession.token}` },
+        headers: { Cookie: `session_id=${session.token}` },
       });
 
       expect(response.status).toBe(200);
 
       const responseBody = await response.json();
-      expect(responseBody.studios).toHaveLength(1);
-      expect(responseBody.studios[0].id).toBe(ownedStudio.id);
-      expect(responseBody.studios[0].name).toBe("My Owned Studio");
-      expect(responseBody.pagination.total).toBe(1);
+      const ids = responseBody.studios.map((item: { id: string }) => item.id);
+      expect(ids).toContain(ownedStudio.id);
+      expect(ids).toContain(memberStudio.id);
+      expect(ids).not.toContain(unrelatedStudio.id);
+      expect(responseBody.studios).toHaveLength(2);
+      expect(responseBody.pagination.total).toBe(2);
     });
 
-    test("With zero studios should return an empty list", async () => {
+    test("Lists owned studios before member-of studios", async () => {
+      const user = await orchestrator.createUser();
+      await orchestrator.activateUser(user.id);
+      const session = await orchestrator.createSession(user.id);
+
+      // Owned name sorts AFTER the member name alphabetically, so if owned
+      // still comes first the owned-first ordering is proven.
+      const ownedStudio = await orchestrator.createStudio(user.id, {
+        name: "Zeta Owned Studio",
+      });
+
+      const otherOwner = await orchestrator.createUser();
+      await orchestrator.activateUser(otherOwner.id);
+      const memberStudio = await orchestrator.createStudio(otherOwner.id, {
+        name: "Alpha Member Studio",
+      });
+      await orchestrator.addStudioMember(memberStudio.id, user.username, [
+        "update:studio",
+      ]);
+
+      const response = await fetch(`${webserver.getOrigin()}/api/v1/studios`, {
+        headers: { Cookie: `session_id=${session.token}` },
+      });
+
+      const responseBody = await response.json();
+      const ids = responseBody.studios.map((item: { id: string }) => item.id);
+      expect(ids.indexOf(ownedStudio.id)).toBeLessThan(
+        ids.indexOf(memberStudio.id),
+      );
+    });
+
+    test("With no owned or member studios should return an empty list", async () => {
       const user = await orchestrator.createUser();
       await orchestrator.activateUser(user.id);
       const session = await orchestrator.createSession(user.id);


### PR DESCRIPTION
## Problem

From the storefront account menu, **My Outlets** (→ `/store/mine`) and **My Studios** (→ `/studio`) always sent the user to a create page when they owned no store/studio — ignoring memberships entirely. A collaborator who was a *member* (not owner) of an outlet/studio was treated as having none and wrongly bounced to the create page. An owner of one who was also a member of another saw an incomplete chooser.

Root cause: `GET /api/v1/stores` and `GET /api/v1/studios` filtered only on `owner_id` and never consulted `StoreMember` / `StudioMember`.

## Change

- **Models** — new `store.findAllForUser(userId)` / `studio.findAllForUser(userId)` that return **owned ∪ member-of**, deduped. Because the repo forbids foreign keys (no `Store`↔`StoreMember` relation), memberships are resolved to ids first, then fetched by id. Ordered owned-first, alphabetical within each group.
- **Controllers** — both list GETs now source from `findAllForUser`, preserving the existing `{ stores|studios, pagination }` response envelope and the `canRequest("create:store"|"create:studio")` gate.
- **Resolver pages** — the 0 → create / 1 → open-directly / >1 → chooser logic is unchanged; the chooser now shows an **Owner/Member** tag per row (`owner_id` is already returned by `filterOutput`).

Behavior now: none → create page; exactly one (owned *or* member) → open it directly; more than one → chooser. Applied identically to Outlets and Studios.

## Tests

Rewrote both `get.test.ts` suites to cover: member-of appears, owner+member mix returns exactly both, isolation (unrelated entity absent), owned-before-member ordering, empty list, and anonymous → 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wb9H8h2atku1TG6rVn4mGc)_