### PR TITLE
feat: add currency and exchange rate models

### DIFF
--- a/docs/payments-tasks.md
+++ b/docs/payments-tasks.md
@@ -2,7 +2,15 @@
 
 Delivery plan for [#177](https://github.com/pedromello/manifoldpowered.com/issues/177) (Milestone 3: Payment Structure — Sales and Payouts).
 
-**Status: under review. Do not implement yet.** This document is the input for a public design discussion; the sequence below is expected to change before any code is written.
+**Status: in progress.** The design is also under public discussion, so tasks not yet started may still change.
+
+| Task                              | State                                                                        |
+| --------------------------------- | ---------------------------------------------------------------------------- |
+| 1. Foundation — features          | not started (deferred: no endpoints yet, so no new features needed)          |
+| 2. Money → `Decimal(19,4)`        | ✅ done ([#181](https://github.com/pedromello/manifoldpowered.com/pull/181)) |
+| 3. Currency + exchange rate model | ✅ done                                                                      |
+| 4. Price resolution               | next                                                                         |
+| 5–11                              | not started                                                                  |
 
 Each task is a separate small PR, landed in order, with `npm run test` passing on its own before merge — the same format as `docs/backoffice-tasks.md`.
 

--- a/models/currency.ts
+++ b/models/currency.ts
@@ -1,0 +1,106 @@
+import { prisma } from "infra/database";
+import { z } from "zod";
+import { Prisma } from "generated/prisma/client";
+import { NotFoundError, ValidationError } from "infra/errors";
+
+// ISO 4217: exactly three letters. Stored and compared uppercase so lookups
+// never depend on how a caller happened to type the code.
+export const currencyCodeSchema = z
+  .string()
+  .trim()
+  .toUpperCase()
+  .regex(/^[A-Z]{3}$/, "code must be a 3-letter ISO 4217 currency code");
+
+export const currencySchema = z.object({
+  code: currencyCodeSchema,
+  symbol: z.string().trim().min(1).max(8),
+  decimal_places: z.coerce.number().int().min(0).max(4).default(2),
+  enabled: z.boolean().default(true),
+});
+
+export type CurrencyCreateDto = z.infer<typeof currencySchema>;
+
+async function create(currencyDto: CurrencyCreateDto) {
+  try {
+    return await prisma.currency.create({
+      data: currencyDto,
+    });
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      throw new ValidationError({
+        message: `The currency "${currencyDto.code}" is already registered.`,
+        action: "Use a different currency code or update the existing one.",
+        cause: error,
+      });
+    }
+
+    throw error;
+  }
+}
+
+async function findOneByCode(code: string) {
+  const foundCurrency = await prisma.currency.findUnique({
+    where: { code: normalizeCode(code) },
+  });
+
+  if (!foundCurrency) {
+    throw new NotFoundError({
+      message: `The currency "${code}" was not found.`,
+      action: "Check the currency code and try again.",
+    });
+  }
+
+  return foundCurrency;
+}
+
+async function findAllEnabled() {
+  return await prisma.currency.findMany({
+    where: { enabled: true },
+    orderBy: { code: "asc" },
+  });
+}
+
+async function setEnabled(code: string, enabled: boolean) {
+  const foundCurrency = await findOneByCode(code);
+
+  return await prisma.currency.update({
+    where: { id: foundCurrency.id },
+    data: { enabled },
+  });
+}
+
+// Returns the subset of the given codes that are not registered, so callers
+// writing several rows at once can validate in a single query instead of one
+// lookup per code.
+async function findUnregisteredCodes(codes: string[]) {
+  const normalizedCodes = [...new Set(codes.map(normalizeCode))];
+
+  const registeredCurrencies = await prisma.currency.findMany({
+    where: { code: { in: normalizedCodes } },
+    select: { code: true },
+  });
+
+  const registeredCodes = new Set(
+    registeredCurrencies.map((currency) => currency.code),
+  );
+
+  return normalizedCodes.filter((code) => !registeredCodes.has(code));
+}
+
+function normalizeCode(code: string) {
+  return code.trim().toUpperCase();
+}
+
+const currency = {
+  create,
+  findOneByCode,
+  findAllEnabled,
+  setEnabled,
+  findUnregisteredCodes,
+  normalizeCode,
+};
+
+export default currency;

--- a/models/exchange_rate.ts
+++ b/models/exchange_rate.ts
@@ -1,0 +1,150 @@
+import { prisma } from "infra/database";
+import { z } from "zod";
+import { Prisma } from "generated/prisma/client";
+import { NotFoundError, ValidationError } from "infra/errors";
+import currency, { currencyCodeSchema } from "models/currency";
+
+const exchangeRateSourceValues = ["AUTOMATIC", "BULK", "MANUAL"] as const;
+
+export const exchangeRateSchema = z
+  .object({
+    base_currency: currencyCodeSchema,
+    quote_currency: currencyCodeSchema,
+    // Rates are stored at Decimal(19,8): a coarser scale loses meaningful
+    // precision on low-value currencies, where a single unit of the base
+    // currency can be worth thousands of the quote.
+    rate: z.coerce.number().positive().max(1_000_000_000),
+    source: z.enum(exchangeRateSourceValues),
+    effective_at: z.coerce.date().default(() => new Date()),
+  })
+  .refine((data) => data.base_currency !== data.quote_currency, {
+    message: "base_currency and quote_currency must be different",
+    path: ["quote_currency"],
+  });
+
+export type ExchangeRateCreateDto = z.infer<typeof exchangeRateSchema>;
+
+async function record(rateDto: ExchangeRateCreateDto) {
+  await validateCurrenciesAreRegistered([
+    rateDto.base_currency,
+    rateDto.quote_currency,
+  ]);
+
+  return await prisma.exchangeRate.create({
+    data: rateDto,
+  });
+}
+
+// Bulk path for the "rates agreed in advance" case. Writes in a single
+// transaction so a partially loaded set never becomes visible to price
+// resolution.
+async function recordMany(rateDtos: ExchangeRateCreateDto[]) {
+  if (rateDtos.length === 0) {
+    throw new ValidationError({
+      message: "No exchange rates were provided.",
+      action: "Send at least one exchange rate to record.",
+    });
+  }
+
+  await validateCurrenciesAreRegistered(
+    rateDtos.flatMap((rateDto) => [
+      rateDto.base_currency,
+      rateDto.quote_currency,
+    ]),
+  );
+
+  return await prisma.$transaction(
+    rateDtos.map((rateDto) => prisma.exchangeRate.create({ data: rateDto })),
+  );
+}
+
+// The newest rate that was already in effect at `asOf`. Rows effective in the
+// future are ignored, so scheduling a rate ahead of time never changes how
+// today's prices are converted.
+async function findLatest(
+  baseCurrency: string,
+  quoteCurrency: string,
+  asOf: Date = new Date(),
+) {
+  return await prisma.exchangeRate.findFirst({
+    where: {
+      base_currency: currency.normalizeCode(baseCurrency),
+      quote_currency: currency.normalizeCode(quoteCurrency),
+      effective_at: { lte: asOf },
+    },
+    orderBy: [{ effective_at: "desc" }, { created_at: "desc" }],
+  });
+}
+
+// Same as findLatest but for callers that cannot proceed without a rate.
+async function findLatestOrFail(
+  baseCurrency: string,
+  quoteCurrency: string,
+  asOf: Date = new Date(),
+) {
+  const foundRate = await findLatest(baseCurrency, quoteCurrency, asOf);
+
+  if (!foundRate) {
+    throw new NotFoundError({
+      message: `No exchange rate is available from ${currency.normalizeCode(baseCurrency)} to ${currency.normalizeCode(quoteCurrency)}.`,
+      action: "Record an exchange rate for this currency pair and try again.",
+    });
+  }
+
+  return foundRate;
+}
+
+async function listByPair(
+  baseCurrency: string,
+  quoteCurrency: string,
+  { page = 1, limit = 20 }: { page?: number; limit?: number } = {},
+) {
+  const where: Prisma.ExchangeRateWhereInput = {
+    base_currency: currency.normalizeCode(baseCurrency),
+    quote_currency: currency.normalizeCode(quoteCurrency),
+  };
+
+  const [rates, total] = await Promise.all([
+    prisma.exchangeRate.findMany({
+      where,
+      orderBy: { effective_at: "desc" },
+      skip: (page - 1) * limit,
+      take: limit,
+    }),
+    prisma.exchangeRate.count({ where }),
+  ]);
+
+  return {
+    rates,
+    pagination: {
+      page,
+      limit,
+      total,
+      pages: Math.ceil(total / limit),
+    },
+  };
+}
+
+// There are no foreign keys in this schema, so referential integrity for
+// currency codes is enforced here instead. Without it a typo becomes a rate
+// that silently never matches anything.
+async function validateCurrenciesAreRegistered(codes: string[]) {
+  const unregisteredCodes = await currency.findUnregisteredCodes(codes);
+
+  if (unregisteredCodes.length > 0) {
+    throw new ValidationError({
+      message: `The following currencies are not registered: ${unregisteredCodes.join(", ")}.`,
+      action: "Register the currency before recording an exchange rate for it.",
+    });
+  }
+}
+
+const exchangeRate = {
+  record,
+  recordMany,
+  findLatest,
+  findLatestOrFail,
+  listByPair,
+};
+
+export default exchangeRate;

--- a/prisma/migrations/20260730024949_add_currency_and_exchange_rate/migration.sql
+++ b/prisma/migrations/20260730024949_add_currency_and_exchange_rate/migration.sql
@@ -1,0 +1,37 @@
+-- CreateEnum
+CREATE TYPE "ExchangeRateSource" AS ENUM ('AUTOMATIC', 'BULK', 'MANUAL');
+
+-- CreateTable
+CREATE TABLE "currencies" (
+    "id" TEXT NOT NULL,
+    "code" VARCHAR(3) NOT NULL,
+    "symbol" VARCHAR(8) NOT NULL,
+    "decimal_places" INTEGER NOT NULL DEFAULT 2,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "currencies_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "exchange_rates" (
+    "id" TEXT NOT NULL,
+    "base_currency" VARCHAR(3) NOT NULL,
+    "quote_currency" VARCHAR(3) NOT NULL,
+    "rate" DECIMAL(19,8) NOT NULL,
+    "source" "ExchangeRateSource" NOT NULL,
+    "effective_at" TIMESTAMP(3) NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "exchange_rates_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "currencies_code_key" ON "currencies"("code");
+
+-- CreateIndex
+CREATE INDEX "currencies_enabled_idx" ON "currencies"("enabled");
+
+-- CreateIndex
+CREATE INDEX "exchange_rates_base_currency_quote_currency_effective_at_idx" ON "exchange_rates"("base_currency", "quote_currency", "effective_at");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -352,3 +352,46 @@ model AdminActionLog {
   @@index([target_type, target_id])
   @@map("admin_action_logs")
 }
+
+// USD is the platform's base currency. Every product carries a USD price and
+// prices in other currencies are derived from it (see GamePriceOverride and
+// ExchangeRate), so this table is a registry of what we are allowed to price
+// and pay in — not a source of prices itself.
+model Currency {
+  id             String   @id @default(uuid())
+  code           String   @unique @db.VarChar(3) // ISO 4217, uppercase (USD, BRL)
+  symbol         String   @db.VarChar(8)
+  // Presentation scale only. Storage is always Decimal(19,4) regardless, so
+  // that intermediate calculations keep more precision than we display.
+  decimal_places Int      @default(2)
+  enabled        Boolean  @default(true)
+  created_at     DateTime @default(now())
+  updated_at     DateTime @updatedAt
+
+  @@index([enabled])
+  @@map("currencies")
+}
+
+enum ExchangeRateSource {
+  AUTOMATIC // fetched from an external rate provider
+  BULK // loaded in advance, e.g. an agreed fixed monthly set
+  MANUAL // written directly by an admin
+}
+
+// Append-only: rates are never updated or deleted, so a conversion made months
+// ago stays reproducible from the rate that was effective at the time. Reads
+// take the newest row whose effective_at is at or before the moment of
+// interest.
+model ExchangeRate {
+  id             String             @id @default(uuid())
+  base_currency  String             @db.VarChar(3) // Logical reference to Currency.code
+  quote_currency String             @db.VarChar(3) // Logical reference to Currency.code
+  rate           Decimal            @db.Decimal(19, 8)
+  source         ExchangeRateSource
+  effective_at   DateTime
+  // No updated_at: rate rows are append-only and never modified.
+  created_at     DateTime           @default(now())
+
+  @@index([base_currency, quote_currency, effective_at])
+  @@map("exchange_rates")
+}

--- a/tests/integration/models/currency.test.ts
+++ b/tests/integration/models/currency.test.ts
@@ -1,0 +1,121 @@
+import orchestrator from "tests/orchestrator";
+import currency from "models/currency";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+describe("models/currency.ts", () => {
+  describe(".create()", () => {
+    test("creates a currency with the given fields", async () => {
+      await orchestrator.clearDatabaseRows();
+
+      const created = await currency.create({
+        code: "USD",
+        symbol: "$",
+        decimal_places: 2,
+        enabled: true,
+      });
+
+      expect(created.code).toBe("USD");
+      expect(created.symbol).toBe("$");
+      expect(created.decimal_places).toBe(2);
+      expect(created.enabled).toBe(true);
+      expect(created.created_at).toBeInstanceOf(Date);
+    });
+
+    test("rejects a duplicate code with a ValidationError", async () => {
+      await orchestrator.clearDatabaseRows();
+      await orchestrator.createCurrency({ code: "BRL", symbol: "R$" });
+
+      await expect(
+        currency.create({
+          code: "BRL",
+          symbol: "R$",
+          decimal_places: 2,
+          enabled: true,
+        }),
+      ).rejects.toMatchObject({
+        name: "ValidationError",
+        message: 'The currency "BRL" is already registered.',
+        action: "Use a different currency code or update the existing one.",
+        statusCode: 400,
+      });
+    });
+  });
+
+  describe(".findOneByCode()", () => {
+    test("finds a currency regardless of the casing used", async () => {
+      await orchestrator.clearDatabaseRows();
+      await orchestrator.createCurrency({ code: "BRL", symbol: "R$" });
+
+      const found = await currency.findOneByCode("brl");
+
+      expect(found.code).toBe("BRL");
+    });
+
+    test("throws NotFoundError for an unregistered code", async () => {
+      await orchestrator.clearDatabaseRows();
+
+      await expect(currency.findOneByCode("JPY")).rejects.toMatchObject({
+        name: "NotFoundError",
+        message: 'The currency "JPY" was not found.',
+        action: "Check the currency code and try again.",
+        statusCode: 404,
+      });
+    });
+  });
+
+  describe(".findAllEnabled()", () => {
+    test("returns only enabled currencies, ordered by code", async () => {
+      await orchestrator.clearDatabaseRows();
+      await orchestrator.createCurrency({ code: "USD", symbol: "$" });
+      await orchestrator.createCurrency({ code: "BRL", symbol: "R$" });
+      await orchestrator.createCurrency({
+        code: "JPY",
+        symbol: "¥",
+        enabled: false,
+      });
+
+      const enabledCurrencies = await currency.findAllEnabled();
+
+      expect(enabledCurrencies.map((row) => row.code)).toEqual(["BRL", "USD"]);
+    });
+  });
+
+  describe(".setEnabled()", () => {
+    test("disables a currency without deleting it", async () => {
+      await orchestrator.clearDatabaseRows();
+      await orchestrator.createCurrency({ code: "BRL", symbol: "R$" });
+
+      const disabled = await currency.setEnabled("BRL", false);
+
+      expect(disabled.enabled).toBe(false);
+      expect((await currency.findOneByCode("BRL")).enabled).toBe(false);
+    });
+  });
+
+  describe(".findUnregisteredCodes()", () => {
+    test("returns only the codes that are missing, deduplicated", async () => {
+      await orchestrator.clearDatabaseRows();
+      await orchestrator.createCurrency({ code: "USD", symbol: "$" });
+
+      const unregistered = await currency.findUnregisteredCodes([
+        "USD",
+        "brl",
+        "BRL",
+        "JPY",
+      ]);
+
+      expect(unregistered.sort()).toEqual(["BRL", "JPY"]);
+    });
+
+    test("returns an empty array when every code is registered", async () => {
+      await orchestrator.clearDatabaseRows();
+      await orchestrator.createCurrency({ code: "USD", symbol: "$" });
+
+      expect(await currency.findUnregisteredCodes(["USD"])).toEqual([]);
+    });
+  });
+});

--- a/tests/integration/models/exchange_rate.test.ts
+++ b/tests/integration/models/exchange_rate.test.ts
@@ -1,0 +1,236 @@
+import orchestrator from "tests/orchestrator";
+import exchangeRate from "models/exchange_rate";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+async function registerBaseCurrencies() {
+  await orchestrator.clearDatabaseRows();
+  await orchestrator.createCurrency({ code: "USD", symbol: "$" });
+  await orchestrator.createCurrency({ code: "BRL", symbol: "R$" });
+}
+
+describe("models/exchange_rate.ts", () => {
+  describe(".record()", () => {
+    test("records a rate with the given fields", async () => {
+      await registerBaseCurrencies();
+
+      const recorded = await exchangeRate.record({
+        base_currency: "USD",
+        quote_currency: "BRL",
+        rate: 5.4321,
+        source: "MANUAL",
+        effective_at: new Date("2026-07-01T00:00:00.000Z"),
+      });
+
+      expect(recorded.base_currency).toBe("USD");
+      expect(recorded.quote_currency).toBe("BRL");
+      expect(recorded.rate.toFixed(4)).toBe("5.4321");
+      expect(recorded.source).toBe("MANUAL");
+      expect(recorded.effective_at.toISOString()).toBe(
+        "2026-07-01T00:00:00.000Z",
+      );
+      expect(recorded.created_at).toBeInstanceOf(Date);
+    });
+
+    test("keeps the full 8-decimal scale", async () => {
+      await registerBaseCurrencies();
+
+      const recorded = await exchangeRate.record({
+        base_currency: "USD",
+        quote_currency: "BRL",
+        rate: 5.43210987,
+        source: "AUTOMATIC",
+        effective_at: new Date(),
+      });
+
+      expect(recorded.rate.toFixed(8)).toBe("5.43210987");
+    });
+
+    test("rejects an unregistered currency with a ValidationError", async () => {
+      await registerBaseCurrencies();
+
+      await expect(
+        exchangeRate.record({
+          base_currency: "USD",
+          quote_currency: "JPY",
+          rate: 150,
+          source: "MANUAL",
+          effective_at: new Date(),
+        }),
+      ).rejects.toMatchObject({
+        name: "ValidationError",
+        message: "The following currencies are not registered: JPY.",
+        action:
+          "Register the currency before recording an exchange rate for it.",
+        statusCode: 400,
+      });
+    });
+  });
+
+  describe(".recordMany()", () => {
+    test("records every rate in the batch", async () => {
+      await registerBaseCurrencies();
+      await orchestrator.createCurrency({ code: "EUR", symbol: "€" });
+
+      const recorded = await exchangeRate.recordMany([
+        {
+          base_currency: "USD",
+          quote_currency: "BRL",
+          rate: 5.5,
+          source: "BULK",
+          effective_at: new Date(),
+        },
+        {
+          base_currency: "USD",
+          quote_currency: "EUR",
+          rate: 0.92,
+          source: "BULK",
+          effective_at: new Date(),
+        },
+      ]);
+
+      expect(recorded).toHaveLength(2);
+      expect(recorded.map((row) => row.quote_currency).sort()).toEqual([
+        "BRL",
+        "EUR",
+      ]);
+    });
+
+    test("writes nothing when any currency in the batch is unregistered", async () => {
+      await registerBaseCurrencies();
+
+      await expect(
+        exchangeRate.recordMany([
+          {
+            base_currency: "USD",
+            quote_currency: "BRL",
+            rate: 5.5,
+            source: "BULK",
+            effective_at: new Date(),
+          },
+          {
+            base_currency: "USD",
+            quote_currency: "JPY",
+            rate: 150,
+            source: "BULK",
+            effective_at: new Date(),
+          },
+        ]),
+      ).rejects.toMatchObject({ name: "ValidationError" });
+
+      // The valid row must not have landed either.
+      expect(await exchangeRate.findLatest("USD", "BRL")).toBeNull();
+    });
+
+    test("rejects an empty batch", async () => {
+      await registerBaseCurrencies();
+
+      await expect(exchangeRate.recordMany([])).rejects.toMatchObject({
+        name: "ValidationError",
+        message: "No exchange rates were provided.",
+        action: "Send at least one exchange rate to record.",
+        statusCode: 400,
+      });
+    });
+  });
+
+  describe(".findLatest()", () => {
+    test("returns the newest rate already in effect", async () => {
+      await registerBaseCurrencies();
+      await orchestrator.createExchangeRate({
+        rate: 5.0,
+        effective_at: new Date("2026-07-01T00:00:00.000Z"),
+      });
+      await orchestrator.createExchangeRate({
+        rate: 5.5,
+        effective_at: new Date("2026-07-15T00:00:00.000Z"),
+      });
+
+      const latest = await exchangeRate.findLatest(
+        "USD",
+        "BRL",
+        new Date("2026-07-20T00:00:00.000Z"),
+      );
+
+      expect(latest?.rate.toFixed(2)).toBe("5.50");
+    });
+
+    test("ignores rates that are not in effect yet", async () => {
+      await registerBaseCurrencies();
+      await orchestrator.createExchangeRate({
+        rate: 5.0,
+        effective_at: new Date("2026-07-01T00:00:00.000Z"),
+      });
+      await orchestrator.createExchangeRate({
+        rate: 9.9,
+        effective_at: new Date("2026-12-01T00:00:00.000Z"),
+      });
+
+      const latest = await exchangeRate.findLatest(
+        "USD",
+        "BRL",
+        new Date("2026-07-20T00:00:00.000Z"),
+      );
+
+      expect(latest?.rate.toFixed(2)).toBe("5.00");
+    });
+
+    test("is case-insensitive on the currency pair", async () => {
+      await registerBaseCurrencies();
+      await orchestrator.createExchangeRate({ rate: 5.25 });
+
+      const latest = await exchangeRate.findLatest("usd", "brl");
+
+      expect(latest?.rate.toFixed(2)).toBe("5.25");
+    });
+
+    test("returns null when the pair has no rate", async () => {
+      await registerBaseCurrencies();
+
+      expect(await exchangeRate.findLatest("BRL", "USD")).toBeNull();
+    });
+  });
+
+  describe(".findLatestOrFail()", () => {
+    test("throws NotFoundError when the pair has no rate", async () => {
+      await registerBaseCurrencies();
+
+      await expect(
+        exchangeRate.findLatestOrFail("BRL", "USD"),
+      ).rejects.toMatchObject({
+        name: "NotFoundError",
+        message: "No exchange rate is available from BRL to USD.",
+        action: "Record an exchange rate for this currency pair and try again.",
+        statusCode: 404,
+      });
+    });
+  });
+
+  describe(".listByPair()", () => {
+    test("returns rates newest-first with pagination metadata", async () => {
+      await registerBaseCurrencies();
+      await orchestrator.createExchangeRate({
+        rate: 5.0,
+        effective_at: new Date("2026-07-01T00:00:00.000Z"),
+      });
+      await orchestrator.createExchangeRate({
+        rate: 5.5,
+        effective_at: new Date("2026-07-15T00:00:00.000Z"),
+      });
+
+      const result = await exchangeRate.listByPair("USD", "BRL", { limit: 1 });
+
+      expect(result.rates).toHaveLength(1);
+      expect(result.rates[0].rate.toFixed(2)).toBe("5.50");
+      expect(result.pagination).toEqual({
+        page: 1,
+        limit: 1,
+        total: 2,
+        pages: 2,
+      });
+    });
+  });
+});

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -12,6 +12,8 @@ import store from "models/store";
 import storeCuration from "models/store_curation";
 import studio from "models/studio";
 import authorization from "models/authorization";
+import currency from "models/currency";
+import exchangeRate from "models/exchange_rate";
 
 const EMAIL_HTTP_URL = `http://${process.env.EMAIL_HTTP_HOST}:${process.env.EMAIL_HTTP_PORT}`;
 
@@ -232,6 +234,29 @@ const addStudioMember = async (studioId, username, permissions) => {
   return studio.addMember(studioId, username, permissions);
 };
 
+// Currencies and exchange rates
+const createCurrency = async (currencyData = {}) => {
+  return currency.create({
+    code: currencyData.code || "USD",
+    symbol: currencyData.symbol || "$",
+    decimal_places:
+      currencyData.decimal_places === undefined
+        ? 2
+        : currencyData.decimal_places,
+    enabled: currencyData.enabled === undefined ? true : currencyData.enabled,
+  });
+};
+
+const createExchangeRate = async (rateData = {}) => {
+  return exchangeRate.record({
+    base_currency: rateData.base_currency || "USD",
+    quote_currency: rateData.quote_currency || "BRL",
+    rate: rateData.rate === undefined ? 5 : rateData.rate,
+    source: rateData.source || "MANUAL",
+    effective_at: rateData.effective_at || new Date(),
+  });
+};
+
 const orchestrator = {
   waitForAllServices,
   clearDatabase,
@@ -259,6 +284,8 @@ const orchestrator = {
   createStudio,
   addStudioMember,
   extractOtpCode,
+  createCurrency,
+  createExchangeRate,
 };
 
 export default orchestrator;


### PR DESCRIPTION
## Description

Adds the two tables multi-currency pricing depends on. **Data layer only — no endpoints, no new features in `AVAILABLE_FEATURES`.**

USD is the platform's base currency: every product carries a USD price and prices in other currencies are derived. This PR provides the registry of allowed currencies and the rate history the derivation will read from. The derivation itself (`priceFor`) is the next task.

### `Currency`

A registry of what the platform is allowed to price and pay in: ISO 4217 `code`, display `symbol`, `decimal_places` and an `enabled` flag.

`decimal_places` is **presentation-only**. Storage stays `Decimal(19,4)` regardless, so intermediate calculations keep more precision than the currency displays — the same reasoning behind #181.

Codes are normalised to uppercase on both write and lookup, so a caller passing `"brl"` finds the same row as `"BRL"`.

### `ExchangeRate`

Append-only, with `rate` as `Decimal(19,8)`. A coarser scale would lose meaningful precision on low-value currencies, where one unit of the base can be worth thousands of the quote.

Reads take the newest row whose `effective_at` is **at or before** the moment of interest. Two consequences worth noting:

- A conversion made months ago stays reproducible from the rate that was effective then, which is what makes a sale auditable later.
- A rate scheduled ahead of time never changes how today's prices convert.

The `source` enum (`AUTOMATIC` / `BULK` / `MANUAL`) records where a rate came from — an external provider fetch, a set agreed in advance, or an admin writing one directly. All three write to the same table and consumers don't need to care which produced a given row.

### Referential integrity without foreign keys

The schema has no foreign keys (project-wide rule), so currency codes on `ExchangeRate` are validated in the model layer instead. Without that, a typo becomes a row that silently never matches anything — the worst kind of pricing bug.

`recordMany` validates the entire batch **before** writing and wraps the inserts in a transaction, so a partially loaded set is never visible to price resolution. There's a test asserting that a batch containing one bad currency leaves nothing behind.

## Related issue

Part of #177 — task 3 in `docs/payments-tasks.md`. Follows #181 (money as `Decimal(19,4)`).

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📖 Documentation
- [ ] ♻️ Refactor
- [ ] 🧪 Tests

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] `npm run lint:eslint:check` passes
- [x] `npm run lint:prettier:check` passes
- [x] `npm run test` passes — **410/413, see below**
- [x] Added or updated tests where relevant

## Test results

`410 passed, 3 failed` across 86 suites (+20 new tests). The 3 failures are the same two environmental suites as #181, both unrelated to this change:

| Suite | Cause |
| --- | --- |
| `api/v1/status/get.test.ts` | Asserts the database version is `"16.0"` (the `postgres:16.0-alpine3.18` image). This run used a natively installed PostgreSQL 16.13. |
| `api/v1/items/games/steam-import/post.test.ts` (2 tests) | The public Steam API is unreachable from this environment, so the endpoint returns 503 instead of 201/404. |

New tests cover: creation and duplicate rejection, case-insensitive lookup, `enabled` filtering, the 8-decimal scale round-tripping, unregistered-currency rejection on both the single and batch paths, the all-or-nothing batch guarantee, newest-in-effect selection, future-dated rates being ignored, and pagination.

## Deliberately not included

- **No seed data.** `clearDatabaseRows` truncates every table, so seeded reference currencies would vanish in tests and any code depending on them would pass locally and fail in CI. Currencies are created explicitly by the orchestrator in tests; production seeding will come with the task that first needs it.
- **No `convert()` helper.** Conversion belongs with price resolution, where the rounding policy and missing-rate behaviour also have to be decided.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Whv49dfByzLEJjor8FbRbt)_