### PR TITLE
feat: add studio price override endpoints

### DIFF
--- a/docs/payments-tasks.md
+++ b/docs/payments-tasks.md
@@ -4,15 +4,16 @@ Delivery plan for [#177](https://github.com/pedromello/manifoldpowered.com/issue
 
 **Status: in progress.** The design is also under public discussion, so tasks not yet started may still change.
 
-| Task                                    | State                                                                        |
-| --------------------------------------- | ---------------------------------------------------------------------------- |
-| 2. Money → `Decimal(19,4)`              | ✅ done ([#181](https://github.com/pedromello/manifoldpowered.com/pull/181)) |
-| 3. Currency + exchange rate model       | ✅ done ([#182](https://github.com/pedromello/manifoldpowered.com/pull/182)) |
-| 4. Price resolution                     | ✅ done ([#183](https://github.com/pedromello/manifoldpowered.com/pull/183)) |
-| 4a. Admin currency + rate endpoints     | ✅ done                                                                      |
-| 4b. Studio price override endpoints     | next                                                                         |
-| 4c. Currency selection by region header | after 4b                                                                     |
-| 5–11 (ledger, payouts)                  | not started                                                                  |
+| Task                                     | State                                                                        |
+| ---------------------------------------- | ---------------------------------------------------------------------------- |
+| 2. Money → `Decimal(19,4)`               | ✅ done ([#181](https://github.com/pedromello/manifoldpowered.com/pull/181)) |
+| 3. Currency + exchange rate model        | ✅ done ([#182](https://github.com/pedromello/manifoldpowered.com/pull/182)) |
+| 4. Price resolution                      | ✅ done ([#183](https://github.com/pedromello/manifoldpowered.com/pull/183)) |
+| 4a. Admin currency + rate endpoints      | ✅ done ([#184](https://github.com/pedromello/manifoldpowered.com/pull/184)) |
+| 4b. Studio price override endpoints      | ✅ done                                                                      |
+| 4c. Backoffice UI for currencies + rates | next                                                                         |
+| 4d. Currency selection by region header  | after 4c                                                                     |
+| 5–11 (ledger, payouts)                   | not started                                                                  |
 
 Each task is a separate small PR, landed in order, with `npm run test` passing on its own before merge — the same format as `docs/backoffice-tasks.md`.
 
@@ -253,6 +254,52 @@ If a balance must be converted to the affiliate's payout currency, the conversio
 Statement and payout history endpoints, gated by the base feature in the router plus a resource-scoped ownership check in the handler. Balances shown per currency. **Never** buyer personal data, never gift card codes.
 
 **Done when:** an affiliate can see their own numbers and provably cannot see another store's.
+
+---
+
+### 4a. Admin currency + exchange rate endpoints
+
+**TLDR:** Backoffice CRUD so currencies and rates can be managed without touching the database.
+
+`GET`/`POST /api/v1/backoffice/currencies`, `GET`/`PATCH /api/v1/backoffice/currencies/[code]`, `GET`/`POST /api/v1/backoffice/exchange-rates`. Every mutation writes an `AdminActionLog`.
+
+The currency code is immutable — it is the logical reference every rate and override points at, and with no foreign keys a rename would orphan them silently.
+
+**Done when:** an admin can register a currency and record a rate through the API. ✅
+
+---
+
+### 4b. Studio price override endpoints
+
+**TLDR:** Let whoever manages a game set its price per currency.
+
+`GET /api/v1/items/games/[slug]/prices` returns one row per enabled currency, showing exactly what a buyer in each would see — including the currencies where the game is unavailable, which is the case most worth noticing. `PUT`/`DELETE /api/v1/items/games/[slug]/prices/[currency]` set and clear an override.
+
+Authorization reuses the `update:game` resource branch: `read:game_price` and `update:game_price` resolve through the game's studio, and both are in `studio.MEMBER_PERMISSIONS`. Anyone who can already change a game's USD price has no reason to be blocked from its price in another currency. Existing studio owners pick the new permissions up from `npm run features:backfill`, which reconciles studio owners against `MEMBER_PERMISSIONS`.
+
+**Done when:** a studio owner can price a game in every enabled currency and see where it is unavailable. ✅
+
+---
+
+### 4c. Backoffice UI for currencies and exchange rates
+
+**TLDR:** Screens for the endpoints from 4a, so currencies and rates are managed without curl.
+
+Follows the existing backoffice conventions (`BackofficeLayout`, Tailwind, SWR, `lucide-react`) and the ground rules in `docs/backoffice-tasks.md`: server-side `canRequest` already enforces access, client gating is cosmetic, and every mutating action gets a confirm dialog naming the resource.
+
+Screens: a currency list with create and edit, and a rate list filtered by pair with a form to record a new rate. Disabling a currency needs a confirm dialog that says plainly it hides every product priced in that currency.
+
+**Done when:** an admin can register a currency, toggle it, and record a rate entirely from the UI.
+
+---
+
+### 4d. Currency selection by region
+
+**TLDR:** Decide which currency a visitor sees, from a geolocation header.
+
+Nothing in the storefront reacts to any of the pricing work until this lands — `priceFor` takes the currency explicitly and nobody chooses it. Detection reads the hosting platform's region header, falling back to the base currency when the region is unknown or its currency is not enabled.
+
+Storefront and detail reads then have to use `resolvableGameIds`/`priceFor`, so a product with no resolvable price disappears rather than showing a price in the wrong currency.
 
 ---
 

--- a/models/authorization.ts
+++ b/models/authorization.ts
@@ -48,6 +48,11 @@ const AVAILABLE_FEATURES = [
   "read:public_game",
   "update:game",
   "update:game:any",
+  // Per-currency price overrides. Resolved through the game's studio exactly
+  // like update:game, since anyone who can already change a game's USD price
+  // has no reason to be blocked from its price in another currency.
+  "read:game_price",
+  "update:game_price",
 
   // Wishlists
   "create:wishlist",
@@ -211,7 +216,9 @@ function can(user: Partial<User>, feature: string, resource?: unknown) {
   if (
     (feature === "update:game" ||
       feature === "create:game_file" ||
-      feature === "delete:game_file") &&
+      feature === "delete:game_file" ||
+      feature === "read:game_price" ||
+      feature === "update:game_price") &&
     resource
   ) {
     authorized = false;
@@ -674,6 +681,24 @@ function filterOutput(user: Partial<User>, feature: string, resource: unknown) {
       enabled: currencyOutput.enabled,
       created_at: currencyOutput.created_at,
       updated_at: currencyOutput.updated_at,
+    };
+  }
+
+  if (feature === "read:game_price" || feature === "update:game_price") {
+    interface GamePriceOutput {
+      currency: string;
+      amount: string | null;
+      source: "BASE" | "OVERRIDE" | "CONVERTED" | null;
+      exchange_rate: string | null;
+      is_override: boolean;
+    }
+    const priceOutput = resource as GamePriceOutput;
+    return {
+      currency: priceOutput.currency,
+      amount: priceOutput.amount,
+      source: priceOutput.source,
+      exchange_rate: priceOutput.exchange_rate,
+      is_override: priceOutput.is_override,
     };
   }
 

--- a/models/pricing.ts
+++ b/models/pricing.ts
@@ -135,6 +135,42 @@ async function priceFor(
   };
 }
 
+export interface GamePriceView {
+  currency: string;
+  // Null means the game is not purchasable in this currency and must be hidden
+  // from anyone browsing in it.
+  amount: string | null;
+  source: "BASE" | "OVERRIDE" | "CONVERTED" | null;
+  exchange_rate: string | null;
+  is_override: boolean;
+}
+
+// One row per enabled currency, so whoever manages a game sees exactly what a
+// buyer in each currency would see — including the currencies where the game
+// is currently unavailable, which is the case most worth noticing.
+async function priceViewFor(
+  game: Pick<Game, "id" | "price">,
+  asOf: Date = new Date(),
+): Promise<GamePriceView[]> {
+  const enabledCurrencies = await currency.findAllEnabled();
+
+  return await Promise.all(
+    enabledCurrencies.map(async (enabledCurrency) => {
+      const resolved = await priceFor(game, enabledCurrency.code, asOf);
+
+      return {
+        currency: enabledCurrency.code,
+        amount: resolved
+          ? resolved.amount.toFixed(enabledCurrency.decimal_places)
+          : null,
+        source: resolved?.source ?? null,
+        exchange_rate: resolved?.exchange_rate?.toFixed(8) ?? null,
+        is_override: resolved?.source === "OVERRIDE",
+      };
+    }),
+  );
+}
+
 // Same as priceFor but for callers that cannot render anything without a
 // price, e.g. a checkout that has already committed to a currency.
 async function priceForOrFail(
@@ -241,6 +277,7 @@ const pricing = {
   listOverrides,
   priceFor,
   priceForOrFail,
+  priceViewFor,
   resolvableGameIds,
   isUsable,
 };

--- a/models/studio.ts
+++ b/models/studio.ts
@@ -22,6 +22,8 @@ export const MEMBER_PERMISSIONS = [
   "update:game",
   "create:game_file",
   "delete:game_file",
+  "read:game_price",
+  "update:game_price",
 ];
 
 export const memberPermissionsSchema = z.object({

--- a/pages/api/v1/items/games/[slug]/prices/[currency]/index.ts
+++ b/pages/api/v1/items/games/[slug]/prices/[currency]/index.ts
@@ -1,0 +1,85 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { createRouter } from "next-connect";
+import controller from "infra/controller";
+import game from "models/game";
+import pricing, { gamePriceOverrideSchema } from "models/pricing";
+import authorization from "models/authorization";
+import { ForbiddenError, NotFoundError, ValidationError } from "infra/errors";
+
+export default createRouter<NextApiRequest, NextApiResponse>()
+  .use(controller.injectAnonymousOrUser)
+  .put(controller.canRequest("update:game_price"), putHandler)
+  .delete(controller.canRequest("update:game_price"), deleteHandler)
+  .handler(controller.errorHandlers);
+
+async function putHandler(req: NextApiRequest, res: NextApiResponse) {
+  const { slug, currency } = req.query;
+
+  const result = gamePriceOverrideSchema.safeParse({
+    currency,
+    amount: req.body?.amount,
+  });
+
+  if (!result.success) {
+    throw new ValidationError({
+      message: "One or more fields are invalid",
+      action: "Check the fields and try again",
+      context: result.error.issues,
+    });
+  }
+
+  const gameToPrice = await authorizeGame(req, slug as string);
+
+  // Upsert: setting a price for a currency that already has one replaces it,
+  // so the caller does not have to know whether an override exists yet.
+  const override = await pricing.setOverride(gameToPrice.id, result.data);
+
+  const priceRow = {
+    currency: override.currency,
+    amount: override.amount.toFixed(2),
+    source: "OVERRIDE" as const,
+    exchange_rate: null,
+    is_override: true,
+  };
+
+  const secureOutputValues = authorization.filterOutput(
+    req.context.user,
+    "update:game_price",
+    priceRow,
+  );
+
+  return res.status(200).json(secureOutputValues);
+}
+
+async function deleteHandler(req: NextApiRequest, res: NextApiResponse) {
+  const { slug, currency } = req.query;
+
+  const gameToPrice = await authorizeGame(req, slug as string);
+
+  // Removing an override does not remove the price: the game falls back to
+  // conversion from its USD base price, or becomes unavailable in this
+  // currency if no rate exists.
+  await pricing.removeOverride(gameToPrice.id, currency as string);
+
+  return res.status(204).end();
+}
+
+async function authorizeGame(req: NextApiRequest, slug: string) {
+  const foundGame = await game.findOneBySlugWithStudio(slug);
+
+  if (!foundGame) {
+    throw new NotFoundError({
+      message: `The game with slug "${slug}" was not found.`,
+      action: "Check if the slug is correct or if the game is still available.",
+    });
+  }
+
+  if (!authorization.can(req.context.user, "update:game_price", foundGame)) {
+    throw new ForbiddenError({
+      message: "You do not have permission to update this game's prices",
+      action: "Verify if you are a member of the studio that owns this game",
+    });
+  }
+
+  return foundGame;
+}

--- a/pages/api/v1/items/games/[slug]/prices/index.ts
+++ b/pages/api/v1/items/games/[slug]/prices/index.ts
@@ -1,0 +1,44 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { createRouter } from "next-connect";
+import controller from "infra/controller";
+import game from "models/game";
+import pricing from "models/pricing";
+import authorization from "models/authorization";
+import { ForbiddenError, NotFoundError } from "infra/errors";
+
+export default createRouter<NextApiRequest, NextApiResponse>()
+  .use(controller.injectAnonymousOrUser)
+  .get(controller.canRequest("read:game_price"), getHandler)
+  .handler(controller.errorHandlers);
+
+async function getHandler(req: NextApiRequest, res: NextApiResponse) {
+  const { slug } = req.query;
+
+  const userTryingToRead = req.context.user;
+  const foundGame = await game.findOneBySlugWithStudio(slug as string);
+
+  if (!foundGame) {
+    throw new NotFoundError({
+      message: `The game with slug "${slug}" was not found.`,
+      action: "Check if the slug is correct or if the game is still available.",
+    });
+  }
+
+  if (!authorization.can(userTryingToRead, "read:game_price", foundGame)) {
+    throw new ForbiddenError({
+      message: "You do not have permission to read this game's prices",
+      action: "Verify if you are a member of the studio that owns this game",
+    });
+  }
+
+  const priceView = await pricing.priceViewFor(foundGame);
+
+  const secureOutputValues = priceView.map((priceRow) =>
+    authorization.filterOutput(userTryingToRead, "read:game_price", priceRow),
+  );
+
+  return res.status(200).json({
+    base_currency: pricing.BASE_CURRENCY,
+    prices: secureOutputValues,
+  });
+}

--- a/tests/integration/api/v1/items/games/[slug]/prices/[currency]/delete.test.ts
+++ b/tests/integration/api/v1/items/games/[slug]/prices/[currency]/delete.test.ts
@@ -148,6 +148,38 @@ describe("DELETE /api/v1/items/games/[slug]/prices/[currency]", () => {
     });
   });
 
+  describe("Studio member without the permission", () => {
+    test("Should return 403 Forbidden and leave the price in place", async () => {
+      const { studio, game } = await setupOwnedGame();
+      await orchestrator.setGamePriceOverride(game.id, "BRL", 49.9);
+
+      // Holds the feature globally so canRequest lets the request through,
+      // but their studio membership does not grant price control — the
+      // resource check is what has to stop them.
+      const member = await orchestrator.createUser();
+      await orchestrator.activateUser(member.id);
+      await orchestrator.addFeaturesToUser(member.id, ["update:game_price"]);
+      await orchestrator.addStudioMember(studio.id, member.username, [
+        "update:game",
+      ]);
+      const memberSession = await orchestrator.createSession(member.id);
+
+      const response = await deletePrice(memberSession.token, game.slug, "BRL");
+
+      expect(response.status).toBe(403);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        message: "You do not have permission to update this game's prices",
+        name: "ForbiddenError",
+        action: "Verify if you are a member of the studio that owns this game",
+        status_code: 403,
+      });
+
+      expect(await pricing.listOverrides(game.id)).toHaveLength(1);
+    });
+  });
+
   describe("Studio member with the permission", () => {
     test("Should return 204 No Content", async () => {
       const { studio, game } = await setupOwnedGame();

--- a/tests/integration/api/v1/items/games/[slug]/prices/[currency]/delete.test.ts
+++ b/tests/integration/api/v1/items/games/[slug]/prices/[currency]/delete.test.ts
@@ -1,0 +1,169 @@
+import orchestrator from "tests/orchestrator";
+import webserver from "infra/webserver";
+import pricing from "models/pricing";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+async function setupOwnedGame(priceInUsd = 10) {
+  await orchestrator.clearDatabaseRows();
+  await orchestrator.createCurrency({ code: "USD", symbol: "$" });
+  await orchestrator.createCurrency({ code: "BRL", symbol: "R$" });
+
+  const owner = await orchestrator.createUser();
+  await orchestrator.activateUser(owner.id);
+  const studio = await orchestrator.createStudio(owner.id);
+  const game = await orchestrator.createGame(owner.id, {
+    price: priceInUsd,
+    studio_id: studio.id,
+  });
+  const session = await orchestrator.createSession(owner.id);
+
+  return { owner, studio, game, session };
+}
+
+async function deletePrice(
+  sessionToken: string | null,
+  slug: string,
+  currencyCode: string,
+) {
+  const headers: Record<string, string> = {};
+
+  if (sessionToken) {
+    headers.Cookie = `session_id=${sessionToken}`;
+  }
+
+  return await fetch(
+    `${webserver.getOrigin()}/api/v1/items/games/${slug}/prices/${currencyCode}`,
+    { method: "DELETE", headers },
+  );
+}
+
+describe("DELETE /api/v1/items/games/[slug]/prices/[currency]", () => {
+  describe("Anonymous user", () => {
+    test("Should return 403 Forbidden", async () => {
+      const { game } = await setupOwnedGame();
+
+      const response = await deletePrice(null, game.slug, "BRL");
+
+      expect(response.status).toBe(403);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        message: "You do not have permission to perform this action",
+        name: "ForbiddenError",
+        action:
+          "Verify your user has the following features: update:game_price",
+        status_code: 403,
+      });
+    });
+  });
+
+  describe("Authenticated user without studio membership", () => {
+    test("Should return 403 Forbidden and leave the price in place", async () => {
+      const { game } = await setupOwnedGame();
+      await orchestrator.setGamePriceOverride(game.id, "BRL", 49.9);
+
+      const outsider = await orchestrator.createUser();
+      await orchestrator.activateUser(outsider.id);
+      await orchestrator.addFeaturesToUser(outsider.id, ["update:game_price"]);
+      const outsiderSession = await orchestrator.createSession(outsider.id);
+
+      const response = await deletePrice(
+        outsiderSession.token,
+        game.slug,
+        "BRL",
+      );
+
+      expect(response.status).toBe(403);
+      expect(await pricing.listOverrides(game.id)).toHaveLength(1);
+    });
+  });
+
+  describe("Studio owner", () => {
+    test("Should return 204 and fall back to conversion", async () => {
+      const { game, session } = await setupOwnedGame(10);
+      await orchestrator.createExchangeRate({ rate: 5.5 });
+      await orchestrator.setGamePriceOverride(game.id, "BRL", 49.9);
+
+      const response = await deletePrice(session.token, game.slug, "BRL");
+
+      expect(response.status).toBe(204);
+
+      const resolved = await pricing.priceFor(game, "BRL");
+      expect(resolved?.source).toBe("CONVERTED");
+      expect(resolved?.amount.toFixed(2)).toBe("55.00");
+    });
+
+    test("Removing the only price makes the game unavailable in that currency", async () => {
+      const { game, session } = await setupOwnedGame(10);
+      await orchestrator.setGamePriceOverride(game.id, "BRL", 49.9);
+
+      // No exchange rate exists, so nothing is left to fall back to.
+      const response = await deletePrice(session.token, game.slug, "BRL");
+
+      expect(response.status).toBe(204);
+      expect(await pricing.priceFor(game, "BRL")).toBeNull();
+    });
+
+    test("Should accept a lowercase currency in the path", async () => {
+      const { game, session } = await setupOwnedGame(10);
+      await orchestrator.setGamePriceOverride(game.id, "BRL", 49.9);
+
+      const response = await deletePrice(session.token, game.slug, "brl");
+
+      expect(response.status).toBe(204);
+      expect(await pricing.listOverrides(game.id)).toHaveLength(0);
+    });
+
+    test("With no override to remove should return 404", async () => {
+      const { game, session } = await setupOwnedGame(10);
+
+      const response = await deletePrice(session.token, game.slug, "BRL");
+
+      expect(response.status).toBe(404);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        message: "No BRL price override exists for this game.",
+        name: "NotFoundError",
+        action: "Check the game and currency and try again.",
+        status_code: 404,
+      });
+    });
+
+    test("With an unknown slug should return 404", async () => {
+      const { session } = await setupOwnedGame();
+
+      const response = await deletePrice(
+        session.token,
+        "does-not-exist",
+        "BRL",
+      );
+
+      expect(response.status).toBe(404);
+      expect((await response.json()).name).toBe("NotFoundError");
+    });
+  });
+
+  describe("Studio member with the permission", () => {
+    test("Should return 204 No Content", async () => {
+      const { studio, game } = await setupOwnedGame();
+      await orchestrator.setGamePriceOverride(game.id, "BRL", 49.9);
+
+      const member = await orchestrator.createUser();
+      await orchestrator.activateUser(member.id);
+      await orchestrator.addFeaturesToUser(member.id, ["update:game_price"]);
+      await orchestrator.addStudioMember(studio.id, member.username, [
+        "update:game_price",
+      ]);
+      const memberSession = await orchestrator.createSession(member.id);
+
+      const response = await deletePrice(memberSession.token, game.slug, "BRL");
+
+      expect(response.status).toBe(204);
+    });
+  });
+});

--- a/tests/integration/api/v1/items/games/[slug]/prices/[currency]/put.test.ts
+++ b/tests/integration/api/v1/items/games/[slug]/prices/[currency]/put.test.ts
@@ -217,6 +217,39 @@ describe("PUT /api/v1/items/games/[slug]/prices/[currency]", () => {
     });
   });
 
+  describe("Studio member without the permission", () => {
+    test("Should return 403 Forbidden and not write a price", async () => {
+      const { studio, game } = await setupOwnedGame();
+
+      // Holds the feature globally so canRequest lets the request through,
+      // but their studio membership does not grant price control — the
+      // resource check is what has to stop them.
+      const member = await orchestrator.createUser();
+      await orchestrator.activateUser(member.id);
+      await orchestrator.addFeaturesToUser(member.id, ["update:game_price"]);
+      await orchestrator.addStudioMember(studio.id, member.username, [
+        "update:game",
+      ]);
+      const memberSession = await orchestrator.createSession(member.id);
+
+      const response = await putPrice(memberSession.token, game.slug, "BRL", {
+        amount: 49.9,
+      });
+
+      expect(response.status).toBe(403);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        message: "You do not have permission to update this game's prices",
+        name: "ForbiddenError",
+        action: "Verify if you are a member of the studio that owns this game",
+        status_code: 403,
+      });
+
+      expect(await pricing.listOverrides(game.id)).toHaveLength(0);
+    });
+  });
+
   describe("Studio member with the permission", () => {
     test("Should return 200 OK", async () => {
       const { studio, game } = await setupOwnedGame();

--- a/tests/integration/api/v1/items/games/[slug]/prices/[currency]/put.test.ts
+++ b/tests/integration/api/v1/items/games/[slug]/prices/[currency]/put.test.ts
@@ -1,0 +1,239 @@
+import orchestrator from "tests/orchestrator";
+import webserver from "infra/webserver";
+import pricing from "models/pricing";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+async function setupOwnedGame(priceInUsd = 10) {
+  await orchestrator.clearDatabaseRows();
+  await orchestrator.createCurrency({ code: "USD", symbol: "$" });
+  await orchestrator.createCurrency({ code: "BRL", symbol: "R$" });
+
+  const owner = await orchestrator.createUser();
+  await orchestrator.activateUser(owner.id);
+  const studio = await orchestrator.createStudio(owner.id);
+  const game = await orchestrator.createGame(owner.id, {
+    price: priceInUsd,
+    studio_id: studio.id,
+  });
+  const session = await orchestrator.createSession(owner.id);
+
+  return { owner, studio, game, session };
+}
+
+async function putPrice(
+  sessionToken: string | null,
+  slug: string,
+  currencyCode: string,
+  body: unknown,
+) {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  if (sessionToken) {
+    headers.Cookie = `session_id=${sessionToken}`;
+  }
+
+  return await fetch(
+    `${webserver.getOrigin()}/api/v1/items/games/${slug}/prices/${currencyCode}`,
+    { method: "PUT", headers, body: JSON.stringify(body) },
+  );
+}
+
+describe("PUT /api/v1/items/games/[slug]/prices/[currency]", () => {
+  describe("Anonymous user", () => {
+    test("Should return 403 Forbidden", async () => {
+      const { game } = await setupOwnedGame();
+
+      const response = await putPrice(null, game.slug, "BRL", { amount: 49.9 });
+
+      expect(response.status).toBe(403);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        message: "You do not have permission to perform this action",
+        name: "ForbiddenError",
+        action:
+          "Verify your user has the following features: update:game_price",
+        status_code: 403,
+      });
+    });
+  });
+
+  describe("Authenticated user without studio membership", () => {
+    test("Should return 403 Forbidden and not write a price", async () => {
+      const { game } = await setupOwnedGame();
+
+      const outsider = await orchestrator.createUser();
+      await orchestrator.activateUser(outsider.id);
+      await orchestrator.addFeaturesToUser(outsider.id, ["update:game_price"]);
+      const outsiderSession = await orchestrator.createSession(outsider.id);
+
+      const response = await putPrice(outsiderSession.token, game.slug, "BRL", {
+        amount: 1,
+      });
+
+      expect(response.status).toBe(403);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        message: "You do not have permission to update this game's prices",
+        name: "ForbiddenError",
+        action: "Verify if you are a member of the studio that owns this game",
+        status_code: 403,
+      });
+
+      expect(await pricing.listOverrides(game.id)).toHaveLength(0);
+    });
+  });
+
+  describe("Studio owner", () => {
+    test("With a valid amount should return 200 and set the price", async () => {
+      const { game, session } = await setupOwnedGame(10);
+
+      const response = await putPrice(session.token, game.slug, "BRL", {
+        amount: 49.9,
+      });
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        currency: "BRL",
+        amount: "49.90",
+        source: "OVERRIDE",
+        exchange_rate: null,
+        is_override: true,
+      });
+
+      const resolved = await pricing.priceFor(game, "BRL");
+      expect(resolved?.source).toBe("OVERRIDE");
+      expect(resolved?.amount.toFixed(2)).toBe("49.90");
+    });
+
+    test("The override wins over an existing exchange rate", async () => {
+      const { game, session } = await setupOwnedGame(10);
+      await orchestrator.createExchangeRate({ rate: 5.5 });
+
+      await putPrice(session.token, game.slug, "BRL", { amount: 49.9 });
+
+      const resolved = await pricing.priceFor(game, "BRL");
+      expect(resolved?.amount.toFixed(2)).toBe("49.90");
+    });
+
+    test("Should replace an existing override rather than duplicating it", async () => {
+      const { game, session } = await setupOwnedGame(10);
+
+      await putPrice(session.token, game.slug, "BRL", { amount: 49.9 });
+      const response = await putPrice(session.token, game.slug, "BRL", {
+        amount: 59.9,
+      });
+
+      expect(response.status).toBe(200);
+      expect((await response.json()).amount).toBe("59.90");
+
+      const overrides = await pricing.listOverrides(game.id);
+      expect(overrides).toHaveLength(1);
+      expect(overrides[0].amount.toFixed(2)).toBe("59.90");
+    });
+
+    test("Should accept a lowercase currency in the path", async () => {
+      const { game, session } = await setupOwnedGame(10);
+
+      const response = await putPrice(session.token, game.slug, "brl", {
+        amount: 49.9,
+      });
+
+      expect(response.status).toBe(200);
+      expect((await response.json()).currency).toBe("BRL");
+    });
+
+    test("Should allow a price of zero", async () => {
+      const { game, session } = await setupOwnedGame(10);
+
+      const response = await putPrice(session.token, game.slug, "BRL", {
+        amount: 0,
+      });
+
+      expect(response.status).toBe(200);
+      expect((await response.json()).amount).toBe("0.00");
+    });
+
+    test("With an unregistered currency should return 400", async () => {
+      const { game, session } = await setupOwnedGame(10);
+
+      const response = await putPrice(session.token, game.slug, "JPY", {
+        amount: 1500,
+      });
+
+      expect(response.status).toBe(400);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        message: 'The currency "JPY" is not registered or is disabled.',
+        name: "ValidationError",
+        action: "Register and enable the currency before pricing in it.",
+        status_code: 400,
+      });
+    });
+
+    test("With a negative amount should return 400", async () => {
+      const { game, session } = await setupOwnedGame(10);
+
+      const response = await putPrice(session.token, game.slug, "BRL", {
+        amount: -1,
+      });
+
+      expect(response.status).toBe(400);
+
+      const responseBody = await response.json();
+      expect(responseBody.name).toBe("ValidationError");
+      expect(responseBody.message).toBe("One or more fields are invalid");
+      expect(responseBody.status_code).toBe(400);
+    });
+
+    test("With a missing amount should return 400", async () => {
+      const { game, session } = await setupOwnedGame(10);
+
+      const response = await putPrice(session.token, game.slug, "BRL", {});
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).name).toBe("ValidationError");
+    });
+
+    test("With an unknown slug should return 404", async () => {
+      const { session } = await setupOwnedGame();
+
+      const response = await putPrice(session.token, "does-not-exist", "BRL", {
+        amount: 10,
+      });
+
+      expect(response.status).toBe(404);
+      expect((await response.json()).name).toBe("NotFoundError");
+    });
+  });
+
+  describe("Studio member with the permission", () => {
+    test("Should return 200 OK", async () => {
+      const { studio, game } = await setupOwnedGame();
+
+      const member = await orchestrator.createUser();
+      await orchestrator.activateUser(member.id);
+      await orchestrator.addFeaturesToUser(member.id, ["update:game_price"]);
+      await orchestrator.addStudioMember(studio.id, member.username, [
+        "update:game_price",
+      ]);
+      const memberSession = await orchestrator.createSession(member.id);
+
+      const response = await putPrice(memberSession.token, game.slug, "BRL", {
+        amount: 49.9,
+      });
+
+      expect(response.status).toBe(200);
+    });
+  });
+});

--- a/tests/integration/api/v1/items/games/[slug]/prices/get.test.ts
+++ b/tests/integration/api/v1/items/games/[slug]/prices/get.test.ts
@@ -1,0 +1,201 @@
+import orchestrator from "tests/orchestrator";
+import webserver from "infra/webserver";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+async function setupOwnedGame(priceInUsd = 10) {
+  await orchestrator.clearDatabaseRows();
+  await orchestrator.createCurrency({ code: "USD", symbol: "$" });
+  await orchestrator.createCurrency({ code: "BRL", symbol: "R$" });
+
+  const owner = await orchestrator.createUser();
+  await orchestrator.activateUser(owner.id);
+  const studio = await orchestrator.createStudio(owner.id);
+  const game = await orchestrator.createGame(owner.id, {
+    price: priceInUsd,
+    studio_id: studio.id,
+  });
+  const session = await orchestrator.createSession(owner.id);
+
+  return { owner, studio, game, session };
+}
+
+function pricesUrl(slug: string) {
+  return `${webserver.getOrigin()}/api/v1/items/games/${slug}/prices`;
+}
+
+describe("GET /api/v1/items/games/[slug]/prices", () => {
+  describe("Anonymous user", () => {
+    test("Should return 403 Forbidden", async () => {
+      const { game } = await setupOwnedGame();
+
+      const response = await fetch(pricesUrl(game.slug));
+
+      expect(response.status).toBe(403);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        message: "You do not have permission to perform this action",
+        name: "ForbiddenError",
+        action: "Verify your user has the following features: read:game_price",
+        status_code: 403,
+      });
+    });
+  });
+
+  describe("Authenticated user without studio membership", () => {
+    test("Should return 403 Forbidden", async () => {
+      const { game } = await setupOwnedGame();
+
+      const outsider = await orchestrator.createUser();
+      await orchestrator.activateUser(outsider.id);
+      await orchestrator.addFeaturesToUser(outsider.id, ["read:game_price"]);
+      const outsiderSession = await orchestrator.createSession(outsider.id);
+
+      const response = await fetch(pricesUrl(game.slug), {
+        headers: { Cookie: `session_id=${outsiderSession.token}` },
+      });
+
+      expect(response.status).toBe(403);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        message: "You do not have permission to read this game's prices",
+        name: "ForbiddenError",
+        action: "Verify if you are a member of the studio that owns this game",
+        status_code: 403,
+      });
+    });
+  });
+
+  describe("Studio owner", () => {
+    test("Should return one row per enabled currency", async () => {
+      const { game, session } = await setupOwnedGame(10);
+      await orchestrator.createExchangeRate({ rate: 5.5 });
+
+      const response = await fetch(pricesUrl(game.slug), {
+        headers: { Cookie: `session_id=${session.token}` },
+      });
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+      expect(responseBody.base_currency).toBe("USD");
+
+      const byCurrency = Object.fromEntries(
+        responseBody.prices.map((row) => [row.currency, row]),
+      );
+
+      expect(byCurrency.USD).toEqual({
+        currency: "USD",
+        amount: "10.00",
+        source: "BASE",
+        exchange_rate: null,
+        is_override: false,
+      });
+      expect(byCurrency.BRL).toEqual({
+        currency: "BRL",
+        amount: "55.00",
+        source: "CONVERTED",
+        exchange_rate: "5.50000000",
+        is_override: false,
+      });
+    });
+
+    test("Should report a null amount where the game is unavailable", async () => {
+      const { game, session } = await setupOwnedGame(10);
+      // No USD→BRL rate and no override: not purchasable in BRL.
+
+      const response = await fetch(pricesUrl(game.slug), {
+        headers: { Cookie: `session_id=${session.token}` },
+      });
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+      const brl = responseBody.prices.find((row) => row.currency === "BRL");
+
+      expect(brl).toEqual({
+        currency: "BRL",
+        amount: null,
+        source: null,
+        exchange_rate: null,
+        is_override: false,
+      });
+    });
+
+    test("Should mark an overridden currency", async () => {
+      const { game, session } = await setupOwnedGame(10);
+      await orchestrator.createExchangeRate({ rate: 5.5 });
+      await orchestrator.setGamePriceOverride(game.id, "BRL", 49.9);
+
+      const response = await fetch(pricesUrl(game.slug), {
+        headers: { Cookie: `session_id=${session.token}` },
+      });
+
+      const responseBody = await response.json();
+      const brl = responseBody.prices.find((row) => row.currency === "BRL");
+
+      expect(brl).toEqual({
+        currency: "BRL",
+        amount: "49.90",
+        source: "OVERRIDE",
+        exchange_rate: null,
+        is_override: true,
+      });
+    });
+
+    test("Should omit disabled currencies", async () => {
+      const { game, session } = await setupOwnedGame(10);
+      await orchestrator.createCurrency({
+        code: "JPY",
+        symbol: "¥",
+        enabled: false,
+      });
+
+      const response = await fetch(pricesUrl(game.slug), {
+        headers: { Cookie: `session_id=${session.token}` },
+      });
+
+      const responseBody = await response.json();
+      expect(responseBody.prices.map((row) => row.currency).sort()).toEqual([
+        "BRL",
+        "USD",
+      ]);
+    });
+
+    test("With an unknown slug should return 404", async () => {
+      const { session } = await setupOwnedGame();
+
+      const response = await fetch(pricesUrl("does-not-exist"), {
+        headers: { Cookie: `session_id=${session.token}` },
+      });
+
+      expect(response.status).toBe(404);
+      expect((await response.json()).name).toBe("NotFoundError");
+    });
+  });
+
+  describe("Studio member with the permission", () => {
+    test("Should return 200 OK", async () => {
+      const { studio, game } = await setupOwnedGame();
+
+      const member = await orchestrator.createUser();
+      await orchestrator.activateUser(member.id);
+      await orchestrator.addFeaturesToUser(member.id, ["read:game_price"]);
+      await orchestrator.addStudioMember(studio.id, member.username, [
+        "read:game_price",
+      ]);
+      const memberSession = await orchestrator.createSession(member.id);
+
+      const response = await fetch(pricesUrl(game.slug), {
+        headers: { Cookie: `session_id=${memberSession.token}` },
+      });
+
+      expect(response.status).toBe(200);
+    });
+  });
+});

--- a/tests/integration/api/v1/items/games/[slug]/prices/get.test.ts
+++ b/tests/integration/api/v1/items/games/[slug]/prices/get.test.ts
@@ -179,6 +179,37 @@ describe("GET /api/v1/items/games/[slug]/prices", () => {
     });
   });
 
+  describe("Studio member without the permission", () => {
+    test("Should return 403 Forbidden", async () => {
+      const { studio, game } = await setupOwnedGame();
+
+      // Holds the feature globally so canRequest lets the request through,
+      // but their studio membership does not grant price access — the
+      // resource check is what has to stop them.
+      const member = await orchestrator.createUser();
+      await orchestrator.activateUser(member.id);
+      await orchestrator.addFeaturesToUser(member.id, ["read:game_price"]);
+      await orchestrator.addStudioMember(studio.id, member.username, [
+        "update:game",
+      ]);
+      const memberSession = await orchestrator.createSession(member.id);
+
+      const response = await fetch(pricesUrl(game.slug), {
+        headers: { Cookie: `session_id=${memberSession.token}` },
+      });
+
+      expect(response.status).toBe(403);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        message: "You do not have permission to read this game's prices",
+        name: "ForbiddenError",
+        action: "Verify if you are a member of the studio that owns this game",
+        status_code: 403,
+      });
+    });
+  });
+
   describe("Studio member with the permission", () => {
     test("Should return 200 OK", async () => {
       const { studio, game } = await setupOwnedGame();


### PR DESCRIPTION
## Description

Lets whoever manages a game set its price per currency.

| Method | Path |
| --- | --- |
| `GET` | `/api/v1/items/games/[slug]/prices` |
| `PUT` | `/api/v1/items/games/[slug]/prices/[currency]` |
| `DELETE` | `/api/v1/items/games/[slug]/prices/[currency]` |

The `GET` is the useful one: it returns a row per enabled currency with the amount, its `source` (`BASE` / `OVERRIDE` / `CONVERTED`) and the rate used — **including the currencies where the game is unavailable**, reported as a `null` amount. That is the case most worth surfacing, since it is exactly where the product disappears from the storefront for that audience.

```json
{
  "base_currency": "USD",
  "prices": [
    { "currency": "USD", "amount": "10.00", "source": "BASE", "exchange_rate": null, "is_override": false },
    { "currency": "BRL", "amount": "49.90", "source": "OVERRIDE", "exchange_rate": null, "is_override": true },
    { "currency": "EUR", "amount": null, "source": null, "exchange_rate": null, "is_override": false }
  ]
}
```

### Authorization reuses `update:game` rather than inventing a parallel scheme

`read:game_price` and `update:game_price` are added to the **existing `can()` resource branch** that already serves `update:game`, `create:game_file` and `delete:game_file` — resolving through the game's studio (owner, or member holding that permission, with `update:game:any` as the escape hatch). Both are added to `studio.MEMBER_PERMISSIONS`.

The reasoning: anyone who can already change a game's USD price through `PATCH /api/v1/items/games/[slug]` has no reason to be blocked from setting its price in another currency. Splitting them would produce the incoherent state of being able to edit one price but not the other.

**Permission propagation:** `studio.create` grants `MEMBER_PERMISSIONS` to the owner, so new studios work immediately. Existing studio owners pick the new permissions up from `npm run features:backfill` — unlike the admin-only features in #184, `reconcileStudioOwners` *does* reconcile against `MEMBER_PERMISSIONS`, so no manual step is needed.

### Removing an override is not the same as removing a price

`DELETE` clears the override and the game falls back to conversion from its USD base — or becomes unavailable in that currency if no rate exists. Both outcomes are covered by tests, since they are easy to conflate and behave very differently for a buyer.

## Related issue

Part of #177 — task 4b in `docs/payments-tasks.md`. Follows #181, #182, #183 and #184.

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📖 Documentation
- [ ] ♻️ Refactor
- [ ] 🧪 Tests

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] `npm run lint:eslint:check` passes
- [x] `npm run lint:prettier:check` passes
- [x] `npm run test` passes — **493/496, see below**
- [x] Added or updated tests where relevant

## Test results

`493 passed, 3 failed` across 95 suites (+28 new tests). Same two environmental suites as every PR in this sequence, both unrelated:

| Suite | Cause |
| --- | --- |
| `api/v1/status/get.test.ts` | Asserts the database version is `"16.0"` (the `postgres:16.0-alpine3.18` image). This run used a natively installed PostgreSQL 16.13. |
| `api/v1/items/games/steam-import/post.test.ts` (2 tests) | The public Steam API is unreachable from this environment, so the endpoint returns 503 instead of 201/404. |

One file per HTTP method, grouped by actor state (anonymous / authenticated outsider / studio owner / studio member). Covers: 403 on both unauthorised states for all three methods, the outsider being blocked *and* leaving data untouched, override upsert rather than duplication, override winning over an existing rate, null amounts for unavailable currencies, disabled currencies omitted, zero as a valid price, lowercase currency codes in the path, unregistered currency → 400, unknown slug → 404, nothing-to-delete → 404, and the two distinct post-delete outcomes.

## Roadmap update

`docs/payments-tasks.md` now records the next two tasks:

- **4c** — backoffice UI for currencies and exchange rates, so the endpoints from #184 are usable without curl. Note for that task: disabling a currency needs a confirm dialog stating plainly that it hides every product priced in it.
- **4d** — currency selection from a region header. **Nothing in the storefront reacts to any of this pricing work until 4d lands**, since `priceFor` takes the currency explicitly and nobody chooses it yet.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Whv49dfByzLEJjor8FbRbt)_