### PR TITLE
docs: overhaul README and add contribution guides

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Report something that isn't working as expected
+title: "[Bug]: "
+labels: bug
+---
+
+## Description
+
+<!-- A clear description of the bug. -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+<!-- What you expected to happen. -->
+
+## Actual behavior
+
+<!-- What actually happened. Include error messages or screenshots if helpful. -->
+
+## Environment
+
+- OS:
+- Node version:
+- Branch/commit:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea or improvement for Manifold
+title: "[Feature]: "
+labels: enhancement
+---
+
+## Problem
+
+<!-- What problem does this solve? Who is it for (creator, developer, player)? -->
+
+## Proposed solution
+
+<!-- Describe what you'd like to see happen. -->
+
+## Alternatives considered
+
+<!-- Any other approaches you thought about. -->
+
+## Additional context
+
+<!-- Anything else that helps explain the request. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Description
+
+<!-- What does this PR change, and why? -->
+
+## Related issue
+
+<!-- e.g. Closes #123 -->
+
+## Type of change
+
+- [ ] 🐛 Bug fix
+- [ ] ✨ New feature
+- [ ] 📖 Documentation
+- [ ] ♻️ Refactor
+- [ ] 🧪 Tests
+
+## Checklist
+
+- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org)
+- [ ] `npm run lint:eslint:check` passes
+- [ ] `npm run lint:prettier:check` passes
+- [ ] `npm run test` passes
+- [ ] Added or updated tests where relevant

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,112 @@
+# Contributing to Manifold
+
+First off — thank you for considering a contribution. Manifold is pre-release, so the foundations are still being laid and your input has outsized impact. This guide gets you from clone to merged pull request.
+
+## Table of Contents
+
+- [Code of Conduct](#code-of-conduct)
+- [Ways to Contribute](#ways-to-contribute)
+- [Local Setup](#local-setup)
+- [Development Workflow](#development-workflow)
+- [Commit Convention](#commit-convention)
+- [Testing](#testing)
+- [Architecture Rules](#architecture-rules)
+- [Opening a Pull Request](#opening-a-pull-request)
+
+## Code of Conduct
+
+Be respectful, assume good faith, and keep discussions constructive. Harassment or discrimination of any kind is not welcome. If you experience or witness unacceptable behavior, please open an issue or contact the maintainer.
+
+## Ways to Contribute
+
+- 🐛 **Report bugs** — open an [issue](https://github.com/pedromello/manifoldpowered.com/issues) with steps to reproduce.
+- 💡 **Suggest features or ideas** — start a [discussion](https://github.com/pedromello/manifoldpowered.com/discussions).
+- 🧑‍💻 **Write code** — pick up a [good first issue](https://github.com/pedromello/manifoldpowered.com/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) or a `help wanted` issue.
+- 📖 **Improve docs** — READMEs, comments, and this guide all count.
+
+## Local Setup
+
+**Prerequisites:**
+
+- **Node.js `v24.13.1`** (pinned in [`.nvmrc`](./.nvmrc) — run `nvm use` if you use nvm).
+- **Docker**, installed and running. Verify with `docker ps` before you start.
+
+```bash
+git clone https://github.com/pedromello/manifoldpowered.com.git
+cd manifoldpowered.com
+npm i
+npm run dev
+```
+
+`npm run dev` handles everything — no manual `.env` needed. It spins up Postgres, MinIO, and Mailcatcher via `infra/compose.yaml`, waits for the database, runs `prisma generate` and migrations, then starts Next.js at [http://localhost:3000](http://localhost:3000).
+
+> Installing a new dependency? Pin the exact version with `npm install -E <package>`.
+
+## Development Workflow
+
+1. Fork the repo and create a branch off `main`.
+2. Make your change, following the [architecture rules](#architecture-rules).
+3. Add or update integration tests.
+4. Run the checks locally (lint, format, tests).
+5. Commit using [Conventional Commits](#commit-convention).
+6. Open a pull request.
+
+## Commit Convention
+
+Commits **must** follow [Conventional Commits](https://www.conventionalcommits.org) — this is enforced by commitlint in CI.
+
+```
+feat: add cross-Outlet download resolver
+fix: prevent duplicate members in store listing
+docs: rewrite the README getting-started section
+```
+
+Common types: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`. Running `npm run commit` walks you through a compliant message interactively.
+
+## Testing
+
+Manifold favors **integration tests** that hit real API routes against real services.
+
+```bash
+npm run test        # full suite from scratch (spins services up and down)
+```
+
+For a tight feedback loop, run the dev server and the watcher in parallel:
+
+```bash
+npm run dev         # terminal 1
+npm run test:watch  # terminal 2
+```
+
+Conventions:
+
+- Tests live in `tests/integration/`, **one file per HTTP method** (`get.test.ts`, `post.test.ts`, …). Don't group methods in an `index.test.ts`.
+- Group tests by user state — e.g. `describe("Anonymous user")`, `describe("Authenticated user")`.
+- Assert exact status codes and precise JSON payloads.
+- Use `tests/orchestrator.js` helpers (`createUser`, `createSession`, `createStore`, …) in `beforeAll` to set up state — don't call your own API to build fixtures.
+
+**Before considering a task done, run the entire suite** to ensure no regressions.
+
+## Architecture Rules
+
+Manifold uses an MVC architecture on top of Next.js API routes (Pages Router) with `next-connect`.
+
+- **Controllers** live in `pages/api/…`; **models** (business logic, queries, Zod schemas) live in `models/`.
+- **Validate all input with Zod** and throw a `ValidationError` on failure.
+- **Filter all output** with `authorization.filterOutput(user, "action:name", data)` before responding.
+- **Never** return raw error responses (`res.status(400).json(...)`). Always `throw` a custom error from `infra/errors` (`ValidationError`, `NotFoundError`, `ForbiddenError`, …) with meaningful `message` and `action` fields, in English.
+- **No foreign keys.** The database forbids FK constraints for horizontal scalability — resolve relationships in application code, not via DB relations.
+- **No `any`.** TypeScript is strict; define proper interfaces and types.
+
+## Opening a Pull Request
+
+Before you push, make sure:
+
+- ✅ `npm run lint:eslint:check` is clean
+- ✅ `npm run lint:prettier:check` is clean (use `npm run lint:prettier:fix` to auto-format)
+- ✅ `npm run test` passes
+- ✅ Commits follow Conventional Commits
+
+CI runs ESLint, Prettier, Commitlint, and Jest on every pull request — green checks are required to merge. Fill out the pull request template, link any related issue, and describe what changed and why.
+
+Thanks again for helping build open infrastructure for game distribution. 🎮

--- a/README.md
+++ b/README.md
@@ -2,156 +2,213 @@
 
 # Manifold
 
+> **Spin up your own Steam.** Manifold is the open infrastructure layer for game distribution — a shared backend that lets anyone launch their own fully interoperable game store.
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](#-contributing)
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://www.conventionalcommits.org)
+[![Next.js](https://img.shields.io/badge/Next.js-black?logo=next.js&logoColor=white)](https://nextjs.org)
+[![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org)
+[![PostgreSQL](https://img.shields.io/badge/PostgreSQL-4169E1?logo=postgresql&logoColor=white)](https://www.postgresql.org)
+
 🌍 **Language:** English | [Português (Brasil)](./README.pt-BR.md)
 
 > [!WARNING]
-> **Project status: pre-release.** Manifold is in active development. This repository presents the vision and technical direction; no production-ready product is available yet.
+> **Project status: pre-release.** Manifold is in active development. This repository presents the vision and technical direction; no production-ready product is available yet. This is the perfect moment to shape it — **[new contributors start here](#-contributing)**.
 
-**Manifold** is the infrastructure that powers multiple independent game stores through a shared backend.
+Just like **Valve** created **Steam**, Manifold lets anyone create their own version of Steam — called an **Outlet** — while staying fully interoperable with every other Outlet in the network. A player can buy a game on one Outlet and download it on another, without losing progress, ownership, or access.
 
-Just like **Valve** created **Steam**, Manifold enables anyone to create their own version of Steam — called an **Outlet** — while remaining fully interoperable with every other Outlet in the network.
+---
+
+## 📖 Table of Contents
+
+- [What is Manifold?](#-what-is-manifold)
+- [What is an Outlet?](#-what-is-an-outlet)
+- [How Manifold Works](#-how-manifold-works)
+- [Key Features](#-key-features)
+- [Getting Started](#-getting-started)
+- [Tech Stack](#-tech-stack)
+- [Project Structure](#-project-structure)
+- [Testing](#-testing)
+- [Contributing](#-contributing)
+- [Philosophy](#-philosophy)
+- [License](#-license)
 
 ---
 
 ## 🌐 What is Manifold?
 
-Manifold is a platform that allows creators, studios, communities, and companies to build their own game distribution platforms using a single shared system.
-
-Each store created with Manifold is called an **Outlet**.
+Manifold lets creators, studios, communities, and companies build their own game distribution platforms on a single shared system. Every store built on Manifold is called an **Outlet**.
 
 Outlets are:
 
-- Visually and operationally independent
-- Powered by the same backend
-- Fully interoperable with each other
-
-A player can buy a game on one Outlet and download it on another — without losing progress, ownership, or access.
-
----
-
-## How Manifold Works in Practice
-
-Manifold is an ecosystem designed to connect those who create, those who sell, and those who play. Here is how the infrastructure works for each party:
-
-<img width="1080" height="810" alt="Manifold - Diagram" src="https://github.com/user-attachments/assets/91c30ea2-eeed-4d52-a130-97f7fb809ae4" />
-
-### 1. For Creators and Communities: A New Revenue Stream and Engagement Hub
-
-Have you ever imagined having your own official game store? Most creators and communities have not even considered this possibility, but Manifold makes it a reality. It is your chance to create a new source of extra income and an exclusive space to interact with your fans. Instead of just recommending a game in your video or Discord server, you can sell it directly to your audience.
-
-- **The Use Case:** Imagine you are a content creator focused on _Cozy Games_. You can use Manifold to open your own official storefront. You handpick which games from our ecosystem you want to sell to your audience.
-- **The Result:** Your store will only feature farming sims, puzzles, and relaxing narratives. No horror or violent games will ever appear on your storefront. You monetize your influence by earning a share from the games your community would buy anyway, while we handle all the invisible technical infrastructure.
-
-### 2. For Developers: One Upload, Hundreds of Storefronts
-
-Expanding your game's reach should not mean managing dozens of different distribution dashboards or fighting a single algorithm.
-
-- **The Use Case:** You just finished your indie game and want maximum distribution. Instead of knocking on every door, you upload your game **just once** to the Manifold dashboard.
-- **The Result:** Once approved, your game becomes available in our central catalog (the backend). From that moment on, any niche store in the network interested in your game's genre can add it to their storefront. Your game gains massive reach and connects with highly engaged audiences without any extra effort on your part.
-
-### 3. For Players: Freedom of Choice, Unified Library
-
-You should not have to fragment your games across multiple launchers just because you wanted to support different communities.
-
-- **The Use Case:** You bought a farming simulator from your favorite _Cozy Games_ streamer's store, and the following week, you bought a shooter from your e-sports clan's FPS-focused store.
-- **The Result:** It does not matter which Outlet (store) you bought them from. Every game you purchase within the Manifold ecosystem goes straight to your **single, centralized library**. One login gives you full access to all your games and saved progress in one place.
+- **Independent** — their own branding, community, and curation
+- **Shared** — powered by the same backend, catalog, and player library
+- **Interoperable** — a purchase on one Outlet works on all of them
 
 ---
 
 ## 🔌 What is an Outlet?
 
-In engineering, a **manifold** distributes a flow into multiple **outlets**.
+In engineering, a **manifold** distributes a single flow into multiple **outlets**. Manifold does the same for games:
 
-In Manifold:
+- **Manifold** is the distributor (the shared infrastructure)
+- **Outlets** are the distribution points (the individual stores)
 
-- **Manifold** is the distributor
-- **Outlets** are the distribution points
-
-Each Outlet is a full-featured game store:
-
-- Custom branding and identity
-- Its own community and curation
-- Shared library, purchases, and save data
+Each Outlet is a full-featured game store with custom branding and its own curated catalog — but purchases, downloads, and save data are shared across the entire network. Buy once, play anywhere.
 
 ---
 
-## 🎮 Key Features
+## 🎮 How Manifold Works
 
-- 🛒 **Buy once, access everywhere**  
-  Games purchased on one Outlet are available on all others.
+Manifold connects those who **create**, those who **sell**, and those who **play**.
 
-- 🔄 **Cross-Outlet downloads**  
-  Download your games from any Outlet in the network.
+<img width="1080" height="810" alt="Manifold - Diagram" src="https://github.com/user-attachments/assets/91c30ea2-eeed-4d52-a130-97f7fb809ae4" />
 
-- 💾 **Shared progress and saves**  
-  Player progress is synchronized across all Outlets.
+**For Creators & Communities — a storefront of your own.** A _Cozy Games_ streamer can open an Outlet that sells only farming sims, puzzles, and relaxing narratives — no horror, no violence. You monetize your influence by curating what your audience would buy anyway, while Manifold handles the technical infrastructure.
 
-- 🧩 **Single integration for developers**  
-  Developers integrate once and reach every Outlet.
+**For Developers — one upload, hundreds of storefronts.** Upload your game **once** to the Manifold catalog. Once approved, any Outlet in the network can add it to their store. Your game reaches highly engaged, niche audiences with no extra distribution work.
 
-- 🏗️ **Modular and scalable architecture**  
-  Designed to support countless Outlets from a single core system.
+**For Players — one library for everything.** Bought a farming sim from a cozy-games streamer and a shooter from your e-sports clan's Outlet? Both land in the same **centralized library**. One login, all your games and saves, in one place.
 
 ---
 
-## 🎯 Why Manifold?
+## 🎯 Key Features
 
-Traditional game stores are siloed.
-Manifold breaks those silos by separating **platform infrastructure** from **store identity**.
-
-This enables:
-
-- More freedom for creators
-- More choice for players
-- A healthier, interconnected ecosystem
+- 🛒 **Buy once, access everywhere** — games bought on one Outlet work on all of them
+- 🔄 **Cross-Outlet downloads** — download from any Outlet in the network
+- 💾 **Shared progress and saves** — player state syncs across every Outlet
+- 🧩 **Single integration for developers** — integrate once, reach every Outlet
+- 🏗️ **Modular, scalable architecture** — built to support countless Outlets from one core
 
 ---
 
-## 🚀 Who is Manifold for?
+## 🚀 Getting Started
 
-- Game studios launching their own stores
-- Influencers and curators building themed platforms
-- Communities creating private or public marketplaces
-- Companies distributing games internally or externally
+Get a full local environment running in two commands.
 
----
+### Prerequisites
 
-## 🧠 Philosophy
+- **Node.js `v24.13.1`** — the version pinned in [`.nvmrc`](./.nvmrc). If you use [nvm](https://github.com/nvm-sh/nvm), just run `nvm use`.
+- **Docker** — must be **installed and running**. This is the #1 setup gotcha: if the Docker daemon isn't up, setup will hang. Verify with `docker ps` first.
 
-Manifold is built on the idea that nearly every part of game development has already been democratized.
+### Run it
 
-Game engines are open or widely accessible.
-Art, design, and audio tools offer powerful solutions — many of them free.
-Knowledge is broadly available.
+```bash
+npm i        # install dependencies
+npm run dev  # start everything
+```
 
-What remains centralized is distribution.
+That's it. **No manual `.env` setup needed** — `npm run dev` handles the entire environment for you. Under the hood it:
 
-Game distribution is still controlled, proprietary, and owned by a small number of platforms.
-This creates an imbalance: developers are free to create, but not free to distribute.
+1. Spins up Postgres, MinIO (S3), and Mailcatcher via `infra/compose.yaml`
+2. Waits for Postgres to be ready
+3. Runs `prisma generate` and applies migrations (`migrate dev`)
+4. Starts the Next.js dev server
 
-We believe that just as development tools evolved into open and shared infrastructure, distribution must follow the same path.
-
-Manifold exists to turn distribution into infrastructure:
-shared, interoperable, and accessible —
-not the exclusive property of a single platform.
+When it's ready, open **[http://localhost:3000](http://localhost:3000)**.
 
 ---
 
-## 🌍 Domain
+## 🛠️ Tech Stack
 
-This project lives at:
-
-**https://manifoldpowered.com**
+| Layer        | Technology                                                                   |
+| ------------ | ---------------------------------------------------------------------------- |
+| Framework    | [Next.js](https://nextjs.org) (Pages Router)                                 |
+| Language     | [TypeScript](https://www.typescriptlang.org) (strict, no `any`)              |
+| Database     | [PostgreSQL](https://www.postgresql.org) via [Prisma](https://www.prisma.io) |
+| API          | [next-connect](https://github.com/hoangvvo/next-connect) (MVC-style routes)  |
+| Styling      | [Tailwind CSS](https://tailwindcss.com)                                      |
+| Object store | S3-compatible (MinIO locally)                                                |
+| Deployment   | [Vercel](https://vercel.com)                                                 |
 
 ---
 
-## 📄 License
+## 📁 Project Structure
 
-MIT
+```
+manifoldpowered.com/
+├── pages/api/     # Controllers — API route handlers
+├── models/        # Business logic, database queries, and Zod schemas
+├── infra/         # Webserver, database connections, and custom error classes
+├── components/    # React UI components
+├── lib/           # Shared utilities
+├── prisma/        # Database schema and migrations
+├── scripts/       # Operational scripts (admin grants, feature backfills)
+└── tests/         # Integration tests and the test orchestrator
+```
+
+Deeper architectural conventions (MVC patterns, error handling, authorization, and the no-foreign-keys rule) are documented in [`CONTRIBUTING.md`](./CONTRIBUTING.md).
+
+---
+
+## 🧪 Testing
+
+Manifold favors robust **integration tests** that exercise real API routes against real services.
+
+```bash
+npm run test        # run the full suite from scratch (spins up services)
+```
+
+For continuous testing while developing, run the dev server in one terminal and the watcher in another:
+
+```bash
+npm run dev         # terminal 1
+npm run test:watch  # terminal 2
+```
+
+Integration tests live in `tests/integration/`, with **one file per HTTP method** (`get.test.ts`, `post.test.ts`, …). The `tests/orchestrator.js` helper manages database state and test fixtures. See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for testing conventions.
 
 ---
 
 ## 🤝 Contributing
 
-This project is in early development.
-Contributions, ideas, and discussions are welcome.
+**Contributions are welcome and genuinely wanted.** Manifold is pre-release, which means the foundations are still being laid — your input has outsized impact right now.
+
+If you've ever shipped on a platform that changed the rules on you, this is the alternative you'd want to exist. Come help build it.
+
+### New here?
+
+👉 Start with a **[good first issue](https://github.com/pedromello/manifoldpowered.com/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)**.
+
+### Quick contribution loop
+
+```bash
+git clone https://github.com/pedromello/manifoldpowered.com.git
+cd manifoldpowered.com
+npm i
+npm run dev          # verify it runs
+npm run test         # verify the suite is green
+```
+
+Before opening a pull request, please make sure:
+
+- ✅ Commits follow [**Conventional Commits**](https://www.conventionalcommits.org) — enforced by commitlint (`npm run commit` helps).
+- ✅ Linting is clean — `npm run lint:eslint:check` and `npm run lint:prettier:check`.
+- ✅ Tests pass — `npm run test`.
+
+CI runs ESLint, Prettier, Commitlint, and Jest on every pull request. The full contributor guide — branch naming, architecture rules, and PR expectations — lives in **[`CONTRIBUTING.md`](./CONTRIBUTING.md)**.
+
+Have a question or an idea? Open an [issue](https://github.com/pedromello/manifoldpowered.com/issues) or start a [discussion](https://github.com/pedromello/manifoldpowered.com/discussions).
+
+---
+
+## 🧠 Philosophy
+
+Nearly every part of game development has been democratized. Engines are open or widely accessible. Art, design, and audio tools are powerful and often free. Knowledge is everywhere.
+
+**What remains centralized is distribution** — still proprietary, still controlled by a handful of platforms. Developers are free to create, but not free to distribute.
+
+Manifold exists to turn distribution into infrastructure: shared, interoperable, and accessible — not the exclusive property of a single platform.
+
+---
+
+## 🌍 Domain
+
+This project lives at **[manifoldpowered.com](https://manifoldpowered.com)**.
+
+---
+
+## 📄 License
+
+Released under the [MIT License](./LICENSE).

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "git+https://github.com/pedromello/manifoldpowered.com.git"
   },
-  "license": "ISC",
+  "license": "MIT",
   "author": "Pedro Mello",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
## Description

Rewrites the project README to better explain what Manifold is **and** make it genuinely easy — and inviting — to contribute. Shaped with input from three perspectives (Product Owner, CEO, and an open-source community expert).

**README changes:**
- Leads with a one-line hook ("Spin up your own Steam") and a focused badge row (License, PRs Welcome, Conventional Commits, tech stack) — static badges only, since the CI workflows run on `pull_request` and a live status badge would render "no status" on the default branch.
- Adds a **table of contents** and a two-command **Getting Started** (Node/Docker prereqs, the Docker "#1 gotcha", the "no `.env` needed" note, and what `npm run dev` does under the hood).
- New **Tech Stack**, **Project Structure**, and **Testing** sections.
- Tightens the vision copy so a cold visitor gets the concept in the first screen; keeps the Philosophy but trims it.
- New **Contributing** section with a `good first issue` callout, a pre-PR checklist, and links to Issues/Discussions.

**Supporting community files the README references:**
- `CONTRIBUTING.md` — setup, Conventional Commits, testing conventions, architecture rules (MVC, Zod, `filterOutput`, no foreign keys, no `any`), and a PR checklist.
- `.github/pull_request_template.md` and bug/feature issue templates.

**Also:** aligns `package.json` `license` to `MIT` to match the `LICENSE` file and README (it previously said `ISC`).

## Notes

- `README.pt-BR.md` was **not** re-translated in this PR; the language switcher still links to it. Happy to follow up with a synced Portuguese version.
- Per the OSS-expert guidance, `CODE_OF_CONDUCT.md` and `SECURITY.md` were intentionally deferred for a pre-release project (a short Code of Conduct note is inlined in `CONTRIBUTING.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wb9H8h2atku1TG6rVn4mGc)_