### PR TITLE
feat: add multi-currency price resolution

### DIFF
--- a/docs/payments-tasks.md
+++ b/docs/payments-tasks.md
@@ -8,8 +8,8 @@ Delivery plan for [#177](https://github.com/pedromello/manifoldpowered.com/issue
 | --------------------------------- | ---------------------------------------------------------------------------- |
 | 1. Foundation — features          | not started (deferred: no endpoints yet, so no new features needed)          |
 | 2. Money → `Decimal(19,4)`        | ✅ done ([#181](https://github.com/pedromello/manifoldpowered.com/pull/181)) |
-| 3. Currency + exchange rate model | ✅ done                                                                      |
-| 4. Price resolution               | next                                                                         |
+| 3. Currency + exchange rate model | ✅ done ([#182](https://github.com/pedromello/manifoldpowered.com/pull/182)) |
+| 4. Price resolution               | ✅ done                                                                      |
 | 5–11                              | not started                                                                  |
 
 Each task is a separate small PR, landed in order, with `npm run test` passing on its own before merge — the same format as `docs/backoffice-tasks.md`.
@@ -158,12 +158,16 @@ priceFor(game, currency) = fixedPriceOverride(game, currency)
                         ?? convert(game.base_price_usd, currency)
 ```
 
-Two things this task must settle, because they're easy to get wrong and expensive to change later:
+Two decisions this task settled:
 
-- **Rounding policy.** Storage is 4 decimals, presentation is usually 2. Converted prices need a documented rule (round half-up to the currency's decimal places, at minimum). Whether to snap to psychological endings is a product decision worth making explicitly.
-- **Missing-rate behaviour.** If no rate exists for a currency and there's no override, does the product fall back to USD or disappear from the storefront? Silently showing a wrong price is the worst option.
+- **Missing price → hide the product.** If there is no rate and no override, the item does not appear for that currency. It never falls back to USD, because showing a price in the wrong currency is worse than showing nothing. This is why `resolvableGameIds` exists alongside `priceFor`: listing queries have to filter too, or the item shows up in search and only breaks on the detail page.
+- **Rounding is half-up to the currency's `decimal_places`.** No psychological endings in the conversion path — a commercially-shaped price like 49.90 is set as an override instead, which keeps conversion a plain, auditable calculation.
 
-**Done when:** resolution is a single tested function used by every read path, both branches are covered, and rounding and missing-rate behaviour are documented in code.
+A disabled currency behaves exactly like an unregistered one, so turning a currency off removes it from every storefront without deleting any price.
+
+**Done when:** resolution is a single tested function used by every read path, both branches are covered, and rounding and missing-price behaviour are documented in code.
+
+**Still open:** how the platform decides which currency a visitor sees. There is no user preference or region detection modelled yet — `priceFor` takes the currency explicitly, and choosing it is a separate task.
 
 **Constraint that must not break:** this is developer/admin pricing only. **Storefront owners must never gain price control** — that is what keeps them affiliates rather than sellers (`docs/legal/phase-0-checklist.md`). Overrides are set at the catalog level, never per store.
 

--- a/models/pricing.ts
+++ b/models/pricing.ts
@@ -1,0 +1,248 @@
+import { prisma } from "infra/database";
+import { z } from "zod";
+import { Game, Prisma } from "generated/prisma/client";
+import { NotFoundError, ValidationError } from "infra/errors";
+import currency, { currencyCodeSchema } from "models/currency";
+import exchangeRate from "models/exchange_rate";
+
+// Every game carries a price in this currency, and prices in any other
+// currency are derived from it.
+export const BASE_CURRENCY = "USD";
+
+export const gamePriceOverrideSchema = z.object({
+  currency: currencyCodeSchema,
+  amount: z.coerce.number().min(0).max(1_000_000),
+});
+
+export type GamePriceOverrideDto = z.infer<typeof gamePriceOverrideSchema>;
+
+export interface ResolvedPrice {
+  amount: Prisma.Decimal;
+  currency: string;
+  // Null when the price came from an override or is already in the base
+  // currency. Set to the rate actually used otherwise, so a sale recorded from
+  // this price can be reconciled later against the rate that produced it.
+  exchange_rate: Prisma.Decimal | null;
+  source: "BASE" | "OVERRIDE" | "CONVERTED";
+}
+
+async function setOverride(gameId: string, overrideDto: GamePriceOverrideDto) {
+  await validateCurrencyIsUsable(overrideDto.currency);
+
+  return await prisma.gamePriceOverride.upsert({
+    where: {
+      game_id_currency: {
+        game_id: gameId,
+        currency: currency.normalizeCode(overrideDto.currency),
+      },
+    },
+    create: {
+      game_id: gameId,
+      currency: currency.normalizeCode(overrideDto.currency),
+      amount: overrideDto.amount,
+    },
+    update: { amount: overrideDto.amount },
+  });
+}
+
+async function removeOverride(gameId: string, currencyCode: string) {
+  const normalizedCode = currency.normalizeCode(currencyCode);
+
+  const deleted = await prisma.gamePriceOverride.deleteMany({
+    where: { game_id: gameId, currency: normalizedCode },
+  });
+
+  if (deleted.count === 0) {
+    throw new NotFoundError({
+      message: `No ${normalizedCode} price override exists for this game.`,
+      action: "Check the game and currency and try again.",
+    });
+  }
+
+  return deleted;
+}
+
+async function listOverrides(gameId: string) {
+  return await prisma.gamePriceOverride.findMany({
+    where: { game_id: gameId },
+    orderBy: { currency: "asc" },
+  });
+}
+
+// Resolves what a game costs in a given currency:
+//
+//   priceFor(game, currency) = fixedOverride(game, currency)
+//                           ?? convert(game.price, currency)
+//
+// Returns null when neither is available. Callers must treat null as "this
+// product is not purchasable in this currency" and hide it, rather than
+// falling back to the base currency — showing a price in the wrong currency is
+// worse than showing nothing.
+async function priceFor(
+  game: Pick<Game, "id" | "price">,
+  currencyCode: string,
+  asOf: Date = new Date(),
+): Promise<ResolvedPrice | null> {
+  const normalizedCode = currency.normalizeCode(currencyCode);
+
+  const isCurrencyUsable = await isUsable(normalizedCode);
+  if (!isCurrencyUsable) {
+    return null;
+  }
+
+  const override = await prisma.gamePriceOverride.findUnique({
+    where: {
+      game_id_currency: { game_id: game.id, currency: normalizedCode },
+    },
+  });
+
+  if (override) {
+    return {
+      amount: override.amount,
+      currency: normalizedCode,
+      exchange_rate: null,
+      source: "OVERRIDE",
+    };
+  }
+
+  if (normalizedCode === BASE_CURRENCY) {
+    return {
+      amount: game.price,
+      currency: BASE_CURRENCY,
+      exchange_rate: null,
+      source: "BASE",
+    };
+  }
+
+  const rate = await exchangeRate.findLatest(
+    BASE_CURRENCY,
+    normalizedCode,
+    asOf,
+  );
+
+  if (!rate) {
+    return null;
+  }
+
+  return {
+    amount: await roundToCurrencyScale(
+      game.price.mul(rate.rate),
+      normalizedCode,
+    ),
+    currency: normalizedCode,
+    exchange_rate: rate.rate,
+    source: "CONVERTED",
+  };
+}
+
+// Same as priceFor but for callers that cannot render anything without a
+// price, e.g. a checkout that has already committed to a currency.
+async function priceForOrFail(
+  game: Pick<Game, "id" | "price">,
+  currencyCode: string,
+  asOf: Date = new Date(),
+) {
+  const resolved = await priceFor(game, currencyCode, asOf);
+
+  if (!resolved) {
+    throw new NotFoundError({
+      message: `This item has no price available in ${currency.normalizeCode(currencyCode)}.`,
+      action:
+        "Choose a different currency, or contact support if you expected this item to be available.",
+    });
+  }
+
+  return resolved;
+}
+
+// The ids from `gameIds` that can be priced in the given currency.
+//
+// Cheap in the common case: every game has a base price, so once a rate exists
+// for the pair the whole catalog is resolvable and no per-game lookup is
+// needed. Only when the rate is missing does this fall back to "the games with
+// an explicit override", which is exactly the set a storefront should show.
+async function resolvableGameIds(
+  gameIds: string[],
+  currencyCode: string,
+  asOf: Date = new Date(),
+): Promise<string[]> {
+  if (gameIds.length === 0) {
+    return [];
+  }
+
+  const normalizedCode = currency.normalizeCode(currencyCode);
+
+  if (!(await isUsable(normalizedCode))) {
+    return [];
+  }
+
+  if (normalizedCode === BASE_CURRENCY) {
+    return gameIds;
+  }
+
+  const rate = await exchangeRate.findLatest(
+    BASE_CURRENCY,
+    normalizedCode,
+    asOf,
+  );
+
+  if (rate) {
+    return gameIds;
+  }
+
+  const overrides = await prisma.gamePriceOverride.findMany({
+    where: { game_id: { in: gameIds }, currency: normalizedCode },
+    select: { game_id: true },
+  });
+
+  const overriddenIds = new Set(overrides.map((row) => row.game_id));
+
+  return gameIds.filter((gameId) => overriddenIds.has(gameId));
+}
+
+// Storage keeps the full Decimal(19,4) scale; this rounds to what the currency
+// actually displays. Half-up, matching how prices are quoted commercially.
+// Prices with a commercial shape (49.90 rather than a converted 51.37) are set
+// as overrides instead, keeping this a plain, auditable calculation.
+async function roundToCurrencyScale(amount: Prisma.Decimal, code: string) {
+  const foundCurrency = await currency.findOneByCode(code);
+
+  return amount.toDecimalPlaces(
+    foundCurrency.decimal_places,
+    Prisma.Decimal.ROUND_HALF_UP,
+  );
+}
+
+// A currency has to be both registered and enabled to be priced in. A disabled
+// currency behaves exactly like an unknown one, so turning it off immediately
+// removes it from every storefront.
+async function isUsable(code: string) {
+  const foundCurrency = await prisma.currency.findUnique({
+    where: { code: currency.normalizeCode(code) },
+    select: { enabled: true },
+  });
+
+  return Boolean(foundCurrency?.enabled);
+}
+
+async function validateCurrencyIsUsable(code: string) {
+  if (!(await isUsable(code))) {
+    throw new ValidationError({
+      message: `The currency "${currency.normalizeCode(code)}" is not registered or is disabled.`,
+      action: "Register and enable the currency before pricing in it.",
+    });
+  }
+}
+
+const pricing = {
+  BASE_CURRENCY,
+  setOverride,
+  removeOverride,
+  listOverrides,
+  priceFor,
+  priceForOrFail,
+  resolvableGameIds,
+  isUsable,
+};
+
+export default pricing;

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/prisma/migrations/20260730234220_add_game_price_override/migration.sql
+++ b/prisma/migrations/20260730234220_add_game_price_override/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "game_price_overrides" (
+    "id" TEXT NOT NULL,
+    "game_id" TEXT NOT NULL,
+    "currency" VARCHAR(3) NOT NULL,
+    "amount" DECIMAL(19,4) NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "game_price_overrides_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "game_price_overrides_game_id_idx" ON "game_price_overrides"("game_id");
+
+-- CreateIndex
+CREATE INDEX "game_price_overrides_currency_idx" ON "game_price_overrides"("currency");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "game_price_overrides_game_id_currency_key" ON "game_price_overrides"("game_id", "currency");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -395,3 +395,26 @@ model ExchangeRate {
   @@index([base_currency, quote_currency, effective_at])
   @@map("exchange_rates")
 }
+
+// A price set explicitly by a developer/admin for one currency. Its presence
+// means "this is the price, do not convert" — it always wins over conversion
+// from the game's USD base price. This is also where commercially-shaped
+// prices live (e.g. 49.90 rather than a converted 51.37), which keeps the
+// conversion path a plain, auditable calculation.
+//
+// Catalog-level only: storefront owners must never gain price control, since
+// that is what keeps them affiliates rather than sellers (see
+// docs/legal/phase-0-checklist.md). There is deliberately no store_id here.
+model GamePriceOverride {
+  id         String   @id @default(uuid())
+  game_id    String // Logical reference to Game.id
+  currency   String   @db.VarChar(3) // Logical reference to Currency.code
+  amount     Decimal  @db.Decimal(19, 4)
+  created_at DateTime @default(now())
+  updated_at DateTime @updatedAt
+
+  @@unique([game_id, currency])
+  @@index([game_id])
+  @@index([currency])
+  @@map("game_price_overrides")
+}

--- a/tests/integration/models/pricing.test.ts
+++ b/tests/integration/models/pricing.test.ts
@@ -1,0 +1,284 @@
+import orchestrator from "tests/orchestrator";
+import pricing from "models/pricing";
+import currency from "models/currency";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+async function setupGame(priceInUsd = 10) {
+  await orchestrator.clearDatabaseRows();
+  await orchestrator.createCurrency({ code: "USD", symbol: "$" });
+  await orchestrator.createCurrency({ code: "BRL", symbol: "R$" });
+
+  const user = await orchestrator.createUser();
+  await orchestrator.activateUser(user.id);
+  const game = await orchestrator.createGame(user.id, { price: priceInUsd });
+
+  return game;
+}
+
+describe("models/pricing.ts", () => {
+  describe(".priceFor()", () => {
+    test("returns the base price unchanged for the base currency", async () => {
+      const game = await setupGame(19.99);
+
+      const resolved = await pricing.priceFor(game, "USD");
+
+      expect(resolved?.source).toBe("BASE");
+      expect(resolved?.currency).toBe("USD");
+      expect(resolved?.amount.toFixed(2)).toBe("19.99");
+      expect(resolved?.exchange_rate).toBeNull();
+    });
+
+    test("converts from the base price when a rate exists", async () => {
+      const game = await setupGame(10);
+      await orchestrator.createExchangeRate({ rate: 5.5 });
+
+      const resolved = await pricing.priceFor(game, "BRL");
+
+      expect(resolved?.source).toBe("CONVERTED");
+      expect(resolved?.currency).toBe("BRL");
+      expect(resolved?.amount.toFixed(2)).toBe("55.00");
+      expect(resolved?.exchange_rate?.toFixed(2)).toBe("5.50");
+    });
+
+    test("a fixed override wins over conversion", async () => {
+      const game = await setupGame(10);
+      await orchestrator.createExchangeRate({ rate: 5.5 });
+      await orchestrator.setGamePriceOverride(game.id, "BRL", 49.9);
+
+      const resolved = await pricing.priceFor(game, "BRL");
+
+      expect(resolved?.source).toBe("OVERRIDE");
+      expect(resolved?.amount.toFixed(2)).toBe("49.90");
+      // An override is a stated price, not a converted one.
+      expect(resolved?.exchange_rate).toBeNull();
+    });
+
+    test("an override applies even when no rate exists at all", async () => {
+      const game = await setupGame(10);
+      await orchestrator.setGamePriceOverride(game.id, "BRL", 49.9);
+
+      const resolved = await pricing.priceFor(game, "BRL");
+
+      expect(resolved?.source).toBe("OVERRIDE");
+      expect(resolved?.amount.toFixed(2)).toBe("49.90");
+    });
+
+    test("returns null when there is no rate and no override", async () => {
+      const game = await setupGame(10);
+
+      expect(await pricing.priceFor(game, "BRL")).toBeNull();
+    });
+
+    test("returns null for an unregistered currency", async () => {
+      const game = await setupGame(10);
+
+      expect(await pricing.priceFor(game, "JPY")).toBeNull();
+    });
+
+    test("returns null once a currency is disabled, even with an override", async () => {
+      const game = await setupGame(10);
+      await orchestrator.createCurrency({ code: "JPY", symbol: "¥" });
+      await orchestrator.setGamePriceOverride(game.id, "JPY", 1500);
+
+      // Priced while enabled...
+      expect((await pricing.priceFor(game, "JPY"))?.source).toBe("OVERRIDE");
+
+      await currency.setEnabled("JPY", false);
+
+      // ...and gone the moment it is disabled. Turning a currency off removes
+      // it from every storefront without having to delete any price.
+      expect(await pricing.priceFor(game, "JPY")).toBeNull();
+    });
+
+    test("rounds half-up to the currency's display scale", async () => {
+      const game = await setupGame(12.99);
+      await orchestrator.createExchangeRate({ rate: 5.4321 });
+
+      // 12.99 * 5.4321 = 70.5629...
+      const resolved = await pricing.priceFor(game, "BRL");
+
+      expect(resolved?.amount.toFixed(2)).toBe("70.56");
+    });
+
+    test("respects a currency with zero decimal places", async () => {
+      const game = await setupGame(10);
+      await orchestrator.createCurrency({
+        code: "JPY",
+        symbol: "¥",
+        decimal_places: 0,
+      });
+      await orchestrator.createExchangeRate({
+        quote_currency: "JPY",
+        rate: 155.75,
+      });
+
+      const resolved = await pricing.priceFor(game, "JPY");
+
+      expect(resolved?.amount.toFixed(0)).toBe("1558");
+    });
+
+    test("uses the rate effective at the given moment", async () => {
+      const game = await setupGame(10);
+      await orchestrator.createExchangeRate({
+        rate: 5.0,
+        effective_at: new Date("2026-07-01T00:00:00.000Z"),
+      });
+      await orchestrator.createExchangeRate({
+        rate: 6.0,
+        effective_at: new Date("2026-07-20T00:00:00.000Z"),
+      });
+
+      const resolvedEarly = await pricing.priceFor(
+        game,
+        "BRL",
+        new Date("2026-07-10T00:00:00.000Z"),
+      );
+      const resolvedLate = await pricing.priceFor(
+        game,
+        "BRL",
+        new Date("2026-07-25T00:00:00.000Z"),
+      );
+
+      expect(resolvedEarly?.amount.toFixed(2)).toBe("50.00");
+      expect(resolvedLate?.amount.toFixed(2)).toBe("60.00");
+    });
+
+    test("is case-insensitive on the currency code", async () => {
+      const game = await setupGame(10);
+      await orchestrator.createExchangeRate({ rate: 5.5 });
+
+      const resolved = await pricing.priceFor(game, "brl");
+
+      expect(resolved?.currency).toBe("BRL");
+      expect(resolved?.amount.toFixed(2)).toBe("55.00");
+    });
+  });
+
+  describe(".priceForOrFail()", () => {
+    test("throws NotFoundError when the price cannot be resolved", async () => {
+      const game = await setupGame(10);
+
+      await expect(pricing.priceForOrFail(game, "BRL")).rejects.toMatchObject({
+        name: "NotFoundError",
+        message: "This item has no price available in BRL.",
+        statusCode: 404,
+      });
+    });
+  });
+
+  describe(".resolvableGameIds()", () => {
+    test("returns every id when a rate exists for the pair", async () => {
+      const gameA = await setupGame(10);
+      const gameB = await orchestrator.createGame(undefined, {
+        price: 20,
+        studio_id: gameA.studio_id,
+      });
+      await orchestrator.createExchangeRate({ rate: 5.5 });
+
+      const resolvable = await pricing.resolvableGameIds(
+        [gameA.id, gameB.id],
+        "BRL",
+      );
+
+      expect(resolvable.sort()).toEqual([gameA.id, gameB.id].sort());
+    });
+
+    test("returns only overridden games when no rate exists", async () => {
+      const gameA = await setupGame(10);
+      const gameB = await orchestrator.createGame(undefined, {
+        price: 20,
+        studio_id: gameA.studio_id,
+      });
+      await orchestrator.setGamePriceOverride(gameA.id, "BRL", 49.9);
+
+      const resolvable = await pricing.resolvableGameIds(
+        [gameA.id, gameB.id],
+        "BRL",
+      );
+
+      expect(resolvable).toEqual([gameA.id]);
+    });
+
+    test("returns nothing for a disabled currency", async () => {
+      const game = await setupGame(10);
+      await orchestrator.createExchangeRate({ rate: 5.5 });
+      await orchestrator.createCurrency({
+        code: "JPY",
+        symbol: "¥",
+        enabled: false,
+      });
+
+      expect(await pricing.resolvableGameIds([game.id], "JPY")).toEqual([]);
+    });
+
+    test("returns every id for the base currency without touching rates", async () => {
+      const game = await setupGame(10);
+
+      expect(await pricing.resolvableGameIds([game.id], "USD")).toEqual([
+        game.id,
+      ]);
+    });
+
+    test("returns an empty array for an empty input", async () => {
+      await setupGame(10);
+
+      expect(await pricing.resolvableGameIds([], "BRL")).toEqual([]);
+    });
+  });
+
+  describe(".setOverride()", () => {
+    test("updates the amount when an override already exists", async () => {
+      const game = await setupGame(10);
+      await orchestrator.setGamePriceOverride(game.id, "BRL", 49.9);
+      await orchestrator.setGamePriceOverride(game.id, "BRL", 59.9);
+
+      const overrides = await pricing.listOverrides(game.id);
+
+      expect(overrides).toHaveLength(1);
+      expect(overrides[0].amount.toFixed(2)).toBe("59.90");
+    });
+
+    test("rejects an unregistered currency", async () => {
+      const game = await setupGame(10);
+
+      await expect(
+        pricing.setOverride(game.id, { currency: "JPY", amount: 1500 }),
+      ).rejects.toMatchObject({
+        name: "ValidationError",
+        message: 'The currency "JPY" is not registered or is disabled.',
+        action: "Register and enable the currency before pricing in it.",
+        statusCode: 400,
+      });
+    });
+  });
+
+  describe(".removeOverride()", () => {
+    test("removes the override so the price falls back to conversion", async () => {
+      const game = await setupGame(10);
+      await orchestrator.createExchangeRate({ rate: 5.5 });
+      await orchestrator.setGamePriceOverride(game.id, "BRL", 49.9);
+
+      await pricing.removeOverride(game.id, "BRL");
+
+      const resolved = await pricing.priceFor(game, "BRL");
+      expect(resolved?.source).toBe("CONVERTED");
+      expect(resolved?.amount.toFixed(2)).toBe("55.00");
+    });
+
+    test("throws NotFoundError when there is nothing to remove", async () => {
+      const game = await setupGame(10);
+
+      await expect(
+        pricing.removeOverride(game.id, "BRL"),
+      ).rejects.toMatchObject({
+        name: "NotFoundError",
+        message: "No BRL price override exists for this game.",
+        statusCode: 404,
+      });
+    });
+  });
+});

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -14,6 +14,7 @@ import studio from "models/studio";
 import authorization from "models/authorization";
 import currency from "models/currency";
 import exchangeRate from "models/exchange_rate";
+import pricing from "models/pricing";
 
 const EMAIL_HTTP_URL = `http://${process.env.EMAIL_HTTP_HOST}:${process.env.EMAIL_HTTP_PORT}`;
 
@@ -247,6 +248,10 @@ const createCurrency = async (currencyData = {}) => {
   });
 };
 
+const setGamePriceOverride = async (gameId, currencyCode, amount) => {
+  return pricing.setOverride(gameId, { currency: currencyCode, amount });
+};
+
 const createExchangeRate = async (rateData = {}) => {
   return exchangeRate.record({
     base_currency: rateData.base_currency || "USD",
@@ -286,6 +291,7 @@ const orchestrator = {
   extractOtpCode,
   createCurrency,
   createExchangeRate,
+  setGamePriceOverride,
 };
 
 export default orchestrator;


### PR DESCRIPTION
## Description

Adds `GamePriceOverride` and `models/pricing.ts`, so a game priced in USD can be shown in another currency:

```
priceFor(game, currency) = fixedOverride(game, currency)
                        ?? convert(game.price, currency)
```

A developer-set override always wins. Absent one, the price is converted from the USD base price using the rate that was **effective at the moment being resolved** — so a price quoted in the past stays reproducible rather than silently re-converting at today's rate.

Data layer only, following #182. No endpoints, so no new entries in `AVAILABLE_FEATURES`.

### Missing price hides the product

When there is no rate and no override, `priceFor` returns `null` and the item must not be shown. It never falls back to USD: a price in the wrong currency is worse than no price at all.

This is why **`resolvableGameIds` exists alongside `priceFor`**. Hiding an item is not only a detail-page concern — listing queries have to filter too, or the item appears in search and only breaks when someone clicks it.

It's cheap in the common case. Every game has a USD base price, so once a rate exists for the pair the entire catalog is resolvable and no per-game lookup happens. Only when the rate is missing does it fall back to "the games with an explicit override", which is exactly the set a storefront should show in that situation.

### Rounding

Half-up to the currency's `decimal_places`. Storage keeps the full `Decimal(19,4)` scale.

No psychological endings in the conversion path. A commercially shaped price like `49.90` (rather than a converted `51.37`) is set as an **override** instead — which is precisely what the override mechanism is for, and keeps conversion a plain, auditable calculation rather than one embedding a pricing strategy.

### Disabling a currency

A disabled currency behaves exactly like an unregistered one. Turning a currency off removes it from every storefront immediately, without deleting any price — useful if a rate goes wrong or a market needs to come down quickly. There's a test covering the real sequence: price it while enabled, disable, confirm it disappears.

### `GamePriceOverride` has no `store_id`

Deliberate. Pricing is catalog-level, and **storefront owners must never gain price control** — that is the load-bearing fact keeping them affiliates rather than sellers (`docs/legal/phase-0-checklist.md`).

### Resolved prices carry the rate used

`ResolvedPrice` includes `exchange_rate` and a `source` of `BASE` / `OVERRIDE` / `CONVERTED`. Without recording which rate produced a converted price, a sale made from it cannot be reconciled or audited later.

## Related issue

Part of #177 — task 4 in `docs/payments-tasks.md`. Follows #181 (money as `Decimal(19,4)`) and #182 (currency and exchange rate models).

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📖 Documentation
- [ ] ♻️ Refactor
- [ ] 🧪 Tests

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] `npm run lint:eslint:check` passes
- [x] `npm run lint:prettier:check` passes
- [x] `npm run test` passes — **431/434, see below**
- [x] Added or updated tests where relevant

## Test results

`431 passed, 3 failed` across 87 suites (+21 new tests). Same two environmental suites as #181 and #182, both unrelated:

| Suite | Cause |
| --- | --- |
| `api/v1/status/get.test.ts` | Asserts the database version is `"16.0"` (the `postgres:16.0-alpine3.18` image). This run used a natively installed PostgreSQL 16.13. |
| `api/v1/items/games/steam-import/post.test.ts` (2 tests) | The public Steam API is unreachable from this environment, so the endpoint returns 503 instead of 201/404. |

New tests cover: base-currency passthrough, conversion, override winning over conversion, override working with no rate at all, null on missing rate, null on unregistered currency, disappearing when a currency is disabled, half-up rounding, a zero-decimal currency, rate selection by effective date, case-insensitivity, the `resolvableGameIds` branches, override upsert, and both `NotFoundError` paths.

## Still open

**How the platform decides which currency a visitor sees.** There is no user preference or region detection modelled yet — `priceFor` takes the currency explicitly and choosing it is a separate task. Nothing in the storefront changes yet as a result of this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Whv49dfByzLEJjor8FbRbt)_