### PR TITLE
Support Steam CDN video URLs in game imports

### DIFF
--- a/infra/steam.ts
+++ b/infra/steam.ts
@@ -20,6 +20,14 @@ export interface SteamAppDetailsData {
   website?: string;
   required_age?: number | string;
   release_date?: { coming_soon: boolean; date: string };
+  movies?: {
+    id: number;
+    name: string;
+    thumbnail: string;
+    webm?: { "480"?: string; max?: string };
+    mp4?: { "480"?: string; max?: string };
+    highlight?: boolean;
+  }[];
 }
 
 export interface SteamAppDetailsResult {

--- a/models/game.ts
+++ b/models/game.ts
@@ -213,15 +213,16 @@ function validateVideoUrl(url: string) {
   try {
     const videoUrl = new URL(url);
     const allowedHosts = ["www.youtube.com", "youtube.com", "youtu.be"];
+    const isSteamCdnHost = videoUrl.hostname.endsWith(".steamstatic.com");
 
-    if (!allowedHosts.includes(videoUrl.hostname)) {
+    if (!allowedHosts.includes(videoUrl.hostname) && !isSteamCdnHost) {
       throw new Error("Invalid video host");
     }
   } catch (error) {
     throw new ValidationError({
-      message: `Invalid video URL: ${url}. Videos must be a valid URL hosted on YouTube.`,
+      message: `Invalid video URL: ${url}. Videos must be a valid URL hosted on YouTube or Steam.`,
       cause: error,
-      action: "Check if video URL is valid and from YouTube.",
+      action: "Check if video URL is valid and from YouTube or Steam.",
     });
   }
 }
@@ -314,9 +315,7 @@ function mapSteamAppToGameData(
       banner: steamGame.header_image,
       screenshots: (steamGame.screenshots ?? []).map((s) => s.path_full),
       icon: steamGame.capsule_image,
-      // Steam trailers aren't YouTube-hosted; validateVideoUrl only allows
-      // YouTube, so trailer import is intentionally out of scope.
-      videos: [],
+      videos: extractSteamTrailerUrls(steamGame.movies),
     },
     social_links: {
       website,
@@ -324,6 +323,14 @@ function mapSteamAppToGameData(
     },
     steam_app_id: steamAppId,
   };
+}
+
+function extractSteamTrailerUrls(
+  movies?: SteamAppDetailsData["movies"],
+): string[] {
+  return (movies ?? [])
+    .map((movie) => movie.mp4?.max || movie.mp4?.["480"])
+    .filter((url): url is string => Boolean(url));
 }
 
 function parseSteamReleaseDate(releaseDate?: {

--- a/tests/integration/api/v1/items/games/post.test.ts
+++ b/tests/integration/api/v1/items/games/post.test.ts
@@ -731,8 +731,8 @@ describe("POST /api/v1/items/games", () => {
       expect(responseBody).toEqual({
         name: "ValidationError",
         message:
-          "Invalid video URL: https://vimeo.com/123456789. Videos must be a valid URL hosted on YouTube.",
-        action: "Check if video URL is valid and from YouTube.",
+          "Invalid video URL: https://vimeo.com/123456789. Videos must be a valid URL hosted on YouTube or Steam.",
+        action: "Check if video URL is valid and from YouTube or Steam.",
         status_code: 400,
       });
     });

--- a/tests/integration/api/v1/items/games/steam-import/post.test.ts
+++ b/tests/integration/api/v1/items/games/steam-import/post.test.ts
@@ -61,7 +61,13 @@ describe("POST /api/v1/items/games/steam-import", () => {
       expect(responseBody.social_links.steam_page).toBe(
         `https://store.steampowered.com/app/${STEAM_TEST_APP_ID}/`,
       );
-      expect(responseBody.media.videos).toEqual([]);
+      expect(Array.isArray(responseBody.media.videos)).toBe(true);
+      for (const videoUrl of responseBody.media.videos) {
+        expect(() => new URL(videoUrl)).not.toThrow();
+        expect(new URL(videoUrl).hostname.endsWith(".steamstatic.com")).toBe(
+          true,
+        );
+      }
       expect(Number(responseBody.price)).toBeGreaterThan(0);
       expect(typeof responseBody.title).toBe("string");
       expect(responseBody.title.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Description

Extends video URL validation to accept Steam CDN-hosted videos (`.steamstatic.com` domains) in addition to YouTube. This enables importing game trailers directly from Steam API data during game imports.

### Changes

- **Video URL validation:** Updated `validateVideoUrl()` to allow `.steamstatic.com` hosts alongside YouTube
- **Steam trailer extraction:** Added `extractSteamTrailerUrls()` function to parse trailer URLs from Steam API movie data, preferring max quality MP4 files with fallback to 480p
- **Type definitions:** Extended `SteamAppDetailsData` interface to include the `movies` field from Steam API
- **Game mapping:** Modified `mapSteamAppToGameData()` to populate videos from Steam trailers instead of leaving the array empty
- **Tests:** Updated integration test to validate that imported Steam games contain valid Steam CDN video URLs

## Related issue

N/A

## Type of change

- [x] ✨ New feature
- [x] 🧪 Tests

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] `npm run lint:eslint:check` passes
- [x] `npm run lint:prettier:check` passes
- [x] `npm run test` passes
- [x] Added or updated tests where relevant

https://claude.ai/code/session_01ET4erZPyLrNsfSjFrMaTYD