### PR TITLE
feat: add HTML5 video support for Steam CDN in MediaGallery

### DIFF
--- a/components/store/MediaGallery.tsx
+++ b/components/store/MediaGallery.tsx
@@ -14,6 +14,7 @@ interface MediaGalleryProps {
 
 type MediaItem = {
   type: "video" | "image";
+  videoType?: "youtube" | "steam";
   url: string;
   id?: string;
 };
@@ -102,11 +103,15 @@ export function MediaGallery({ videos, images, gameTitle }: MediaGalleryProps) {
 
   // Combine media items: Videos first, then Images
   const mediaList = useMemo(() => {
-    const videoItems: MediaItem[] = videos.map((url) => ({
-      type: "video",
-      url,
-      id: getYouTubeID(url) || "",
-    }));
+    const videoItems: MediaItem[] = videos.map((url) => {
+      const ytId = getYouTubeID(url);
+      return {
+        type: "video",
+        videoType: ytId ? "youtube" : "steam",
+        url,
+        id: ytId || "",
+      };
+    });
 
     const imageItems: MediaItem[] = images.map((url) => ({
       type: "image",
@@ -144,13 +149,24 @@ export function MediaGallery({ videos, images, gameTitle }: MediaGalleryProps) {
       <div className="group relative aspect-video w-full rounded-[2.5rem] overflow-hidden bg-black/40 border border-white/10 shadow-2xl">
         {/* Stage Content */}
         {activeMedia.type === "video" ? (
-          <iframe
-            src={`https://www.youtube.com/embed/${activeMedia.id}?rel=0&modestbranding=1&autoplay=1&mute=1`}
-            title={`${gameTitle} Trailer`}
-            className="absolute inset-0 w-full h-full border-0"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-            allowFullScreen
-          />
+          activeMedia.videoType === "youtube" ? (
+            <iframe
+              src={`https://www.youtube.com/embed/${activeMedia.id}?rel=0&modestbranding=1&autoplay=1&mute=1`}
+              title={`${gameTitle} Trailer`}
+              className="absolute inset-0 w-full h-full border-0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+            />
+          ) : (
+            <video
+              src={activeMedia.url}
+              controls
+              autoPlay
+              muted
+              playsInline
+              className="absolute inset-0 w-full h-full object-cover"
+            />
+          )
         ) : (
           <Image
             src={activeMedia.url}
@@ -201,13 +217,15 @@ export function MediaGallery({ videos, images, gameTitle }: MediaGalleryProps) {
             onMouseLeave={onMouseLeave}
             onMouseUp={onMouseUp}
             onMouseMove={onMouseMove}
-            className="flex gap-4 overflow-x-auto pb-2 no-scrollbar snap-x scroll-smooth cursor-grab select-none active:cursor-grabbing"
+            className="flex gap-4 overflow-x-auto pb-2 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none] snap-x scroll-smooth cursor-grab select-none active:cursor-grabbing"
           >
             {mediaList.map((item, idx) => {
               const isActive = idx === activeIndex;
               const thumbUrl =
                 item.type === "video"
-                  ? `https://img.youtube.com/vi/${item.id}/hqdefault.jpg`
+                  ? item.videoType === "youtube"
+                    ? `https://img.youtube.com/vi/${item.id}/hqdefault.jpg`
+                    : (images[0] || "/placeholder-game.png")
                   : item.url;
 
               return (
@@ -267,15 +285,6 @@ export function MediaGallery({ videos, images, gameTitle }: MediaGalleryProps) {
         )}
       </div>
 
-      <style jsx>{`
-        .no-scrollbar::-webkit-scrollbar {
-          display: none;
-        }
-        .no-scrollbar {
-          -ms-overflow-style: none;
-          scrollbar-width: none;
-        }
-      `}</style>
     </section>
   );
 }

--- a/components/store/MediaGallery.tsx
+++ b/components/store/MediaGallery.tsx
@@ -225,7 +225,7 @@ export function MediaGallery({ videos, images, gameTitle }: MediaGalleryProps) {
                 item.type === "video"
                   ? item.videoType === "youtube"
                     ? `https://img.youtube.com/vi/${item.id}/hqdefault.jpg`
-                    : (images[0] || "/placeholder-game.png")
+                    : images[0] || "/placeholder-game.png"
                   : item.url;
 
               return (
@@ -284,7 +284,6 @@ export function MediaGallery({ videos, images, gameTitle }: MediaGalleryProps) {
           </div>
         )}
       </div>
-
     </section>
   );
 }

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
**Title:** feat: Add HTML5 video support for Steam CDN in MediaGallery

**Description:**
Adds support for rendering native HTML5 `<video>` elements in the `MediaGallery` component to accommodate Steam CDN video URLs, alongside the existing YouTube `<iframe>` embeds. 

**Changes:**
- Extracted and differentiated `videoType` (`youtube` vs `steam`) based on URL origin.
- Added native `<video>` player fallback with standard attributes (`autoPlay`, `muted`, `playsInline`) for Steam URLs.
- Fixed a minor styling policy violation by replacing a Next.js `style jsx` block with Tailwind CSS arbitrary variants for hidden scrollbars.
- Ran Prettier formatter for strict CI compliance.