### PR TITLE
fix: populate video media from Steam trailers on import

### DIFF
--- a/components/store/MediaGallery.tsx
+++ b/components/store/MediaGallery.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo, useRef, useEffect } from "react";
 import Image from "next/image";
+import Hls from "hls.js";
 import {
   IconPlayerPlayFilled,
   IconChevronLeft,
@@ -18,6 +19,52 @@ type MediaItem = {
   url: string;
   id?: string;
 };
+
+// Steam serves newer trailers only as HLS (.m3u8) manifests, which play
+// natively in Safari/iOS but need hls.js everywhere else. Older mp4/webm
+// URLs (also passed through here) play fine as a direct <video src>.
+function SteamVideoPlayer({
+  url,
+  className,
+}: {
+  url: string;
+  className: string;
+}) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+
+    if (
+      !url.includes(".m3u8") ||
+      video.canPlayType("application/vnd.apple.mpegurl")
+    ) {
+      video.src = url;
+      return;
+    }
+
+    if (Hls.isSupported()) {
+      const hls = new Hls();
+      hls.loadSource(url);
+      hls.attachMedia(video);
+      return () => hls.destroy();
+    }
+
+    video.src = url;
+  }, [url]);
+
+  return (
+    <video
+      ref={videoRef}
+      controls
+      autoPlay
+      muted
+      playsInline
+      className={className}
+    />
+  );
+}
 
 export function MediaGallery({ videos, images, gameTitle }: MediaGalleryProps) {
   const [activeIndex, setActiveIndex] = useState(0);
@@ -158,12 +205,8 @@ export function MediaGallery({ videos, images, gameTitle }: MediaGalleryProps) {
               allowFullScreen
             />
           ) : (
-            <video
-              src={activeMedia.url}
-              controls
-              autoPlay
-              muted
-              playsInline
+            <SteamVideoPlayer
+              url={activeMedia.url}
               className="absolute inset-0 w-full h-full object-cover"
             />
           )

--- a/infra/steam.ts
+++ b/infra/steam.ts
@@ -24,8 +24,16 @@ export interface SteamAppDetailsData {
     id: number;
     name: string;
     thumbnail: string;
+    // Legacy progressive-download encodes. Steam has largely moved to
+    // streaming-only manifests (dash_h264/hls_h264 below) for newer titles,
+    // so these are frequently absent.
     webm?: { "480"?: string; max?: string };
     mp4?: { "480"?: string; max?: string };
+    // Streaming manifests. hls_h264 plays natively in Safari/iOS and via
+    // hls.js elsewhere (see components/store/MediaGallery.tsx).
+    hls_h264?: string;
+    dash_h264?: string;
+    dash_av1?: string;
     highlight?: boolean;
   }[];
 }

--- a/models/game.ts
+++ b/models/game.ts
@@ -334,7 +334,8 @@ function extractSteamTrailerUrls(
         movie.mp4?.max ||
         movie.mp4?.["480"] ||
         movie.webm?.max ||
-        movie.webm?.["480"],
+        movie.webm?.["480"] ||
+        movie.hls_h264,
     )
     .filter((url): url is string => Boolean(url));
 }

--- a/models/game.ts
+++ b/models/game.ts
@@ -329,7 +329,13 @@ function extractSteamTrailerUrls(
   movies?: SteamAppDetailsData["movies"],
 ): string[] {
   return (movies ?? [])
-    .map((movie) => movie.mp4?.max || movie.mp4?.["480"])
+    .map(
+      (movie) =>
+        movie.mp4?.max ||
+        movie.mp4?.["480"] ||
+        movie.webm?.max ||
+        movie.webm?.["480"],
+    )
     .filter((url): url is string => Boolean(url));
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "manifoldpowered.com",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "3.1038.0",
         "@aws-sdk/s3-request-presigner": "3.1038.0",
@@ -19,6 +19,7 @@
         "async-retry": "1.3.3",
         "bcryptjs": "3.0.3",
         "cookie": "1.1.1",
+        "hls.js": "1.6.16",
         "lucide-react": "1.8.0",
         "next": "16.2.3",
         "next-connect": "1.0.0",
@@ -10006,6 +10007,12 @@
       "dependencies": {
         "hermes-estree": "0.25.1"
       }
+    },
+    "node_modules/hls.js": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz",
+      "integrity": "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==",
+      "license": "Apache-2.0"
     },
     "node_modules/homedir-polyfill": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "async-retry": "1.3.3",
     "bcryptjs": "3.0.3",
     "cookie": "1.1.1",
+    "hls.js": "1.6.16",
     "lucide-react": "1.8.0",
     "next": "16.2.3",
     "next-connect": "1.0.0",


### PR DESCRIPTION
## Description

Steam-imported games never got trailer videos: `mapSteamAppToGameData` always set `media.videos` to `[]`, and `validateVideoUrl` only allowed YouTube hosts.

This PR:
- Extracts trailer URLs from Steam's `movies` field and allows Steam's `*.steamstatic.com` video CDN in `validateVideoUrl` (previously YouTube-only).
- Falls back through `mp4` → `webm` → `hls_h264`, since Steam has moved newer titles (e.g. Resident Evil Requiem) to streaming-only HLS/DASH manifests with no progressive-download file at all.
- Adds `hls.js` (exact-pinned) and wires it into `MediaGallery.tsx` so `.m3u8` trailers play in browsers without native HLS support (Safari already plays HLS natively).

## Related issue

N/A

## Type of change

- [x] 🐛 Bug fix

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [ ] `npm run lint:eslint:check` passes (not run locally — no network/Docker access in this environment; verify via CI)
- [x] `npm run lint:prettier:check` passes
- [ ] `npm run test` passes (not run locally — this environment has no Docker and can't reach the Steam API; verify via CI)
- [x] Added or updated tests where relevant


---
_Generated by [Claude Code](https://claude.ai/code/session_01ET4erZPyLrNsfSjFrMaTYD)_