### PR TITLE
refactor: migrate money columns to Decimal(19,4)

### DIFF
--- a/docs/legal/business-description.md
+++ b/docs/legal/business-description.md
@@ -3,7 +3,7 @@
 > Purpose: the disclosure text submitted to payment processors (Stripe, and any
 > backup provider) when applying for approval to sell digital game/gift card
 > codes. Written to be handed over as-is. Keep it accurate — if the product
-> changes, update this file *before* the change ships.
+> changes, update this file _before_ the change ships.
 
 ## Summary
 

--- a/docs/legal/business-description.md
+++ b/docs/legal/business-description.md
@@ -8,9 +8,9 @@
 ## Summary
 
 Manifold is a digital goods storefront operated by <LEGAL ENTITY NAME>,
-incorporated in <JURISDICTION>. Manifold sells prepaid digital game codes and
-gift cards to consumers at manifoldpowered.com and on branded sub-storefronts
-hosted on the same platform.
+incorporated in <JURISDICTION>. Manifold sells branded digital gift cards to
+consumers at manifoldpowered.com and on branded sub-storefronts hosted on the
+same platform. Launch markets are the United States and Brazil.
 
 **Manifold is the seller and merchant of record for every transaction.** There
 is no third-party seller. All consumer payments are collected by Manifold, all
@@ -19,12 +19,13 @@ disputes are handled by Manifold.
 
 ## Inventory sourcing
 
-All codes are purchased wholesale from CodesWholesale
-(https://codeswholesale.com/), a licensed B2B distributor of digital game keys,
-under a supply agreement. Manifold takes title to inventory. Codes are drawn
-from CodesWholesale's API at the moment of fulfilment. Manifold does not accept
-user-supplied, user-uploaded, or user-traded codes at any point — there is no
-consumer-to-consumer or seller-to-consumer resale channel on the platform.
+All gift cards are sourced from Reloadly (https://www.reloadly.com/), a
+regulated digital gift card and payments distributor, under a commercial
+agreement. Manifold funds a prepaid balance with Reloadly and draws each code
+from Reloadly's API at the moment of fulfilment, taking title to the code on
+purchase. Manifold does not accept user-supplied, user-uploaded, or user-traded
+codes at any point — there is no consumer-to-consumer or seller-to-consumer
+resale channel on the platform, and no secondary market.
 
 ## The affiliate storefront model
 
@@ -55,7 +56,8 @@ facilitator or intermediary for any third party.
 ## Fulfilment
 
 1. Consumer pays Manifold at checkout.
-2. On payment confirmation, Manifold requests a code from CodesWholesale.
+2. On payment confirmation, Manifold places an order against Reloadly's Gift
+   Cards API and retrieves the redeem code/PIN.
 3. If the supplier call succeeds, the code is assigned to the order and revealed
    to the consumer (in-account reveal plus email). Reveal time is recorded.
 4. If the supplier call fails, the order is auto-refunded in full and no code is

--- a/docs/legal/business-description.md
+++ b/docs/legal/business-description.md
@@ -1,0 +1,100 @@
+# Manifold — Business Description (Payment Processor Application)
+
+> Purpose: the disclosure text submitted to payment processors (Stripe, and any
+> backup provider) when applying for approval to sell digital game/gift card
+> codes. Written to be handed over as-is. Keep it accurate — if the product
+> changes, update this file *before* the change ships.
+
+## Summary
+
+Manifold is a digital goods storefront operated by <LEGAL ENTITY NAME>,
+incorporated in <JURISDICTION>. Manifold sells prepaid digital game codes and
+gift cards to consumers at manifoldpowered.com and on branded sub-storefronts
+hosted on the same platform.
+
+**Manifold is the seller and merchant of record for every transaction.** There
+is no third-party seller. All consumer payments are collected by Manifold, all
+inventory is purchased by Manifold, and all consumer support, refunds, and
+disputes are handled by Manifold.
+
+## Inventory sourcing
+
+All codes are purchased wholesale from CodesWholesale
+(https://codeswholesale.com/), a licensed B2B distributor of digital game keys,
+under a supply agreement. Manifold takes title to inventory. Codes are drawn
+from CodesWholesale's API at the moment of fulfilment. Manifold does not accept
+user-supplied, user-uploaded, or user-traded codes at any point — there is no
+consumer-to-consumer or seller-to-consumer resale channel on the platform.
+
+## The affiliate storefront model
+
+Registered users may create a branded storefront on Manifold and curate which
+titles from Manifold's catalogue appear on it. These users are **affiliates
+(marketing partners)**, not sellers. Specifically:
+
+- Affiliates never take title to any inventory.
+- Affiliates never set, alter, or discount prices. Pricing is set solely by
+  Manifold and is identical across every storefront.
+- Affiliates never receive, hold, or route consumer funds. Checkout runs
+  entirely through Manifold's own processor account.
+- Affiliates have no contractual relationship with the consumer. The consumer's
+  contract of sale is with Manifold, and Manifold's Terms of Sale are presented
+  at checkout on every storefront.
+- Affiliates receive no consumer personal data — they see aggregate sales
+  figures only.
+- Affiliates earn a percentage commission, paid by Manifold out of Manifold's
+  own revenue, as an ordinary marketing expense. Commission is held for 30 days
+  after the sale and is forfeited/clawed back if the underlying sale is refunded
+  or charged back.
+
+Functionally this is a standard affiliate/referral programme with a
+white-labelled landing surface. It is not a marketplace: Manifold does not
+onboard sellers, does not split payments, and does not act as a payment
+facilitator or intermediary for any third party.
+
+## Fulfilment
+
+1. Consumer pays Manifold at checkout.
+2. On payment confirmation, Manifold requests a code from CodesWholesale.
+3. If the supplier call succeeds, the code is assigned to the order and revealed
+   to the consumer (in-account reveal plus email). Reveal time is recorded.
+4. If the supplier call fails, the order is auto-refunded in full and no code is
+   delivered.
+
+Typical delivery time: under 60 seconds. Nothing is shipped physically.
+
+## Refunds and dispute handling
+
+Codes are non-refundable **once revealed**, disclosed prominently pre-purchase
+and re-confirmed with an explicit click-through at the reveal step. Unrevealed
+orders are refundable within 14 days, no questions asked. Supplier failures are
+refunded automatically.
+
+Dispute evidence retained per order: authenticated account identity, IP and
+device at purchase, the pre-purchase non-refundability acceptance, the reveal
+timestamp, and the delivery email receipt.
+
+## Fraud controls
+
+- Purchases require a registered, email-activated account. No guest checkout.
+- Velocity limits per account, per card, and per IP.
+- Manual review hold on the first order placed through any newly created
+  storefront.
+- Billing-country vs. code-region mismatch blocks.
+- Minimum payout threshold and a 30-day commission hold, making the affiliate
+  channel unattractive as a laundering route.
+- Affiliates are identity-verified and tax-documented before any payout.
+
+## Expected volumes
+
+- Average order value: <FILL>
+- Expected monthly volume at launch: <FILL>
+- Expected monthly volume at 12 months: <FILL>
+- Target chargeback rate: below <FILL>%
+
+## Contacts
+
+- Legal entity: <FILL>
+- Registered address: <FILL>
+- Tax/VAT registration: <FILL>
+- Compliance contact: <FILL>

--- a/docs/legal/phase-0-checklist.md
+++ b/docs/legal/phase-0-checklist.md
@@ -1,7 +1,7 @@
 # Phase 0 — Legal & Financial Groundwork
 
 Blocking work that must complete before payment/ledger code ships. Nothing in
-Phase 1+ is safe to launch (though it is safe to *build*) until items 1–4 close.
+Phase 1+ is safe to launch (though it is safe to _build_) until items 1–4 close.
 
 Status key: [ ] not started · [~] in progress · [x] done
 
@@ -12,9 +12,9 @@ Status key: [ ] not started · [~] in progress · [x] done
 **Deliverable:** written approval to process the digital game/gift card category
 under the model described in `business-description.md`.
 
-- [ ] Submit `business-description.md` to Stripe. Ask explicitly: *"Please
+- [ ] Submit `business-description.md` to Stripe. Ask explicitly: _"Please
       confirm our account is approved for the sale of branded digital gift cards
-      under this model."* Get it in writing — a support ticket reply is fine, a
+      under this model."_ Get it in writing — a support ticket reply is fine, a
       verbal from sales is not.
 - [ ] Ask specifically whether the affiliate storefront model requires Connect,
       or whether commission payouts as an ordinary expense are acceptable on a
@@ -40,7 +40,7 @@ Questions to get answered in writing before integrating:
       (Reloadly markets itself as a reseller-enablement API, so this is likely
       yes — get it confirmed in writing anyway.)
 - [ ] **Dead/invalid code liability.** Reloadly's published terms state refunds,
-      exchanges and returns are *not applicable* to digital products, with a
+      exchanges and returns are _not applicable_ to digital products, with a
       narrow exception where we can show publisher confirmation that the code
       was redeemed before delivery. Confirm the exact claim process, window, and
       evidence standard — and assume most bad codes are our loss.
@@ -74,7 +74,7 @@ the data model, so close this before Phase 1 migrations are finalised.
 - [ ] Confirm the entity and where it is incorporated.
 - [ ] VAT/OSS/sales-tax: where are we registered, what are the thresholds, and
       does selling prepaid codes cross-border change the place-of-supply
-      treatment? (Digital goods rules commonly tax at the *consumer's*
+      treatment? (Digital goods rules commonly tax at the _consumer's_
       location — this drives what we must collect and store at checkout.)
 - [ ] Are affiliate commissions reportable income requiring tax-ID collection
       and annual reporting? Determine per affiliate jurisdiction and set the
@@ -106,18 +106,18 @@ than starting from a blank page.
 
 Record here as each closes, with date and evidence link:
 
-| Decision | Outcome | Date | Evidence |
-| --- | --- | --- | --- |
-| Processor approval (primary) | | | |
-| Processor approval (backup) | | | |
-| Connect required? | | | |
-| Rolling reserve terms | | | |
-| Reloadly resale permitted | | | |
-| Dead-code liability | | | |
-| Discount stability / margin | | | |
-| Wallet float requirement | | | |
-| VAT/place-of-supply treatment | | | |
-| Affiliate tax reporting required | | | |
+| Decision                         | Outcome | Date | Evidence |
+| -------------------------------- | ------- | ---- | -------- |
+| Processor approval (primary)     |         |      |          |
+| Processor approval (backup)      |         |      |          |
+| Connect required?                |         |      |          |
+| Rolling reserve terms            |         |      |          |
+| Reloadly resale permitted        |         |      |          |
+| Dead-code liability              |         |      |          |
+| Discount stability / margin      |         |      |          |
+| Wallet float requirement         |         |      |          |
+| VAT/place-of-supply treatment    |         |      |          |
+| Affiliate tax reporting required |         |      |          |
 
 ---
 

--- a/docs/legal/phase-0-checklist.md
+++ b/docs/legal/phase-0-checklist.md
@@ -13,7 +13,7 @@ Status key: [ ] not started · [~] in progress · [x] done
 under the model described in `business-description.md`.
 
 - [ ] Submit `business-description.md` to Stripe. Ask explicitly: *"Please
-      confirm our account is approved for the sale of prepaid digital game codes
+      confirm our account is approved for the sale of branded digital gift cards
       under this model."* Get it in writing — a support ticket reply is fine, a
       verbal from sales is not.
 - [ ] Ask specifically whether the affiliate storefront model requires Connect,
@@ -31,29 +31,40 @@ under the model described in `business-description.md`.
 approval, and a category violation discovered post-launch means frozen funds
 plus undelivered orders you have already been paid for.
 
-## 2. CodesWholesale supply agreement [ ]
+## 2. Reloadly supply agreement [ ]
 
 Questions to get answered in writing before integrating:
 
-- [ ] Does our contract permit resale to consumers via affiliate-branded
+- [ ] Does our agreement permit resale to consumers via affiliate-branded
       storefronts under our own brand? Any restriction on white-labelling?
-- [ ] Who bears the loss on a dead, duplicate, region-locked, or
-      already-redeemed key? What is the claim window and evidence standard?
-- [ ] Is there an API SLA? What is the documented behaviour when a code reserve
-      call fails or times out mid-transaction — is a timed-out call ever
-      chargeable to us?
-- [ ] Are there territorial restrictions on where we may sell? (This determines
-      geo-blocking rules at checkout.)
-- [ ] What are the pricing/stock refresh guarantees? If wholesale price moves
-      between catalogue sync and sale, who absorbs it?
-- [ ] Are there minimum volume commitments or prepayment/float requirements?
-      (Affects working capital — you pay the supplier before consumer funds
-      settle.)
+      (Reloadly markets itself as a reseller-enablement API, so this is likely
+      yes — get it confirmed in writing anyway.)
+- [ ] **Dead/invalid code liability.** Reloadly's published terms state refunds,
+      exchanges and returns are *not applicable* to digital products, with a
+      narrow exception where we can show publisher confirmation that the code
+      was redeemed before delivery. Confirm the exact claim process, window, and
+      evidence standard — and assume most bad codes are our loss.
+- [ ] Is there an API SLA? Documented behaviour when an order call fails or
+      times out mid-transaction — is a timed-out order ever chargeable to us,
+      and how do we reconcile an ambiguous order state?
+- [ ] Territorial restrictions on where we may sell, and confirmation that US
+      and Brazil consumer sales are permitted.
+- [ ] Discount/commission structure per product, and whether discounts are
+      guaranteed for a period or can move without notice. **This is our entire
+      gross margin** — if a product discount drops after we set a retail price,
+      we absorb it.
+- [ ] Prepaid wallet mechanics: minimum balance, top-up settlement time,
+      supported funding currencies, whether balance is refundable on exit, and
+      what happens to in-flight orders if balance runs out mid-day.
+- [ ] Volume commitments or tiering thresholds.
 
-**Working-capital note:** processor settlement is typically T+2 to T+7, and any
-rolling reserve extends that, while CodesWholesale is likely prepaid. Model the
-gap before launch — this is the most common way a marketplace MVP dies with
-healthy-looking revenue.
+**Working-capital note (now sharper):** Reloadly operates a **prepaid wallet**
+— we fund before we sell, with no credit terms. Card settlement is typically
+T+2 to T+7, and any rolling reserve extends that. So we float the entire
+inventory cost plus the settlement gap. Model this before launch; it is the most
+common way a marketplace MVP dies with healthy-looking revenue. A wallet
+auto-top-up threshold and low-balance alerting are launch requirements, not
+nice-to-haves — an empty wallet means paid orders we cannot fulfil.
 
 ## 3. Entity and tax posture [ ]
 
@@ -101,8 +112,10 @@ Record here as each closes, with date and evidence link:
 | Processor approval (backup) | | | |
 | Connect required? | | | |
 | Rolling reserve terms | | | |
-| CodesWholesale resale permitted | | | |
-| Dead-key liability | | | |
+| Reloadly resale permitted | | | |
+| Dead-code liability | | | |
+| Discount stability / margin | | | |
+| Wallet float requirement | | | |
 | VAT/place-of-supply treatment | | | |
 | Affiliate tax reporting required | | | |
 

--- a/docs/legal/phase-0-checklist.md
+++ b/docs/legal/phase-0-checklist.md
@@ -1,0 +1,128 @@
+# Phase 0 — Legal & Financial Groundwork
+
+Blocking work that must complete before payment/ledger code ships. Nothing in
+Phase 1+ is safe to launch (though it is safe to *build*) until items 1–4 close.
+
+Status key: [ ] not started · [~] in progress · [x] done
+
+---
+
+## 1. Payment processor approval [ ]
+
+**Deliverable:** written approval to process the digital game/gift card category
+under the model described in `business-description.md`.
+
+- [ ] Submit `business-description.md` to Stripe. Ask explicitly: *"Please
+      confirm our account is approved for the sale of prepaid digital game codes
+      under this model."* Get it in writing — a support ticket reply is fine, a
+      verbal from sales is not.
+- [ ] Ask specifically whether the affiliate storefront model requires Connect,
+      or whether commission payouts as an ordinary expense are acceptable on a
+      standard account. (Expected: standard account is fine. Confirm it.)
+- [ ] Apply to at least one backup in parallel — Paddle, Adyen, or a
+      games-vertical specialist. Do not launch single-threaded on one processor
+      in a high-risk category; deplatforming mid-growth is the single largest
+      existential risk to this MVP.
+- [ ] Record reserve/rolling-reserve terms offered by each. High-risk categories
+      often carry a rolling reserve; this directly affects your cash flow and
+      whether a 30-day commission hold is even affordable.
+
+**Do not proceed to launch on a "they haven't said no" basis.** Silence is not
+approval, and a category violation discovered post-launch means frozen funds
+plus undelivered orders you have already been paid for.
+
+## 2. CodesWholesale supply agreement [ ]
+
+Questions to get answered in writing before integrating:
+
+- [ ] Does our contract permit resale to consumers via affiliate-branded
+      storefronts under our own brand? Any restriction on white-labelling?
+- [ ] Who bears the loss on a dead, duplicate, region-locked, or
+      already-redeemed key? What is the claim window and evidence standard?
+- [ ] Is there an API SLA? What is the documented behaviour when a code reserve
+      call fails or times out mid-transaction — is a timed-out call ever
+      chargeable to us?
+- [ ] Are there territorial restrictions on where we may sell? (This determines
+      geo-blocking rules at checkout.)
+- [ ] What are the pricing/stock refresh guarantees? If wholesale price moves
+      between catalogue sync and sale, who absorbs it?
+- [ ] Are there minimum volume commitments or prepayment/float requirements?
+      (Affects working capital — you pay the supplier before consumer funds
+      settle.)
+
+**Working-capital note:** processor settlement is typically T+2 to T+7, and any
+rolling reserve extends that, while CodesWholesale is likely prepaid. Model the
+gap before launch — this is the most common way a marketplace MVP dies with
+healthy-looking revenue.
+
+## 3. Entity and tax posture [ ]
+
+Take these to an accountant in your incorporation jurisdiction. Answers change
+the data model, so close this before Phase 1 migrations are finalised.
+
+- [ ] Confirm the entity and where it is incorporated.
+- [ ] VAT/OSS/sales-tax: where are we registered, what are the thresholds, and
+      does selling prepaid codes cross-border change the place-of-supply
+      treatment? (Digital goods rules commonly tax at the *consumer's*
+      location — this drives what we must collect and store at checkout.)
+- [ ] Are affiliate commissions reportable income requiring tax-ID collection
+      and annual reporting? Determine per affiliate jurisdiction and set the
+      reporting threshold.
+- [ ] **Schema impact:** if tax IDs and legal addresses are required, they must
+      exist on `PayoutAccount` from the first migration, encrypted at rest, and
+      be excluded from every `filterOutput` path.
+- [ ] Confirm treatment of the 30-day commission hold — accrued liability vs.
+      unearned. Affects revenue recognition and the ledger account structure.
+
+## 4. Document set [ ]
+
+Draft with counsel. `storefront-owner-agreement-termsheet.md` in this directory
+is the input brief for the affiliate agreement — hand it to the lawyer rather
+than starting from a blank page.
+
+- [ ] **Consumer Terms of Sale** — Manifold as seller of record; affiliate
+      storefronts explicitly disclosed as marketing surfaces operated under
+      Manifold's terms.
+- [ ] **Refund Policy** — non-refundable once revealed; 14-day window while
+      unrevealed; auto-refund on supplier failure. Must be linked pre-purchase
+      and acknowledged at reveal.
+- [ ] **Storefront Owner (Affiliate) Agreement** — see term sheet.
+- [ ] **Privacy Policy** — must state affiliates receive aggregate data only.
+- [ ] **Acceptable Use / storefront content rules** — you are lending your brand
+      and your merchant account to user-branded pages; you need takedown rights.
+
+## 5. Decision log
+
+Record here as each closes, with date and evidence link:
+
+| Decision | Outcome | Date | Evidence |
+| --- | --- | --- | --- |
+| Processor approval (primary) | | | |
+| Processor approval (backup) | | | |
+| Connect required? | | | |
+| Rolling reserve terms | | | |
+| CodesWholesale resale permitted | | | |
+| Dead-key liability | | | |
+| VAT/place-of-supply treatment | | | |
+| Affiliate tax reporting required | | | |
+
+---
+
+## Standing constraint: protect the affiliate characterisation
+
+The affiliate model holds only while it is true in substance. As of today
+`StoreGameOverride` carries visibility only — storefront owners curate which
+titles appear but **cannot set prices**. That single fact is the strongest
+evidence that they are marketers rather than sellers.
+
+Before shipping any of the following, re-confirm the legal position with
+counsel, because each one moves storefront owners toward being sellers — which
+would pull you into marketplace, payment-facilitator, and per-seller tax
+obligations:
+
+- Per-store price overrides or storefront-set discounts.
+- Letting storefront owners list inventory they source themselves.
+- Giving storefront owners access to consumer identity or contact data.
+- Letting storefront owners handle consumer support, refunds, or disputes.
+- Custom domains presented as an independent business rather than as "powered by
+  Manifold".

--- a/docs/legal/storefront-owner-agreement-termsheet.md
+++ b/docs/legal/storefront-owner-agreement-termsheet.md
@@ -1,0 +1,97 @@
+# Storefront Owner (Affiliate) Agreement — Term Sheet
+
+> Not a contract. This is the drafting brief to hand to counsel, capturing the
+> commercial terms and the characterisation the platform's compliance posture
+> depends on. Each term maps to a system behaviour — the contract and the code
+> must not drift apart.
+
+## Parties and characterisation
+
+- Manifold (<LEGAL ENTITY>) — seller and merchant of record.
+- Storefront Owner — an independent marketing affiliate. Not an employee, agent,
+  partner, joint venturer, or reseller.
+
+The agreement must state plainly that the Storefront Owner:
+
+- takes no title to any product at any time;
+- has no authority to bind Manifold or to make representations on its behalf;
+- is not party to any contract of sale with a consumer;
+- may not describe themselves as the seller, merchant, or retailer.
+
+## Commercial terms
+
+| Term | Value | System behaviour |
+| --- | --- | --- |
+| Commission rate | <FILL>% of net sale value | `LedgerEntry.affiliate_commission` |
+| Commission basis | Net of tax, refunds, supplier cost | Computed at fulfilment |
+| Hold period | 30 days from payment | Maturation job |
+| Payout schedule | Monthly, matured balances only | `Payout` batch |
+| Minimum payout | <FILL> | Blocks payout below threshold |
+| Payment method | <FILL> | — |
+| Currency / FX | <FILL>, FX cost borne by <FILL> | — |
+
+## Terms the platform's risk position depends on
+
+**Pricing control.** Manifold sets all prices. The Storefront Owner has no right
+to set, alter, discount, or bundle prices. *(Enforced today by
+`StoreGameOverride` carrying visibility only.)*
+
+**No funds handling.** All consumer payments are collected by Manifold. The
+Storefront Owner has no right to collect payment, request payment off-platform,
+or direct consumers to any other payment method. Off-platform payment collection
+is a material breach and grounds for immediate termination and forfeiture.
+
+**Commission is contingent, not earned at sale.** Commission accrues on payment
+but becomes payable only after the hold period expires with no refund, dispute,
+or chargeback on the underlying order. This must be drafted as a condition
+precedent to payment, not as a debt subject to later deduction — the distinction
+matters if an affiliate becomes insolvent.
+
+**Clawback.** Where commission has been paid and the underlying sale is later
+refunded or charged back, the amount is recoverable, and Manifold may set it off
+against future commissions. Negative balances carry forward.
+
+**Fraud forfeiture.** Commission on any order Manifold determines in good faith
+to be fraudulent, self-dealing, or the product of prohibited traffic is
+forfeited in full, whether or not matured.
+
+**Prohibited promotion.** No spam, no misrepresentation of Manifold or the
+goods, no trademark bidding on Manifold's marks, no incentivised or bot traffic,
+no promotion to minors, no promotion in territories where Manifold does not
+sell, no claims about code region or validity beyond the catalogue text.
+
+**Verification and tax.** No payout until identity verification and tax
+documentation are complete. Manifold may withhold where required by law.
+
+**Data.** The Storefront Owner receives aggregate sales data only, never
+consumer personal data, and never product codes. Any incidental receipt must be
+reported and deleted.
+
+**Termination.** Either party on <FILL> days' notice; Manifold immediately for
+breach, fraud, or legal/processor requirement. On termination, matured
+commissions are paid on the normal schedule; unmatured commissions <FILL —
+decide: forfeited, or paid on maturation>. Storefront goes offline immediately.
+
+**Suspension.** Manifold may suspend a storefront and withhold payouts pending
+investigation, for up to <FILL> days.
+
+**Amendment.** Manifold may amend commission rates and programme terms on <FILL>
+days' notice; continued participation is acceptance.
+
+**Liability.** No guarantee of sales, traffic, or availability. Manifold's
+aggregate liability capped at commissions paid in the preceding <FILL> months.
+
+**Governing law.** <FILL>.
+
+## Open decisions for you
+
+1. Commission rate, and whether it varies by volume tier or title.
+2. Unmatured commission on termination — forfeited or paid out? Forfeiture is
+   cleaner operationally and a stronger anti-abuse lever; paying out is fairer
+   and better for recruiting affiliates. Recommend: pay on maturation for
+   voluntary termination, forfeit for termination for cause.
+3. Whether affiliates may operate custom domains. Recommend: not at MVP — a
+   custom domain badly weakens the "marketing surface, not independent seller"
+   characterisation, for little launch value.
+4. Whether to cap the number of storefronts per user (recommend: yes, one at
+   MVP — multiple storefronts per identity is a standard laundering pattern).

--- a/docs/legal/storefront-owner-agreement-termsheet.md
+++ b/docs/legal/storefront-owner-agreement-termsheet.md
@@ -20,21 +20,21 @@ The agreement must state plainly that the Storefront Owner:
 
 ## Commercial terms
 
-| Term | Value | System behaviour |
-| --- | --- | --- |
-| Commission rate | <FILL>% of net sale value | `LedgerEntry.affiliate_commission` |
-| Commission basis | Net of tax, refunds, supplier cost | Computed at fulfilment |
-| Hold period | 30 days from payment | Maturation job |
-| Payout schedule | Monthly, matured balances only | `Payout` batch |
-| Minimum payout | <FILL> | Blocks payout below threshold |
-| Payment method | <FILL> | — |
-| Currency / FX | <FILL>, FX cost borne by <FILL> | — |
+| Term             | Value                              | System behaviour                   |
+| ---------------- | ---------------------------------- | ---------------------------------- |
+| Commission rate  | <FILL>% of net sale value          | `LedgerEntry.affiliate_commission` |
+| Commission basis | Net of tax, refunds, supplier cost | Computed at fulfilment             |
+| Hold period      | 30 days from payment               | Maturation job                     |
+| Payout schedule  | Monthly, matured balances only     | `Payout` batch                     |
+| Minimum payout   | <FILL>                             | Blocks payout below threshold      |
+| Payment method   | <FILL>                             | —                                  |
+| Currency / FX    | <FILL>, FX cost borne by <FILL>    | —                                  |
 
 ## Terms the platform's risk position depends on
 
 **Pricing control.** Manifold sets all prices. The Storefront Owner has no right
-to set, alter, discount, or bundle prices. *(Enforced today by
-`StoreGameOverride` carrying visibility only.)*
+to set, alter, discount, or bundle prices. _(Enforced today by
+`StoreGameOverride` carrying visibility only.)_
 
 **No funds handling.** All consumer payments are collected by Manifold. The
 Storefront Owner has no right to collect payment, request payment off-platform,

--- a/docs/payments-tasks.md
+++ b/docs/payments-tasks.md
@@ -1,4 +1,4 @@
-# Payments — Ledger & Payouts Task Breakdown
+# Payments — Ledger, Multi-Currency Pricing & Payouts
 
 Delivery plan for [#177](https://github.com/pedromello/manifoldpowered.com/issues/177) (Milestone 3: Payment Structure — Sales and Payouts).
 
@@ -10,16 +10,29 @@ Each task is a separate small PR, landed in order, with `npm run test` passing o
 
 ## The model in one paragraph
 
-Manifold is the **merchant of record**. Consumers buy gift cards from us; storefront owners are **marketing affiliates** who never take title, never set prices and never touch consumer money. We collect the full payment, hold the affiliate's commission for 30 days so refunds and chargebacks can resolve, then pay a **periodic lump sum** per affiliate — a real fiscal payment against a statement, the way Steam pays developers. This is deliberately *not* a per-transaction payment split.
+Manifold is the **merchant of record**. Consumers buy from us; storefront owners are **marketing affiliates** who never take title, never set prices and never touch consumer money. We collect the full payment, hold the affiliate's commission for 30 days so refunds and chargebacks can resolve, then pay a **periodic lump sum** per affiliate — a real fiscal payment against a statement, the way Steam pays developers. This is deliberately *not* a per-transaction payment split.
+
+## Settled decisions
+
+These are no longer open. They constrain everything below.
+
+- **Money is `Decimal(19,4)`** everywhere — ledger, prices, payouts. Four decimal places is the standard scale for tax-inclusive amounts, where intermediate calculations need more precision than the two decimals a currency displays. This replaces the current `String @db.VarChar(20)` convention, and existing money columns migrate to it (task 2) rather than leaving two representations in the codebase.
+- **USD is the base currency.** Every product carries a USD price. Other currencies are derived.
+- **Price resolution is override-first:**
+  ```
+  priceFor(game, currency) = fixedPriceOverride(game, currency)
+                          ?? convert(game.base_price_usd, currency)
+  ```
+  A developer-set fixed price for a currency always wins. Absent one, the price is converted from USD.
 
 ## Money flow
 
 ```mermaid
 flowchart TD
-    C[Consumer] -->|pays full retail price| P[Manifold — Merchant of Record]
-    P -->|draws code, prepaid wallet| R[Reloadly]
-    R -->|gift card code| C
-    P -->|writes balanced entries| L[(LedgerEntry — append-only)]
+    C[Consumer] -->|pays in local currency| P[Manifold — Merchant of Record]
+    P -->|draws code| S[Supplier]
+    S -->|gift card code| C
+    P -->|writes balanced entries| L[(LedgerEntry — append-only, Decimal 19,4)]
 
     L --> M{Maturation<br/>paid_at + 30 days}
     M -->|clean| MB[Matured balance]
@@ -31,10 +44,25 @@ flowchart TD
     TH -->|yes| PO[Payout batch]
 
     PO --> IF[PayoutProvider interface]
-    IF --> S[Stripe]
-    IF --> BR[Trolley / Wise — Brazil, Pix]
-    S --> A[Affiliate]
+    IF --> ST[Stripe]
+    IF --> BR[Alternate rail — Pix]
+    ST --> A[Affiliate]
     BR --> A
+```
+
+## Price resolution
+
+```mermaid
+flowchart LR
+    R[priceFor game, currency] --> O{Fixed override<br/>for this currency?}
+    O -->|yes| F[Use developer-set price]
+    O -->|no| E{Exchange rate<br/>available?}
+    E -->|yes| CV[convert base_price_usd → currency]
+    E -->|no| FB[Fall back to USD<br/>or hide product]
+    F --> RD[Apply rounding policy]
+    CV --> RD
+    RD --> OUT[Displayed price]
+    OUT -.->|snapshot amount + currency + rate| SALE[(Sale / Ledger)]
 ```
 
 ## One sale, end to end
@@ -43,15 +71,16 @@ flowchart TD
 sequenceDiagram
     participant C as Consumer
     participant M as Manifold
-    participant R as Reloadly
+    participant S as Supplier
     participant L as Ledger
 
-    C->>M: Pays retail price on affiliate storefront
-    M->>R: Order gift card (prepaid wallet)
-    R-->>M: Redeem code
+    C->>M: Pays resolved price in local currency
+    M->>M: Snapshot amount, currency and FX rate used
+    M->>S: Order gift card
+    S-->>M: Redeem code
     M-->>C: Reveal code (timestamp recorded)
     M->>L: supplier_cost −, platform_revenue +,<br/>affiliate_commission + (matures_at = now + 30d)
-    Note over L: Entries must sum to zero
+    Note over L: Entries must sum to zero, per currency
 
     alt Chargeback within 30 days
         M->>L: Reversing entries (sum to zero again)
@@ -68,7 +97,7 @@ sequenceDiagram
 
 ### 1. Foundation — features, fixtures, checklist
 
-**TLDR:** Register the eleven new permission strings before anything else exists, and fix the tests that assert the old permission list.
+**TLDR:** Register the new permission strings before anything else exists, and fix the tests that assert the old permission list.
 
 Nothing on this platform can be built before its features are registered in `AVAILABLE_FEATURES` (CLAUDE.md, non-negotiable). This task adds the payments group, assigns each to the right progression tier, and writes a `filterOutput` branch per feature — that function returns `{}` for unhandled features, so a missing branch silently empties the response body rather than failing loudly.
 
@@ -78,77 +107,134 @@ The catch: adding features to `ACTIVATED_USER_FEATURES` changes an array that fo
 
 ---
 
-### 2. Schema + migration
+### 2. Money representation — migrate to `Decimal(19,4)`
 
-**TLDR:** Three new tables — `LedgerEntry`, `PayoutAccount`, `Payout` — with money as integer minor units and no foreign keys.
+**TLDR:** Convert existing money columns from decimal-as-string to real numeric, before building anything financial on top of them.
 
-`LedgerEntry` is append-only (no `updated_at`), carries a **signed** `amount_minor`, and references its source polymorphically (`source_type` + `source_id`) so it can point at a `Sale` today and an `Order` later without a migration. `Payout` gets a uniqueness constraint on `(user_id, period_start, period_end)` so a re-run can't double-pay.
+`Game.price`, `Game.base_price` and `Sale.price_at_sale` are `String @db.VarChar(20)` today. That already forces raw `::numeric` SQL for range filters in `game.findAllPaginated`, and makes `orderBy: { price: "asc" }` sort lexicographically, which is subtly wrong. Building a ledger on a second, different representation would lock that split in permanently.
+
+Migration is a hand-written SQL data migration (precedent: `20260723060000_lowercase_store_tag_filters`) doing `ALTER TABLE ... USING price::numeric`.
+
+**Watch out:** Prisma returns `Decimal` objects, not numbers. Every API response must serialise them explicitly in `filterOutput` — the same treatment `GameFile.size_bytes` already gets with `.toString()`. Zod input schemas keep accepting a number and convert on the way in.
+
+**Done when:** no money column is a string, price sorting and range filters use native numeric comparison, the raw `::numeric` workaround in `game.findAllPaginated` is deleted, and the full suite passes.
+
+---
+
+### 3. Currency + exchange rate model
+
+**TLDR:** A table of supported currencies and a table of rates, so prices in non-USD currencies can be derived rather than hand-maintained.
+
+`Currency` — code (ISO 4217), display symbol, decimal places for presentation, enabled flag. `ExchangeRate` — base currency, quote currency, `rate Decimal(19,8)`, source, `effective_at`. Rates are append-only and read newest-first, so historical conversions stay reproducible.
+
+Three ways a rate arrives, all writing to the same table:
+1. **Automatic** — a fetch from an external rate provider, run as a batch job.
+2. **Pre-made table** — rates loaded in bulk, e.g. a monthly fixed set agreed in advance.
+3. **Manual** — an admin writes a rate directly.
+
+The consumer of this table doesn't care which produced it.
+
+**Done when:** a rate can be recorded and the newest effective rate for a currency pair can be read back.
+
+---
+
+### 4. Price resolution
+
+**TLDR:** `priceFor(game, currency)` — a developer's fixed price wins; otherwise convert from USD.
+
+`GamePriceOverride` — `game_id`, `currency`, `amount Decimal(19,4)`. Its presence means "this is the price in this currency, do not convert."
+
+```
+priceFor(game, currency) = fixedPriceOverride(game, currency)
+                        ?? convert(game.base_price_usd, currency)
+```
+
+Two things this task must settle, because they're easy to get wrong and expensive to change later:
+
+- **Rounding policy.** Storage is 4 decimals, presentation is usually 2. Converted prices need a documented rule (round half-up to the currency's decimal places, at minimum). Whether to snap to psychological endings is a product decision worth making explicitly.
+- **Missing-rate behaviour.** If no rate exists for a currency and there's no override, does the product fall back to USD or disappear from the storefront? Silently showing a wrong price is the worst option.
+
+**Done when:** resolution is a single tested function used by every read path, both branches are covered, and rounding and missing-rate behaviour are documented in code.
+
+**Constraint that must not break:** this is developer/admin pricing only. **Storefront owners must never gain price control** — that is what keeps them affiliates rather than sellers (`docs/legal/phase-0-checklist.md`). Overrides are set at the catalog level, never per store.
+
+---
+
+### 5. Ledger, payout account and payout schema
+
+**TLDR:** Three new tables, all money as `Decimal(19,4)`, all carrying an explicit currency, no foreign keys.
+
+`LedgerEntry` is append-only (no `updated_at`), carries a **signed** amount, and references its source polymorphically (`source_type` + `source_id`) so it can point at a `Sale` today and an `Order` later without a migration. `Payout` gets a uniqueness constraint on `(user_id, period_start, period_end)` so a re-run can't double-pay.
+
+**Every money row stores its currency, and any row produced by a conversion also stores the rate used.** Without the rate snapshot, a sale converted at last month's rate cannot be reconciled or audited later.
 
 **Done when:** migration created via `npm run migrate:create` and the suite passes.
 
-**⚠ Hardest decision in the sequence.** The repo stores money as `String @db.VarChar(20)`. This introduces integer minor units for ledger tables only, knowingly leaving two money representations in the codebase. Reversing this after the table has live rows means a data migration.
-
 ---
 
-### 3. Ledger model
+### 6. Ledger model
 
 **TLDR:** The accounting core — write balanced entry sets, never update a row, reverse by writing negatives.
 
-`record()` accepts a set of entries and **rejects any set that does not sum to zero**. That single invariant is what makes the ledger auditable: every money movement is balanced by construction, and a bug that loses money fails at write time instead of surfacing in a payout three weeks later. `reverse()` writes a new negative entry rather than mutating the original, so history is never rewritten.
+`record()` accepts a set of entries and **rejects any set that does not sum to zero within a currency**. That single invariant is what makes the ledger auditable: every money movement is balanced by construction, and a bug that loses money fails at write time instead of surfacing in a payout three weeks later. `reverse()` writes a new negative entry rather than mutating the original, so history is never rewritten.
 
-**Done when:** balance and matured-balance queries work, the zero-sum rule has unit tests, and the orchestrator can seed ledger entries.
+Balances are **per currency**. A single affiliate can hold a BRL balance and a USD balance simultaneously; they are never silently added together.
+
+**Done when:** balance and matured-balance queries work per currency, the zero-sum rule has unit tests, and the orchestrator can seed ledger entries.
 
 ---
 
-### 4. Provider interface + Stripe adapter
+### 7. Provider interface + Stripe adapter
 
 **TLDR:** Make the payout rail swappable before writing the first one.
 
 Four methods — `createAccount`, `getAccountStatus`, `sendPayout`, `getPayoutStatus` — with a registry keyed on the `provider` column. Stripe implements it first; an in-memory fake implements it for tests so the payout path is exercisable without network.
 
-**Why it matters:** Stripe's cross-border payout coverage doesn't reach every market we'll have affiliates in, and Brazil is the likely first gap. Adding a provider later must mean writing an adapter, not migrating a table.
+Providers declare which currencies they can pay in, so the payout run can route a BRL balance to a rail that reaches Pix and a USD balance to Stripe.
 
 **Done when:** the fake and Stripe adapters satisfy the same interface and the call sites never import a provider directly.
 
 ---
 
-### 5. Payout account model + endpoints
+### 8. Payout account model + endpoints
 
 **TLDR:** Affiliates register where their money should go; nothing is payable until verification passes.
 
-Create and read a `PayoutAccount`, with `payouts_enabled` defaulting to false. The output filter must never expose the provider's external account ID — or, later, tax identifiers.
+Create and read a `PayoutAccount`, with `payouts_enabled` defaulting to false and a preferred payout currency. The output filter must never expose the provider's external account ID — or, later, tax identifiers.
 
 **Done when:** both endpoints follow the standard router chain, validate with Zod, and pass every response through `filterOutput`.
 
 ---
 
-### 6. Maturation + clawback
+### 9. Maturation + clawback
 
 **TLDR:** The 30-day hold, implemented as a batch job.
 
-Commission becomes payable at `matures_at` if no reversing entry exists against its source. A chargeback writes the reversal; if the commission was already paid out, the negative balance carries forward against future earnings.
+Commission becomes payable at `matures_at` if no reversing entry exists against its source. A chargeback writes the reversal; if the commission was already paid out, the negative balance carries forward against future earnings **in the same currency**.
 
-This repo has **no scheduler**, so this follows the existing precedent for batch work: a model function returning a report, callable from a `tsx` script, a GitHub `workflow_dispatch` job, and an admin-gated endpoint that writes an audit log entry.
+This repo has no scheduler, so this follows the existing precedent for batch work: a model function returning a report, callable from a `tsx` script, a GitHub `workflow_dispatch` job, and an admin-gated endpoint that writes an audit log entry.
 
 **Done when:** a matured balance excludes anything reversed, and a clawback after payout produces a carried negative balance.
 
 ---
 
-### 7. Payout run
+### 10. Payout run
 
-**TLDR:** Monthly batch — pay everyone whose matured balance clears the threshold and whose KYC is done.
+**TLDR:** Monthly batch — pay everyone whose matured balance clears the threshold and whose verification is done.
 
 Writes the `Payout` row and its balancing ledger entries in one transaction, then calls the provider. Sub-threshold balances roll forward with no row written. Idempotent per period.
 
-**Done when:** the run is safely re-runnable, blocked for unverified accounts, and audit-logged.
+If a balance must be converted to the affiliate's payout currency, the conversion is itself a pair of ledger entries with the rate recorded — never an untracked adjustment.
+
+**Done when:** the run is safely re-runnable, blocked for unverified accounts, correct across multiple currencies, and audit-logged.
 
 ---
 
-### 8. Affiliate-facing reads
+### 11. Affiliate-facing reads
 
 **TLDR:** Let affiliates see their own earnings — and nothing else.
 
-Statement and payout history endpoints, gated by the base feature in the router plus a resource-scoped ownership check in the handler. **Never** buyer personal data, never gift card codes.
+Statement and payout history endpoints, gated by the base feature in the router plus a resource-scoped ownership check in the handler. Balances shown per currency. **Never** buyer personal data, never gift card codes.
 
 **Done when:** an affiliate can see their own numbers and provably cannot see another store's.
 
@@ -156,10 +242,10 @@ Statement and payout history endpoints, gated by the base feature in the router 
 
 ## Open questions
 
-These are the points taken to public review rather than settled internally:
+1. **FX cost bearer** — when a sale is collected in BRL and commission is paid in USD, who absorbs the conversion spread? Currently assigned to the affiliate in the agreement draft.
+2. **Rate staleness** — how old is too old? A rate table with no freshness policy will eventually sell something at a two-month-old rate.
+3. **Scope** — ledger and payouts first, with checkout and an `Order` model later. Is the polymorphic source reference the right seam?
+4. **Tax fields** — deferred until the tax position is written, with payouts hard-gated meanwhile.
+5. **Scheduling** — batch jobs are manually triggered (script / workflow / admin endpoint) because there's no scheduler.
 
-1. **Money type** — integer minor units for the ledger while the rest of the codebase uses decimal strings. Two representations, or migrate everything?
-2. **Scope** — ledger and payouts first, with checkout and an `Order` model later. Is the polymorphic source reference the right seam?
-3. **Tax fields** — deferred until the tax position is written, with payouts hard-gated meanwhile. Right call, or does the schema need them from day one?
-4. **Currency/FX** — the codebase has no currency column at all today. Who bears conversion cost when we collect in BRL and pay in USD?
-5. **Scheduling** — batch jobs are manually triggered (script / workflow / admin endpoint) because there's no scheduler. Does a payout system need a real one before launch?
+**Resolved:** money representation is `Decimal(19,4)`; USD is the base currency; price resolution is override-first with conversion as fallback.

--- a/docs/payments-tasks.md
+++ b/docs/payments-tasks.md
@@ -1,0 +1,165 @@
+# Payments — Ledger & Payouts Task Breakdown
+
+Delivery plan for [#177](https://github.com/pedromello/manifoldpowered.com/issues/177) (Milestone 3: Payment Structure — Sales and Payouts).
+
+**Status: under review. Do not implement yet.** This document is the input for a public design discussion; the sequence below is expected to change before any code is written.
+
+Each task is a separate small PR, landed in order, with `npm run test` passing on its own before merge — the same format as `docs/backoffice-tasks.md`.
+
+---
+
+## The model in one paragraph
+
+Manifold is the **merchant of record**. Consumers buy gift cards from us; storefront owners are **marketing affiliates** who never take title, never set prices and never touch consumer money. We collect the full payment, hold the affiliate's commission for 30 days so refunds and chargebacks can resolve, then pay a **periodic lump sum** per affiliate — a real fiscal payment against a statement, the way Steam pays developers. This is deliberately *not* a per-transaction payment split.
+
+## Money flow
+
+```mermaid
+flowchart TD
+    C[Consumer] -->|pays full retail price| P[Manifold — Merchant of Record]
+    P -->|draws code, prepaid wallet| R[Reloadly]
+    R -->|gift card code| C
+    P -->|writes balanced entries| L[(LedgerEntry — append-only)]
+
+    L --> M{Maturation<br/>paid_at + 30 days}
+    M -->|clean| MB[Matured balance]
+    M -->|refund / chargeback| CB[Reversing entry — clawback]
+    CB -.->|negative balance carries forward| MB
+
+    MB --> TH{Above minimum<br/>threshold?}
+    TH -->|no| RF[Rolls forward to next period]
+    TH -->|yes| PO[Payout batch]
+
+    PO --> IF[PayoutProvider interface]
+    IF --> S[Stripe]
+    IF --> BR[Trolley / Wise — Brazil, Pix]
+    S --> A[Affiliate]
+    BR --> A
+```
+
+## One sale, end to end
+
+```mermaid
+sequenceDiagram
+    participant C as Consumer
+    participant M as Manifold
+    participant R as Reloadly
+    participant L as Ledger
+
+    C->>M: Pays retail price on affiliate storefront
+    M->>R: Order gift card (prepaid wallet)
+    R-->>M: Redeem code
+    M-->>C: Reveal code (timestamp recorded)
+    M->>L: supplier_cost −, platform_revenue +,<br/>affiliate_commission + (matures_at = now + 30d)
+    Note over L: Entries must sum to zero
+
+    alt Chargeback within 30 days
+        M->>L: Reversing entries (sum to zero again)
+        Note over L: Commission never matures
+    else Clean after 30 days
+        M->>L: Commission matures
+        M->>C: Monthly batch pays affiliate
+    end
+```
+
+---
+
+## Tasks
+
+### 1. Foundation — features, fixtures, checklist
+
+**TLDR:** Register the eleven new permission strings before anything else exists, and fix the tests that assert the old permission list.
+
+Nothing on this platform can be built before its features are registered in `AVAILABLE_FEATURES` (CLAUDE.md, non-negotiable). This task adds the payments group, assigns each to the right progression tier, and writes a `filterOutput` branch per feature — that function returns `{}` for unhandled features, so a missing branch silently empties the response body rather than failing loudly.
+
+The catch: adding features to `ACTIVATED_USER_FEATURES` changes an array that four existing test files assert with whole-object equality. They must be updated in the same PR or it lands red.
+
+**Done when:** features registered, tiers assigned, filters written, existing fixtures green, and a decision recorded on how existing admins get the new admin features (`feature_backfill.ts` does not reconcile admin-only features today).
+
+---
+
+### 2. Schema + migration
+
+**TLDR:** Three new tables — `LedgerEntry`, `PayoutAccount`, `Payout` — with money as integer minor units and no foreign keys.
+
+`LedgerEntry` is append-only (no `updated_at`), carries a **signed** `amount_minor`, and references its source polymorphically (`source_type` + `source_id`) so it can point at a `Sale` today and an `Order` later without a migration. `Payout` gets a uniqueness constraint on `(user_id, period_start, period_end)` so a re-run can't double-pay.
+
+**Done when:** migration created via `npm run migrate:create` and the suite passes.
+
+**⚠ Hardest decision in the sequence.** The repo stores money as `String @db.VarChar(20)`. This introduces integer minor units for ledger tables only, knowingly leaving two money representations in the codebase. Reversing this after the table has live rows means a data migration.
+
+---
+
+### 3. Ledger model
+
+**TLDR:** The accounting core — write balanced entry sets, never update a row, reverse by writing negatives.
+
+`record()` accepts a set of entries and **rejects any set that does not sum to zero**. That single invariant is what makes the ledger auditable: every money movement is balanced by construction, and a bug that loses money fails at write time instead of surfacing in a payout three weeks later. `reverse()` writes a new negative entry rather than mutating the original, so history is never rewritten.
+
+**Done when:** balance and matured-balance queries work, the zero-sum rule has unit tests, and the orchestrator can seed ledger entries.
+
+---
+
+### 4. Provider interface + Stripe adapter
+
+**TLDR:** Make the payout rail swappable before writing the first one.
+
+Four methods — `createAccount`, `getAccountStatus`, `sendPayout`, `getPayoutStatus` — with a registry keyed on the `provider` column. Stripe implements it first; an in-memory fake implements it for tests so the payout path is exercisable without network.
+
+**Why it matters:** Stripe's cross-border payout coverage doesn't reach every market we'll have affiliates in, and Brazil is the likely first gap. Adding a provider later must mean writing an adapter, not migrating a table.
+
+**Done when:** the fake and Stripe adapters satisfy the same interface and the call sites never import a provider directly.
+
+---
+
+### 5. Payout account model + endpoints
+
+**TLDR:** Affiliates register where their money should go; nothing is payable until verification passes.
+
+Create and read a `PayoutAccount`, with `payouts_enabled` defaulting to false. The output filter must never expose the provider's external account ID — or, later, tax identifiers.
+
+**Done when:** both endpoints follow the standard router chain, validate with Zod, and pass every response through `filterOutput`.
+
+---
+
+### 6. Maturation + clawback
+
+**TLDR:** The 30-day hold, implemented as a batch job.
+
+Commission becomes payable at `matures_at` if no reversing entry exists against its source. A chargeback writes the reversal; if the commission was already paid out, the negative balance carries forward against future earnings.
+
+This repo has **no scheduler**, so this follows the existing precedent for batch work: a model function returning a report, callable from a `tsx` script, a GitHub `workflow_dispatch` job, and an admin-gated endpoint that writes an audit log entry.
+
+**Done when:** a matured balance excludes anything reversed, and a clawback after payout produces a carried negative balance.
+
+---
+
+### 7. Payout run
+
+**TLDR:** Monthly batch — pay everyone whose matured balance clears the threshold and whose KYC is done.
+
+Writes the `Payout` row and its balancing ledger entries in one transaction, then calls the provider. Sub-threshold balances roll forward with no row written. Idempotent per period.
+
+**Done when:** the run is safely re-runnable, blocked for unverified accounts, and audit-logged.
+
+---
+
+### 8. Affiliate-facing reads
+
+**TLDR:** Let affiliates see their own earnings — and nothing else.
+
+Statement and payout history endpoints, gated by the base feature in the router plus a resource-scoped ownership check in the handler. **Never** buyer personal data, never gift card codes.
+
+**Done when:** an affiliate can see their own numbers and provably cannot see another store's.
+
+---
+
+## Open questions
+
+These are the points taken to public review rather than settled internally:
+
+1. **Money type** — integer minor units for the ledger while the rest of the codebase uses decimal strings. Two representations, or migrate everything?
+2. **Scope** — ledger and payouts first, with checkout and an `Order` model later. Is the polymorphic source reference the right seam?
+3. **Tax fields** — deferred until the tax position is written, with payouts hard-gated meanwhile. Right call, or does the schema need them from day one?
+4. **Currency/FX** — the codebase has no currency column at all today. Who bears conversion cost when we collect in BRL and pay in USD?
+5. **Scheduling** — batch jobs are manually triggered (script / workflow / admin endpoint) because there's no scheduler. Does a payout system need a real one before launch?

--- a/docs/payments-tasks.md
+++ b/docs/payments-tasks.md
@@ -10,7 +10,7 @@ Each task is a separate small PR, landed in order, with `npm run test` passing o
 
 ## The model in one paragraph
 
-Manifold is the **merchant of record**. Consumers buy from us; storefront owners are **marketing affiliates** who never take title, never set prices and never touch consumer money. We collect the full payment, hold the affiliate's commission for 30 days so refunds and chargebacks can resolve, then pay a **periodic lump sum** per affiliate — a real fiscal payment against a statement, the way Steam pays developers. This is deliberately *not* a per-transaction payment split.
+Manifold is the **merchant of record**. Consumers buy from us; storefront owners are **marketing affiliates** who never take title, never set prices and never touch consumer money. We collect the full payment, hold the affiliate's commission for 30 days so refunds and chargebacks can resolve, then pay a **periodic lump sum** per affiliate — a real fiscal payment against a statement, the way Steam pays developers. This is deliberately _not_ a per-transaction payment split.
 
 ## Settled decisions
 
@@ -128,6 +128,7 @@ Migration is a hand-written SQL data migration (precedent: `20260723060000_lower
 `Currency` — code (ISO 4217), display symbol, decimal places for presentation, enabled flag. `ExchangeRate` — base currency, quote currency, `rate Decimal(19,8)`, source, `effective_at`. Rates are append-only and read newest-first, so historical conversions stay reproducible.
 
 Three ways a rate arrives, all writing to the same table:
+
 1. **Automatic** — a fetch from an external rate provider, run as a batch job.
 2. **Pre-made table** — rates loaded in bulk, e.g. a monthly fixed set agreed in advance.
 3. **Manual** — an admin writes a rate directly.

--- a/models/authorization.ts
+++ b/models/authorization.ts
@@ -393,7 +393,9 @@ function filterOutput(user: Partial<User>, feature: string, resource: unknown) {
       description: gameOutput.description,
       detailed_description: gameOutput.detailed_description,
       launch_date: gameOutput.launch_date,
-      price: gameOutput.price,
+      // Decimal is serialised at this boundary so the wire format stays a
+      // fixed 2-decimal string, independent of the stored 4-decimal scale.
+      price: gameOutput.price.toFixed(2),
       developer_name: gameOutput.developer_name,
       publisher_name: gameOutput.publisher_name,
       tags: gameOutput.tags,
@@ -408,7 +410,7 @@ function filterOutput(user: Partial<User>, feature: string, resource: unknown) {
       positive_reviews: gameOutput.positive_reviews,
       negative_reviews: gameOutput.negative_reviews,
       review_score: gameOutput.review_score,
-      base_price: gameOutput.base_price,
+      base_price: gameOutput.base_price?.toFixed(2) ?? null,
       discount_label: gameOutput.discount_label,
       created_at: gameOutput.created_at,
       updated_at: gameOutput.updated_at,
@@ -531,7 +533,7 @@ function filterOutput(user: Partial<User>, feature: string, resource: unknown) {
       game_id: saleOutput.game_id,
       game_title: saleOutput.game_title,
       store_id: saleOutput.store_id,
-      price_at_sale: saleOutput.price_at_sale,
+      price_at_sale: saleOutput.price_at_sale.toFixed(2),
       created_at: saleOutput.created_at,
     };
   }

--- a/models/game.ts
+++ b/models/game.ts
@@ -160,16 +160,14 @@ async function create(gameData: GameCreateDto) {
     }
   }
 
-  const priceAsString = gameData.price.toFixed(2);
-
   return await prisma.game.create({
     data: {
       ...gameData,
       developer_name: developerStudio.name,
       publisher_name: publisherStudio.name,
       slug,
-      price: priceAsString,
-      base_price: priceAsString,
+      // A new game has no prior price, so base_price starts equal to price.
+      base_price: gameData.price,
       launch_date: new Date(gameData.launch_date),
       meta_tags: gameData.meta_tags || {},
       media: gameData.media || {},
@@ -503,19 +501,9 @@ async function update(
     await validateVideoUrls(validatedData.media.videos);
   }
 
-  const priceAsString =
-    validatedData.price !== undefined
-      ? validatedData.price.toFixed(2)
-      : undefined;
-
-  const basePriceAsString =
-    validatedData.base_price !== undefined
-      ? validatedData.base_price.toFixed(2)
-      : undefined;
-
   const discountLabel = calculateDiscountLabel(
-    validatedData.price ?? Number(existingGame.price),
-    validatedData.base_price ?? Number(existingGame.base_price),
+    validatedData.price ?? existingGame.price.toNumber(),
+    validatedData.base_price ?? existingGame.base_price?.toNumber() ?? 0,
   );
 
   return await prisma.game.update({
@@ -525,8 +513,6 @@ async function update(
     data: {
       ...validatedData,
       slug: newSlug,
-      price: priceAsString,
-      base_price: basePriceAsString,
       discount_label: discountLabel,
       launch_date: validatedData.launch_date
         ? new Date(validatedData.launch_date)
@@ -604,23 +590,10 @@ async function findAllPaginated({
   }
 
   if (min_price !== undefined || max_price !== undefined) {
-    // `price` is stored as VARCHAR for financial precision, so a plain
-    // Prisma string comparison would sort/filter lexicographically
-    // (e.g. "9.99" > "19.99"). Cast to numeric in raw SQL to get a
-    // correct range, then constrain the typed query by the matching ids.
-    const priceConditions: Prisma.Sql[] = [];
-    if (min_price !== undefined) {
-      priceConditions.push(Prisma.sql`price::numeric >= ${min_price}`);
-    }
-    if (max_price !== undefined) {
-      priceConditions.push(Prisma.sql`price::numeric <= ${max_price}`);
-    }
-
-    const matchingGames = await prisma.$queryRaw<{ id: string }[]>`
-      SELECT id FROM games WHERE ${Prisma.join(priceConditions, " AND ")}
-    `;
-
-    where.id = { in: matchingGames.map((matchingGame) => matchingGame.id) };
+    where.price = {
+      ...(min_price !== undefined && { gte: min_price }),
+      ...(max_price !== undefined && { lte: max_price }),
+    };
   }
 
   if (curationWhere && Object.keys(curationWhere).length > 0) {

--- a/models/sale.ts
+++ b/models/sale.ts
@@ -1,10 +1,11 @@
 import { prisma } from "infra/database";
+import { Prisma } from "generated/prisma/client";
 
 interface RecordSaleDto {
   user_id: string;
   game_id: string;
   store_id: string | null;
-  price_at_sale: string;
+  price_at_sale: Prisma.Decimal;
 }
 
 async function record(saleDto: RecordSaleDto) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "manifoldpowered.com",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "3.1038.0",
         "@aws-sdk/s3-request-presigner": "3.1038.0",

--- a/prisma/migrations/20260730120000_money_columns_to_decimal/migration.sql
+++ b/prisma/migrations/20260730120000_money_columns_to_decimal/migration.sql
@@ -1,0 +1,23 @@
+-- Money columns move from decimal-as-string (VARCHAR) to native NUMERIC.
+--
+-- Decimal(19,4) is the standard scale for amounts subject to tax: intermediate
+-- calculations (commission splits, tax lines, FX conversion) need more
+-- precision than the two decimals a currency displays. Rounding now happens
+-- only at the presentation boundary, never in storage.
+--
+-- Existing values were always written via Number.prototype.toFixed(2), so a
+-- plain cast is safe. Nullable columns use NULLIF so an empty string becomes
+-- NULL rather than failing the cast; the NOT NULL columns are cast directly,
+-- which fails loudly on unexpected data instead of silently writing 0.
+--
+-- Beyond storage, this fixes two live defects:
+--   * ORDER BY price sorted lexicographically ("9.99" after "10.00").
+--   * min_price/max_price filtering needed a raw `price::numeric` subquery,
+--     now removed from models/game.ts.
+
+ALTER TABLE "games"
+  ALTER COLUMN "price" TYPE DECIMAL(19,4) USING "price"::numeric,
+  ALTER COLUMN "base_price" TYPE DECIMAL(19,4) USING NULLIF(btrim("base_price"), '')::numeric;
+
+ALTER TABLE "sales"
+  ALTER COLUMN "price_at_sale" TYPE DECIMAL(19,4) USING "price_at_sale"::numeric;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -113,10 +113,14 @@ model Game {
   launch_date          DateTime
   status               GameStatus @default(PRIVATE)
 
-  // Financial (String for absolute precision as standard for financial systems)
-  price          String  @db.VarChar(20)
-  base_price     String? @db.VarChar(20)
-  discount_label String? @db.VarChar(10)
+  // Financial. Decimal(19,4) is the standard scale for amounts subject to
+  // tax: intermediate calculations (commission splits, tax lines, FX) need
+  // more precision than the two decimals a currency displays. Rounding
+  // happens at the presentation boundary (authorization.filterOutput),
+  // never in storage.
+  price          Decimal  @db.Decimal(19, 4)
+  base_price     Decimal? @db.Decimal(19, 4)
+  discount_label String?  @db.VarChar(10)
 
   // Taxonomy and Authorship
   // developer_name/publisher_name are denormalized from Studio.name at creation time
@@ -225,7 +229,7 @@ model Sale {
   user_id       String // Logical reference to User.id (who acquired)
   game_id       String // Logical reference to Game.id (what was acquired)
   store_id      String? // Logical reference to Store.id; null = platform/global acquisition
-  price_at_sale String   @db.VarChar(20) // Snapshot of Game.price at acquisition time
+  price_at_sale Decimal  @db.Decimal(19, 4) // Snapshot of Game.price at acquisition time
   // No updated_at: sale records are append-only and never modified.
   created_at    DateTime @default(now())
 

--- a/tests/integration/_use-cases/purchase-and-download-flow.test.ts
+++ b/tests/integration/_use-cases/purchase-and-download-flow.test.ts
@@ -255,6 +255,9 @@ describe("Use case: Purchase and Download Flow", () => {
         launch_date: game.launch_date.toISOString(),
         created_at: game.created_at.toISOString(),
         updated_at: game.updated_at.toISOString(),
+        // The API serialises Decimal to a fixed 2-decimal string.
+        price: game.price.toFixed(2),
+        base_price: game.base_price?.toFixed(2) ?? null,
       };
       expect(gamesInLibrary).toContainEqual(gameWithDatesAsString);
 

--- a/tests/integration/api/v1/items/games/[slug]/get.test.ts
+++ b/tests/integration/api/v1/items/games/[slug]/get.test.ts
@@ -27,7 +27,8 @@ describe("GET /api/v1/items/games/[slug]", () => {
       expect(responseBody.slug).toBe(game.slug);
       expect(responseBody.title).toBe(game.title);
       expect(responseBody.description).toBe(game.description);
-      expect(responseBody.price).toBe(game.price);
+      // The API serialises Decimal to a fixed 2-decimal string.
+      expect(responseBody.price).toBe(game.price.toFixed(2));
     });
 
     test("With non-existent slug should return 404", async () => {

--- a/tests/integration/api/v1/items/games/post.test.ts
+++ b/tests/integration/api/v1/items/games/post.test.ts
@@ -96,11 +96,12 @@ describe("POST /api/v1/items/games", () => {
       expect(game.status).toBe("PRIVATE");
       expect(game.developer_name).toBe(studio.name);
       expect(game.publisher_name).toBe(studio.name);
-      expect(game.price).toBe(gameData.price);
+      // price is a Prisma Decimal; compare at the currency's display scale.
+      expect(game.price.toFixed(2)).toBe(gameData.price);
 
       expect(game.positive_reviews).toBe(0);
       expect(game.negative_reviews).toBe(0);
-      expect(game.base_price).toBe(gameData.price);
+      expect(game.base_price?.toFixed(2)).toBe(gameData.price);
     });
 
     test("Without 'create:game' feature should return 403 Forbidden", async () => {
@@ -575,9 +576,16 @@ describe("POST /api/v1/items/games", () => {
 
       // Assert
       expect(response.status).toBe(201);
+
+      // Two-decimal formatting is now a presentation concern: storage keeps the
+      // full Decimal(19,4) scale and the API serialises it to a fixed string.
+      const responseBody = await response.json();
+      expect(responseBody.price).toBe("50.00");
+      expect(responseBody.base_price).toBe("50.00");
+
       const game = await orchestrator.getGameBySlug("price-formatting-test");
-      expect(game.price).toBe("50.00");
-      expect(game.base_price).toBe("50.00");
+      expect(game.price.toFixed(2)).toBe("50.00");
+      expect(game.base_price?.toFixed(2)).toBe("50.00");
     });
 
     test("With negative price should return 400 Bad Request", async () => {

--- a/tests/integration/api/v1/items/games/steam-import/post.test.ts
+++ b/tests/integration/api/v1/items/games/steam-import/post.test.ts
@@ -72,7 +72,8 @@ describe("POST /api/v1/items/games/steam-import", () => {
       expect(persistedGame.steam_app_id).toBe(STEAM_TEST_APP_ID);
       expect(persistedGame.studio_id).toBe(studio.id);
       expect(persistedGame.developer_name).toBe(studio.name);
-      expect(persistedGame.base_price).toBe(persistedGame.price);
+      // Both are Prisma Decimal instances, so compare values not references.
+      expect(persistedGame.base_price?.equals(persistedGame.price)).toBe(true);
 
       // Act again: the same studio re-imports the same Steam app.
       const reimportResponse = await fetch(

--- a/tests/integration/api/v1/library/get.test.ts
+++ b/tests/integration/api/v1/library/get.test.ts
@@ -115,7 +115,8 @@ describe("GET /api/v1/library", () => {
         description: game.description,
         detailed_description: game.detailed_description,
         launch_date: expect.any(String),
-        price: game.price,
+        // The API serialises Decimal to a fixed 2-decimal string.
+        price: game.price.toFixed(2),
         developer_name: game.developer_name,
         publisher_name: game.publisher_name,
         tags: game.tags,
@@ -130,7 +131,7 @@ describe("GET /api/v1/library", () => {
         positive_reviews: game.positive_reviews,
         negative_reviews: game.negative_reviews,
         review_score: game.review_score,
-        base_price: game.base_price,
+        base_price: game.base_price?.toFixed(2) ?? null,
         discount_label: game.discount_label,
         created_at: expect.any(String),
         updated_at: expect.any(String),

--- a/tests/integration/api/v1/library/post.test.ts
+++ b/tests/integration/api/v1/library/post.test.ts
@@ -150,7 +150,8 @@ describe("POST /api/v1/library", () => {
       });
       expect(sales).toHaveLength(1);
       expect(sales[0].store_id).toBeNull();
-      expect(sales[0].price_at_sale).toBe(game.price);
+      // Both are Prisma Decimal instances, so compare values not references.
+      expect(sales[0].price_at_sale.equals(game.price)).toBe(true);
     });
 
     test("With a valid store_slug should record a Sale attributed to that store", async () => {


### PR DESCRIPTION
## Description

Money moves from decimal-as-string (`VARCHAR(20)`) to native `NUMERIC` on `Game.price`, `Game.base_price` and `Sale.price_at_sale`.

`Decimal(19,4)` is the standard scale for amounts subject to tax: intermediate calculations (commission splits, tax lines, FX conversion) need more precision than the two decimals a currency displays. Rounding now happens only at the presentation boundary, never in storage.

This is the first step of the payments work in Milestone 3. Everything financial that follows — the ledger, multi-currency pricing, affiliate payouts — needs exact arithmetic on money, and building it on top of decimal strings would have locked a second representation into the codebase permanently. Doing the migration first means there is only ever one.

**Serialisation boundary.** All server-side rendering fetches through the API, so `authorization.filterOutput` is the single place money leaves the system. It serialises `Decimal` with `toFixed(2)`, which keeps the API wire format byte-identical to before (`"12.99"`) — **no frontend code needed touching**. This follows the existing precedent for `GameFile.size_bytes`, which is serialised with `.toString()` for the same reason.

### Two pre-existing defects fixed as a side effect

- **`ORDER BY price` sorted lexicographically.** With prices as text, `"9.99"` sorted after `"10.00"`. The `price_asc` / `price_desc` sort options were quietly wrong.
- **`min_price`/`max_price` filtering used a raw `price::numeric` subquery** which also assigned `where.id`, clobbering any other id-based constraint on the same query. Both the raw SQL and the collision are gone, replaced by a normal Prisma `where.price` range.

## Related issue

Part of #177 (Milestone 3: Payment Structure — Sales and Payouts). Task breakdown in `docs/payments-tasks.md`.

## Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📖 Documentation
- [x] ♻️ Refactor
- [ ] 🧪 Tests

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] `npm run lint:eslint:check` passes
- [x] `npm run lint:prettier:check` passes
- [x] `npm run test` passes — **390/393, see below**
- [x] Added or updated tests where relevant

## Test results

`390 passed, 3 failed` across 84 suites. The 3 failures are environmental and unrelated to this change:

| Suite | Cause |
| --- | --- |
| `api/v1/status/get.test.ts` | Asserts the database version is `"16.0"` (the `postgres:16.0-alpine3.18` image). This run used a natively installed PostgreSQL 16.13, so it reports `"16.13 (Ubuntu …)"`. |
| `api/v1/items/games/steam-import/post.test.ts` (2 tests) | The public Steam API is unreachable from this environment (403), so the endpoint correctly returns 503 instead of 201/404. |

Neither touches money, prices or serialisation. Both should pass on a normal `npm run test` with Docker available.

### Test changes in this PR

Six assertions across five files compared a raw Prisma value against a formatted string, which only surfaces at runtime — neither typecheck nor lint catches it. Three of them were found only by executing the suite against a real database:

- `Decimal.toString()` normalises trailing zeros, so a stored `199.9000` renders `"199.9"`, not `"199.90"`. Assertions on DB values now use `.toFixed(2)`.
- Comparisons between two `Decimal` instances use `.equals()` rather than `toBe`, which was doing reference equality.
- The "price sent without decimals should be formatted to .00" test now asserts the contract where it actually lives: the API response returns `"50.00"` while storage keeps the full 4-decimal scale.

## Migration notes

`prisma/migrations/20260730120000_money_columns_to_decimal/` is hand-written, following the precedent of `20260723060000_lowercase_store_tag_filters`.

`NOT NULL` columns are cast directly (`USING "price"::numeric`) so unexpected data fails the migration loudly rather than silently becoming `0`. The nullable `base_price` uses `NULLIF(btrim(...), '')` so an empty string becomes `NULL` instead of failing the cast.

Verified against real data before opening: the full migration chain applied to a clean database, then the exact `ALTER` statements were replayed on a scratch database seeded with string prices including edge cases (`0.00`, the maximum `1000000.00`, a `NULL` `base_price`, and an empty-string `base_price`). All cast correctly, the empty string became `NULL`, and the resulting rows sort numerically — demonstrating the ordering fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Whv49dfByzLEJjor8FbRbt)_