### PR TITLE
feat: add studio games list and searchable per-game override picker

### DIFF
--- a/components/store/GameAutocomplete.tsx
+++ b/components/store/GameAutocomplete.tsx
@@ -1,0 +1,86 @@
+import { useState } from "react";
+import useSWR from "swr";
+import { Search, Loader2 } from "lucide-react";
+import { type GameApi } from "components/store/GameListItem";
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+export function GameAutocomplete({
+  onSelect,
+  placeholder = "Search games...",
+}: {
+  onSelect: (game: GameApi) => void;
+  placeholder?: string;
+}) {
+  const [query, setQuery] = useState("");
+  const [isFocused, setIsFocused] = useState(false);
+
+  const { data, isLoading } = useSWR<{ games: GameApi[] }>(
+    query.trim()
+      ? `/api/v1/games?q=${encodeURIComponent(query)}&limit=5`
+      : null,
+    fetcher,
+  );
+
+  const suggestions = data?.games || [];
+  const defaultGradient =
+    "linear-gradient(135deg, var(--color-purple-dark) 0%, rgba(53,34,89,0.7) 100%)";
+
+  function handleSelect(game: GameApi) {
+    onSelect(game);
+    setQuery("");
+    setIsFocused(false);
+  }
+
+  return (
+    <div className="relative flex-1 min-w-[200px]">
+      <div className="absolute inset-y-0 left-4 flex items-center pointer-events-none text-white/30">
+        <Search size={16} />
+      </div>
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setTimeout(() => setIsFocused(false), 200)}
+        placeholder={placeholder}
+        className="w-full rounded-xl border border-white/10 bg-white/5 pl-11 pr-4 py-2.5 text-sm font-bold text-white placeholder:text-white/30 outline-none focus:bg-white/10 focus:border-white/20"
+      />
+
+      {isFocused && query && (
+        <div className="flex flex-col gap-1 absolute top-full mt-2 left-0 w-full max-w-md bg-[#130b25] border border-white/10 rounded-2xl shadow-2xl overflow-hidden py-2 z-10">
+          {isLoading ? (
+            <div className="px-6 py-6 flex justify-center">
+              <Loader2 className="animate-spin text-white/30" size={20} />
+            </div>
+          ) : suggestions.length > 0 ? (
+            suggestions.map((game) => (
+              <button
+                key={game.id}
+                type="button"
+                onClick={() => handleSelect(game)}
+                className="flex items-center gap-3 px-4 py-2 transition-colors hover:bg-white/5 text-left"
+              >
+                <div
+                  className="h-10 aspect-[16/9] rounded-lg shrink-0 border border-white/5"
+                  style={{
+                    background: game.media.banner
+                      ? `url(${game.media.banner}) center/cover no-repeat`
+                      : defaultGradient,
+                  }}
+                />
+                <span className="font-bold text-white text-sm truncate">
+                  {game.title}
+                </span>
+              </button>
+            ))
+          ) : (
+            <div className="px-6 py-6 text-center text-white/40 font-semibold text-sm">
+              No games found matching &quot;{query}&quot;
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/store/GameListItem.tsx
+++ b/components/store/GameListItem.tsx
@@ -21,6 +21,10 @@ export type GameApi = {
     icon?: string;
     videos: string[];
   };
+  status?: "ACTIVE" | "INACTIVE" | "PRIVATE";
+  positive_reviews?: number;
+  negative_reviews?: number;
+  review_score?: string | null;
 };
 
 export function GameListItem({

--- a/pages/api/v1/studios/[slug]/games/index.ts
+++ b/pages/api/v1/studios/[slug]/games/index.ts
@@ -1,0 +1,40 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { createRouter } from "next-connect";
+import controller from "infra/controller";
+import studio from "models/studio";
+import game from "models/game";
+import authorization from "models/authorization";
+import { ForbiddenError } from "infra/errors";
+
+export default createRouter<NextApiRequest, NextApiResponse>()
+  .use(controller.injectAnonymousOrUser)
+  .get(controller.canRequest("update:studio"), getHandler)
+  .handler(controller.errorHandlers);
+
+async function getHandler(req: NextApiRequest, res: NextApiResponse) {
+  const { slug } = req.query;
+
+  const userTryingToRead = req.context.user;
+  const foundStudio = await studio.findOneBySlugWithMembers(slug as string);
+
+  if (!authorization.can(userTryingToRead, "update:studio", foundStudio)) {
+    throw new ForbiddenError({
+      message: "You do not have permission to view this studio's games",
+      action: "Verify if you are an administrator of this studio",
+    });
+  }
+
+  const { games, pagination } = await game.findAllPaginatedAdmin({
+    studio_id: foundStudio.id,
+    limit: 100,
+  });
+
+  const secureOutputValues = games.map((gameItem) =>
+    authorization.filterOutput(userTryingToRead, "update:game", gameItem),
+  );
+
+  return res.status(200).json({
+    games: secureOutputValues,
+    pagination,
+  });
+}

--- a/pages/store/[slug]/manage.tsx
+++ b/pages/store/[slug]/manage.tsx
@@ -4,6 +4,8 @@ import Head from "next/head";
 import Link from "next/link";
 import useSWR, { useSWRConfig } from "swr";
 import { Loader2, ExternalLink, X, ChevronDown } from "lucide-react";
+import { GameAutocomplete } from "components/store/GameAutocomplete";
+import { type GameApi } from "components/store/GameListItem";
 
 interface StoreApi {
   id: string;
@@ -319,28 +321,28 @@ function GameOverridesPanel({ storeSlug }: { storeSlug: string }) {
     fetcher,
   );
 
-  const [gameSlug, setGameSlug] = useState("");
+  const [selectedGame, setSelectedGame] = useState<GameApi | null>(null);
   const [visibility, setVisibility] = useState<"SHOW" | "HIDE">("SHOW");
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   async function handleAddOverride(event: React.FormEvent) {
     event.preventDefault();
-    if (!gameSlug.trim()) return;
+    if (!selectedGame) return;
     setError(null);
     setIsSubmitting(true);
     try {
       const response = await fetch(overridesKey, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ game_slug: gameSlug.trim(), visibility }),
+        body: JSON.stringify({ game_slug: selectedGame.slug, visibility }),
       });
       const body = await response.json().catch(() => null);
       if (!response.ok) {
         setError(body?.message || "Failed to add game override.");
         return;
       }
-      setGameSlug("");
+      setSelectedGame(null);
       mutate(overridesKey);
     } finally {
       setIsSubmitting(false);
@@ -361,13 +363,34 @@ function GameOverridesPanel({ storeSlug }: { storeSlug: string }) {
       </p>
 
       <form onSubmit={handleAddOverride} className="flex flex-wrap gap-2">
-        <input
-          type="text"
-          value={gameSlug}
-          onChange={(e) => setGameSlug(e.target.value)}
-          placeholder="game-slug"
-          className="flex-1 min-w-[160px] rounded-xl border border-white/10 bg-white/5 px-4 py-2.5 text-sm font-bold text-white placeholder:text-white/30 outline-none focus:bg-white/10 focus:border-white/20"
-        />
+        {selectedGame ? (
+          <div className="flex-1 min-w-[160px] flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-3 py-2">
+            <div
+              className="h-8 aspect-[16/9] rounded-md shrink-0 border border-white/5"
+              style={{
+                background: selectedGame.media.banner
+                  ? `url(${selectedGame.media.banner}) center/cover no-repeat`
+                  : "linear-gradient(135deg, var(--color-purple-dark) 0%, rgba(53,34,89,0.7) 100%)",
+              }}
+            />
+            <span className="flex-1 font-bold text-white text-sm truncate">
+              {selectedGame.title}
+            </span>
+            <button
+              type="button"
+              onClick={() => setSelectedGame(null)}
+              className="text-white/40 hover:text-white transition-colors shrink-0"
+              aria-label="Clear selected game"
+            >
+              <X size={14} />
+            </button>
+          </div>
+        ) : (
+          <GameAutocomplete
+            onSelect={(game) => setSelectedGame(game)}
+            placeholder="Search games..."
+          />
+        )}
         <select
           value={visibility}
           onChange={(e) => setVisibility(e.target.value as "SHOW" | "HIDE")}
@@ -378,7 +401,7 @@ function GameOverridesPanel({ storeSlug }: { storeSlug: string }) {
         </select>
         <button
           type="submit"
-          disabled={isSubmitting || !gameSlug.trim()}
+          disabled={isSubmitting || !selectedGame}
           className="px-4 py-2.5 rounded-xl bg-emerald-500 text-black font-black text-sm uppercase tracking-wider hover:bg-emerald-400 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
         >
           Add
@@ -400,29 +423,57 @@ function GameOverridesPanel({ storeSlug }: { storeSlug: string }) {
           </p>
         ) : (
           overrides.map((override) => (
-            <div
+            <OverrideChip
               key={override.id}
-              className={`flex items-center gap-2 pl-3 pr-2 py-1.5 rounded-xl border text-sm font-bold ${
-                override.visibility === "SHOW"
-                  ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-300"
-                  : "border-rose-500/30 bg-rose-500/10 text-rose-300"
-              }`}
-            >
-              <span>
-                {override.visibility === "SHOW" ? "Shown" : "Hidden"}:{" "}
-                {override.game_slug}
-              </span>
-              <button
-                onClick={() => handleRemoveOverride(override)}
-                className="text-white/40 hover:text-white transition-colors"
-                aria-label={`Remove override for ${override.game_slug}`}
-              >
-                <X size={14} />
-              </button>
-            </div>
+              override={override}
+              onRemove={handleRemoveOverride}
+            />
           ))
         )}
       </div>
+    </div>
+  );
+}
+
+function OverrideChip({
+  override,
+  onRemove,
+}: {
+  override: GameOverrideApi;
+  onRemove: (override: GameOverrideApi) => void;
+}) {
+  const { data: game } = useSWR<GameApi>(
+    `/api/v1/items/games/${override.game_slug}`,
+    (url) => fetch(url).then((res) => (res.ok ? res.json() : null)),
+  );
+
+  return (
+    <div
+      className={`flex items-center gap-2 pl-2 pr-2 py-1.5 rounded-xl border text-sm font-bold ${
+        override.visibility === "SHOW"
+          ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-300"
+          : "border-rose-500/30 bg-rose-500/10 text-rose-300"
+      }`}
+    >
+      {game?.media.banner && (
+        <div
+          className="h-6 aspect-[16/9] rounded shrink-0 border border-white/10"
+          style={{
+            background: `url(${game.media.banner}) center/cover no-repeat`,
+          }}
+        />
+      )}
+      <span>
+        {override.visibility === "SHOW" ? "Shown" : "Hidden"}:{" "}
+        {game?.title ?? override.game_slug}
+      </span>
+      <button
+        onClick={() => onRemove(override)}
+        className="text-white/40 hover:text-white transition-colors"
+        aria-label={`Remove override for ${game?.title ?? override.game_slug}`}
+      >
+        <X size={14} />
+      </button>
     </div>
   );
 }

--- a/pages/studio/[slug]/index.tsx
+++ b/pages/studio/[slug]/index.tsx
@@ -2,7 +2,10 @@ import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import useSWR from "swr";
-import { Loader2, Building2 } from "lucide-react";
+import { useState } from "react";
+import { Loader2, Building2, Copy, Check, Gamepad2 } from "lucide-react";
+import { ReviewSummary } from "components/store/ReviewSummary";
+import { type GameApi } from "components/store/GameListItem";
 
 interface Studio {
   id: string;
@@ -15,6 +18,12 @@ interface Studio {
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
+const STATUS_STYLES: Record<string, string> = {
+  ACTIVE: "bg-emerald-500/20 text-emerald-300",
+  PRIVATE: "bg-amber-500/20 text-amber-300",
+  INACTIVE: "bg-white/10 text-white/50",
+};
+
 export default function StudioPage() {
   const router = useRouter();
   const slug = router.query.slug as string | undefined;
@@ -25,6 +34,12 @@ export default function StudioPage() {
     error,
   } = useSWR<Studio>(slug ? `/api/v1/studios/${slug}` : null, fetcher);
 
+  const { data: gamesData, isLoading: isLoadingGames } = useSWR<{
+    games: GameApi[];
+  }>(studio ? `/api/v1/studios/${studio.slug}/games` : null, fetcher);
+
+  const games = gamesData?.games ?? [];
+
   return (
     <>
       <Head>
@@ -33,14 +48,18 @@ export default function StudioPage() {
         </title>
       </Head>
 
-      <div className="min-h-screen bg-[#1D0F3B] text-white flex items-center justify-center px-4">
+      <div className="min-h-screen bg-[#1D0F3B] text-white px-4 py-12">
         {isLoading ? (
-          <Loader2 className="animate-spin text-white/30" />
+          <div className="flex items-center justify-center min-h-[60vh]">
+            <Loader2 className="animate-spin text-white/30" />
+          </div>
         ) : error || !studio ? (
-          <p className="text-rose-300 font-bold">Studio not found.</p>
+          <div className="flex items-center justify-center min-h-[60vh]">
+            <p className="text-rose-300 font-bold">Studio not found.</p>
+          </div>
         ) : (
-          <div className="w-full max-w-md flex flex-col gap-6">
-            <div className="flex items-center gap-4">
+          <div className="w-full max-w-4xl mx-auto flex flex-col gap-8">
+            <div className="flex flex-col sm:flex-row sm:items-center gap-4">
               {studio.logo_url ? (
                 // eslint-disable-next-line @next/next/no-img-element
                 <img
@@ -54,7 +73,7 @@ export default function StudioPage() {
                 </div>
               )}
 
-              <div className="min-w-0">
+              <div className="min-w-0 flex-1">
                 <h1 className="text-2xl font-black break-words">
                   {studio.name}
                 </h1>
@@ -64,6 +83,13 @@ export default function StudioPage() {
                   </span>
                 )}
               </div>
+
+              <Link
+                href={`/studio/${studio.slug}/games/steam-import`}
+                className="shrink-0 px-4 py-3 rounded-xl bg-emerald-500 text-black font-black text-sm uppercase tracking-wider text-center hover:bg-emerald-400 transition-colors"
+              >
+                Import from Steam
+              </Link>
             </div>
 
             {studio.description && (
@@ -72,15 +98,117 @@ export default function StudioPage() {
               </p>
             )}
 
-            <Link
-              href={`/studio/${studio.slug}/games/steam-import`}
-              className="px-4 py-3 rounded-xl bg-emerald-500 text-black font-black text-sm uppercase tracking-wider text-center hover:bg-emerald-400 transition-colors"
-            >
-              Import a Game from Steam
-            </Link>
+            <div className="flex flex-col gap-4">
+              <h2 className="text-lg font-black uppercase tracking-wider text-white/80">
+                Your Games
+              </h2>
+
+              {isLoadingGames ? (
+                <div className="flex items-center justify-center py-12">
+                  <Loader2 className="animate-spin text-white/30" />
+                </div>
+              ) : games.length === 0 ? (
+                <div className="flex flex-col items-center gap-4 py-12 px-6 rounded-2xl border border-white/10 bg-white/5 text-center">
+                  <Gamepad2 size={32} className="text-white/20" />
+                  <p className="text-white/50 font-bold text-sm">
+                    No games yet.
+                  </p>
+                  <Link
+                    href={`/studio/${studio.slug}/games/steam-import`}
+                    className="px-4 py-2.5 rounded-xl bg-emerald-500 text-black font-black text-sm uppercase tracking-wider hover:bg-emerald-400 transition-colors"
+                  >
+                    Import a Game from Steam
+                  </Link>
+                </div>
+              ) : (
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  {games.map((game) => (
+                    <StudioGameCard key={game.id} game={game} />
+                  ))}
+                </div>
+              )}
+            </div>
           </div>
         )}
       </div>
     </>
+  );
+}
+
+function StudioGameCard({ game }: { game: GameApi }) {
+  const [copied, setCopied] = useState(false);
+
+  const isDemo = !game.price || Number(game.price) === 0;
+  const defaultGradient =
+    "linear-gradient(135deg, var(--color-purple-dark) 0%, rgba(53,34,89,0.7) 100%)";
+
+  const launchDate = new Date(game.launch_date).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+
+  async function handleCopyLink() {
+    const url = `${window.location.origin}/item/${game.slug}`;
+    await navigator.clipboard.writeText(url);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <div className="flex flex-col rounded-2xl border border-white/10 bg-white/5 overflow-hidden">
+      <div
+        className="aspect-[16/9] w-full"
+        style={{
+          background: game.media.banner
+            ? `url(${game.media.banner}) center/cover no-repeat`
+            : defaultGradient,
+        }}
+      />
+
+      <div className="flex flex-col gap-3 p-4">
+        <div className="flex items-start justify-between gap-2">
+          <h3 className="font-black text-white truncate">{game.title}</h3>
+          {game.status && (
+            <span
+              className={`shrink-0 px-2 py-0.5 rounded-md text-[10px] font-black uppercase tracking-wider ${
+                STATUS_STYLES[game.status] ?? STATUS_STYLES.INACTIVE
+              }`}
+            >
+              {game.status}
+            </span>
+          )}
+        </div>
+
+        <div className="flex items-center gap-3 text-xs text-white/40 font-bold">
+          <span>{isDemo ? "Free" : `$${game.price}`}</span>
+          <span className="text-white/20">•</span>
+          <span>{launchDate}</span>
+        </div>
+
+        <ReviewSummary
+          positive={game.positive_reviews ?? 0}
+          negative={game.negative_reviews ?? 0}
+          reviewScore={game.review_score ?? null}
+        />
+
+        <button
+          onClick={handleCopyLink}
+          className="flex items-center justify-center gap-2 px-3 py-2 rounded-xl border border-white/10 bg-white/5 hover:bg-white/10 text-white/70 hover:text-white text-xs font-black uppercase tracking-wider transition-colors"
+        >
+          {copied ? (
+            <>
+              <Check size={14} className="text-emerald-400" />
+              Copied!
+            </>
+          ) : (
+            <>
+              <Copy size={14} />
+              Copy Link
+            </>
+          )}
+        </button>
+      </div>
+    </div>
   );
 }

--- a/tests/integration/api/v1/studios/[slug]/games/get.test.ts
+++ b/tests/integration/api/v1/studios/[slug]/games/get.test.ts
@@ -1,0 +1,152 @@
+import orchestrator from "tests/orchestrator";
+import webserver from "infra/webserver";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+describe("GET /api/v1/studios/[slug]/games", () => {
+  describe("Anonymous user", () => {
+    test("Should return 403 Forbidden", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const createdStudio = await orchestrator.createStudio(owner.id);
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/studios/${createdStudio.slug}/games`,
+      );
+
+      expect(response.status).toBe(403);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        name: "ForbiddenError",
+        message: "You do not have permission to perform this action",
+        action: "Verify your user has the following features: update:studio",
+        status_code: 403,
+      });
+    });
+  });
+
+  describe("Owner", () => {
+    test("Returns the studio's own games, including non-ACTIVE ones", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const ownerSession = await orchestrator.createSession(owner.id);
+      const createdStudio = await orchestrator.createStudio(owner.id);
+
+      // createGame defaults to the schema's PRIVATE status, which is exactly
+      // the "not yet publicly visible" case the studio owner still needs to
+      // see in their own games list.
+      const privateGame = await orchestrator.createGame(owner.id, {
+        studio_id: createdStudio.id,
+        title: "Unreleased Game",
+      });
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/studios/${createdStudio.slug}/games`,
+        {
+          headers: { Cookie: `session_id=${ownerSession.token}` },
+        },
+      );
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+      expect(responseBody.games).toHaveLength(1);
+      expect(responseBody.games[0].id).toBe(privateGame.id);
+      expect(responseBody.games[0].slug).toBe(privateGame.slug);
+      expect(responseBody.games[0].status).toBe("PRIVATE");
+      expect(responseBody.pagination.total).toBe(1);
+    });
+
+    test("Does not include another studio's games", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const ownerSession = await orchestrator.createSession(owner.id);
+      const createdStudio = await orchestrator.createStudio(owner.id);
+
+      const otherOwner = await orchestrator.createUser();
+      await orchestrator.activateUser(otherOwner.id);
+      const otherStudio = await orchestrator.createStudio(otherOwner.id);
+      await orchestrator.createGame(otherOwner.id, {
+        studio_id: otherStudio.id,
+        title: "Someone Else's Game",
+      });
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/studios/${createdStudio.slug}/games`,
+        {
+          headers: { Cookie: `session_id=${ownerSession.token}` },
+        },
+      );
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+      expect(responseBody.games).toEqual([]);
+      expect(responseBody.pagination.total).toBe(0);
+    });
+  });
+
+  describe("Studio member with update:studio permission", () => {
+    test("Should return 200 with the studio's games", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const createdStudio = await orchestrator.createStudio(owner.id);
+      const memberGame = await orchestrator.createGame(owner.id, {
+        studio_id: createdStudio.id,
+      });
+
+      const member = await orchestrator.createUser();
+      await orchestrator.activateUser(member.id);
+      const memberSession = await orchestrator.createSession(member.id);
+      await orchestrator.addStudioMember(createdStudio.id, member.username, [
+        "update:studio",
+      ]);
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/studios/${createdStudio.slug}/games`,
+        {
+          headers: { Cookie: `session_id=${memberSession.token}` },
+        },
+      );
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+      expect(responseBody.games).toHaveLength(1);
+      expect(responseBody.games[0].id).toBe(memberGame.id);
+    });
+  });
+
+  describe("Unrelated activated user", () => {
+    test("Targeting a studio they do not own or administer should return 403", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const createdStudio = await orchestrator.createStudio(owner.id);
+
+      const outsider = await orchestrator.createUser();
+      await orchestrator.activateUser(outsider.id);
+      const outsiderSession = await orchestrator.createSession(outsider.id);
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/studios/${createdStudio.slug}/games`,
+        {
+          headers: { Cookie: `session_id=${outsiderSession.token}` },
+        },
+      );
+
+      expect(response.status).toBe(403);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        message: "You do not have permission to view this studio's games",
+        name: "ForbiddenError",
+        action: "Verify if you are an administrator of this studio",
+        status_code: 403,
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Two owner-facing UX gaps closed:

**1. Studio page (`/studio/[slug]`) — "Your Games" list**
Previously the page showed only an "Import from Steam" CTA with no way to see games the studio already has. Now it lists them as cards with capsule image, status badge (ACTIVE/PRIVATE/INACTIVE), price, launch date, and a review summary — plus a **Copy Link** button for the game's shareable `/item/[slug]` URL.
- New `GET /api/v1/studios/[slug]/games`, gated the same way as the existing `game-overrides` route (`update:studio` + resource-level ownership check via `authorization.can`).
- Reuses `game.findAllPaginatedAdmin` (already supports `studio_id` + any status) — no model changes needed.

**2. Manage Outlet → Per-Game Overrides — searchable picker**
Previously the owner had to type a raw game slug into a plain text box. Now there's a type-ahead search (name + capsule, no slug shown) modeled on the storefront nav bar's search UX.
- New reusable `components/store/GameAutocomplete`, decoupled from navigation via an `onSelect` callback (the nav bar's search is inline/tightly coupled to `<Link>`, so this is a new component rather than a risky refactor of already-shipped nav code).
- Searches the **uncurated** `/api/v1/games` endpoint — not the store-scoped curated search — so a game currently hidden by the store's own tag filters can still be found and force-shown. Using the curated endpoint would have made it impossible to un-hide a filtered-out game.
- The existing overrides list below the form previously showed raw slugs (e.g. "Shown: half-life-2"). Per request, this was fixed **without a backend change**: each override now resolves its own title/capsule client-side via the existing public `GET /api/v1/items/games/[slug]` endpoint.

## Tests

Added `tests/integration/api/v1/studios/[slug]/games/get.test.ts`: anonymous → 403, owner sees own games including non-ACTIVE ones, isolation from another studio's games, studio member with `update:studio` permission → 200, unrelated user → 403.

## Notes

- Docker isn't available in this sandbox, so I couldn't run `npm run dev`/`npm run test` locally — verified via `tsc --noEmit`, `eslint`, and `prettier --check` (all clean; the only pre-existing repo-wide noise is ambient `tests/` jest-globals errors under `tsc`, unrelated to this change), plus a careful manual code review. CI will run the full Jest suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wb9H8h2atku1TG6rVn4mGc)_