### PR TITLE
feat: add backoffice UI for currencies and exchange rates

### DIFF
--- a/components/backoffice/BackofficeTopNav.tsx
+++ b/components/backoffice/BackofficeTopNav.tsx
@@ -6,6 +6,8 @@ import {
   Users,
   Building2,
   Store as StoreIcon,
+  Coins,
+  ArrowLeftRight,
   LogOut,
   ArrowLeft,
   ShieldCheck,
@@ -17,6 +19,12 @@ const NAV_ITEMS = [
   { href: "/backoffice/users", label: "Users", icon: Users },
   { href: "/backoffice/studios", label: "Studios", icon: Building2 },
   { href: "/backoffice/stores", label: "Stores", icon: StoreIcon },
+  { href: "/backoffice/currencies", label: "Currencies", icon: Coins },
+  {
+    href: "/backoffice/exchange-rates",
+    label: "Rates",
+    icon: ArrowLeftRight,
+  },
 ];
 
 export function BackofficeTopNav({ username }: { username: string }) {
@@ -61,7 +69,10 @@ export function BackofficeTopNav({ username }: { username: string }) {
               <span className="hidden sm:inline">Manifold Admin</span>
             </Link>
 
-            <nav className="hidden md:flex items-center gap-1">
+            {/* Scrollable and shrinkable: the item list has outgrown the
+                available width on mid-size screens, and without this the
+                last link overlaps the controls on the right. */}
+            <nav className="hidden md:flex min-w-0 items-center gap-1 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
               {renderNavLinks()}
             </nav>
           </div>
@@ -69,7 +80,7 @@ export function BackofficeTopNav({ username }: { username: string }) {
           <div className="flex items-center gap-3 shrink-0">
             <Link
               href="/store"
-              className="hidden sm:flex items-center gap-2 px-3 py-2 rounded-xl text-white/50 hover:text-white hover:bg-white/5 text-xs font-bold uppercase tracking-wider transition-colors"
+              className="hidden 2xl:flex items-center gap-2 px-3 py-2 rounded-xl text-white/50 hover:text-white hover:bg-white/5 text-xs font-bold uppercase tracking-wider transition-colors"
             >
               <ArrowLeft size={14} />
               Back to Store

--- a/docs/payments-tasks.md
+++ b/docs/payments-tasks.md
@@ -11,8 +11,8 @@ Delivery plan for [#177](https://github.com/pedromello/manifoldpowered.com/issue
 | 4. Price resolution                      | ✅ done ([#183](https://github.com/pedromello/manifoldpowered.com/pull/183)) |
 | 4a. Admin currency + rate endpoints      | ✅ done ([#184](https://github.com/pedromello/manifoldpowered.com/pull/184)) |
 | 4b. Studio price override endpoints      | ✅ done                                                                      |
-| 4c. Backoffice UI for currencies + rates | next                                                                         |
-| 4d. Currency selection by region header  | after 4c                                                                     |
+| 4c. Backoffice UI for currencies + rates | ✅ done                                                                      |
+| 4d. Currency selection by region header  | next                                                                         |
 | 5–11 (ledger, payouts)                   | not started                                                                  |
 
 Each task is a separate small PR, landed in order, with `npm run test` passing on its own before merge — the same format as `docs/backoffice-tasks.md`.
@@ -289,7 +289,12 @@ Follows the existing backoffice conventions (`BackofficeLayout`, Tailwind, SWR, 
 
 Screens: a currency list with create and edit, and a rate list filtered by pair with a form to record a new rate. Disabling a currency needs a confirm dialog that says plainly it hides every product priced in that currency.
 
-**Done when:** an admin can register a currency, toggle it, and record a rate entirely from the UI.
+**Done when:** an admin can register a currency, toggle it, and record a rate entirely from the UI. ✅
+
+Two details worth keeping if these screens are extended:
+
+- The currency **code** is disabled in the edit form, with the reason shown inline. It is the reference every rate and override points at, so it can only be set at creation.
+- Rates whose `effective_at` is in the future are badged **Scheduled**, because a rate that exists but is not affecting prices yet is otherwise indistinguishable from one that is.
 
 ---
 

--- a/pages/backoffice/currencies/index.tsx
+++ b/pages/backoffice/currencies/index.tsx
@@ -1,0 +1,448 @@
+import { useState } from "react";
+import Head from "next/head";
+import useSWR, { mutate } from "swr";
+import { Ban, CheckCircle2, Loader2, Pencil, Plus } from "lucide-react";
+import { BackofficeLayout } from "components/backoffice/BackofficeLayout";
+
+interface Currency {
+  id: string;
+  code: string;
+  symbol: string;
+  decimal_places: number;
+  enabled: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+interface CurrenciesResponse {
+  currencies: Currency[];
+  pagination: { page: number; limit: number; total: number; pages: number };
+}
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+type EnabledFilter = "all" | "true" | "false";
+
+export default function BackofficeCurrenciesPage() {
+  const [enabledFilter, setEnabledFilter] = useState<EnabledFilter>("all");
+  const [page, setPage] = useState(1);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+  const [editTarget, setEditTarget] = useState<Currency | null>(null);
+  const [disableTarget, setDisableTarget] = useState<Currency | null>(null);
+
+  const queryParams = new URLSearchParams();
+  if (enabledFilter !== "all") queryParams.set("enabled", enabledFilter);
+  queryParams.set("page", String(page));
+  queryParams.set("limit", "20");
+
+  const key = `/api/v1/backoffice/currencies?${queryParams.toString()}`;
+  const { data, isLoading, error } = useSWR<CurrenciesResponse>(key, fetcher);
+
+  const currencies = data?.currencies ?? [];
+  const pagination = data?.pagination;
+
+  async function setEnabled(currency: Currency, enabled: boolean) {
+    setActionError(null);
+
+    const response = await fetch(
+      `/api/v1/backoffice/currencies/${currency.code}`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled }),
+      },
+    );
+
+    if (!response.ok) {
+      const body = await response.json().catch(() => null);
+      setActionError(body?.message || "Failed to update currency.");
+      return;
+    }
+
+    setDisableTarget(null);
+    mutate(key);
+  }
+
+  async function enableCurrency(currency: Currency) {
+    const confirmed = window.confirm(
+      `Enable ${currency.code}? Products priced in it become visible again.`,
+    );
+    if (!confirmed) return;
+
+    await setEnabled(currency, true);
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Currencies | Manifold Admin</title>
+      </Head>
+
+      <div className="flex flex-col gap-6">
+        <div className="flex items-center justify-between gap-4 flex-wrap">
+          <div>
+            <h1 className="text-3xl font-black">Currencies</h1>
+            <p className="text-sm font-bold text-white/40 mt-1">
+              USD is the base currency — every product is priced in it, and
+              other currencies are derived.
+            </p>
+          </div>
+          <button
+            onClick={() => setIsCreating(true)}
+            className="flex items-center gap-2 px-4 py-2 rounded-xl bg-indigo-500 text-black font-black text-sm uppercase tracking-wider hover:bg-indigo-400 transition-colors"
+          >
+            <Plus size={16} />
+            New Currency
+          </button>
+        </div>
+
+        {actionError && (
+          <div className="px-4 py-3 rounded-xl bg-rose-500/10 border border-rose-500/30 text-rose-300 text-sm font-bold">
+            {actionError}
+          </div>
+        )}
+
+        <div className="flex items-center gap-2">
+          {(
+            [
+              ["all", "All"],
+              ["true", "Enabled"],
+              ["false", "Disabled"],
+            ] as [EnabledFilter, string][]
+          ).map(([value, label]) => (
+            <button
+              key={value}
+              onClick={() => {
+                setEnabledFilter(value);
+                setPage(1);
+              }}
+              className={`px-3 py-1.5 rounded-lg text-xs font-black uppercase tracking-wider transition-colors ${
+                enabledFilter === value
+                  ? "bg-white/10 text-white"
+                  : "text-white/40 hover:text-white hover:bg-white/5"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+
+        <div className="rounded-2xl border border-white/10 overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-white/5 text-white/50 text-xs uppercase tracking-wider">
+              <tr>
+                <th className="px-4 py-3 text-left">Code</th>
+                <th className="px-4 py-3 text-left">Symbol</th>
+                <th className="px-4 py-3 text-left">Decimals</th>
+                <th className="px-4 py-3 text-left">Status</th>
+                <th className="px-4 py-3 text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {isLoading ? (
+                <tr>
+                  <td colSpan={5} className="px-4 py-12 text-center">
+                    <Loader2 className="animate-spin inline-block text-white/30" />
+                  </td>
+                </tr>
+              ) : error ? (
+                <tr>
+                  <td
+                    colSpan={5}
+                    className="px-4 py-12 text-center text-rose-300 font-bold"
+                  >
+                    Failed to load currencies.
+                  </td>
+                </tr>
+              ) : currencies.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={5}
+                    className="px-4 py-12 text-center text-white/40 font-bold"
+                  >
+                    No currencies found.
+                  </td>
+                </tr>
+              ) : (
+                currencies.map((currency) => (
+                  <tr key={currency.id} className="border-t border-white/5">
+                    <td className="px-4 py-3 font-black text-white">
+                      {currency.code}
+                    </td>
+                    <td className="px-4 py-3 text-white/60">
+                      {currency.symbol}
+                    </td>
+                    <td className="px-4 py-3 text-white/60">
+                      {currency.decimal_places}
+                    </td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={`px-2 py-1 rounded-md text-xs font-black uppercase tracking-wider ${
+                          currency.enabled
+                            ? "bg-emerald-500/20 text-emerald-300"
+                            : "bg-rose-500/20 text-rose-300"
+                        }`}
+                      >
+                        {currency.enabled ? "Enabled" : "Disabled"}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center justify-end gap-2">
+                        <button
+                          onClick={() => setEditTarget(currency)}
+                          className="flex items-center gap-1 px-3 py-1.5 rounded-lg bg-white/5 text-white/70 hover:bg-white/10 hover:text-white text-xs font-black uppercase tracking-wider transition-colors"
+                        >
+                          <Pencil size={14} />
+                          Edit
+                        </button>
+                        {currency.enabled ? (
+                          <button
+                            onClick={() => setDisableTarget(currency)}
+                            className="flex items-center gap-1 px-3 py-1.5 rounded-lg bg-rose-500/10 text-rose-300 hover:bg-rose-500/20 text-xs font-black uppercase tracking-wider transition-colors"
+                          >
+                            <Ban size={14} />
+                            Disable
+                          </button>
+                        ) : (
+                          <button
+                            onClick={() => enableCurrency(currency)}
+                            className="flex items-center gap-1 px-3 py-1.5 rounded-lg bg-emerald-500/10 text-emerald-300 hover:bg-emerald-500/20 text-xs font-black uppercase tracking-wider transition-colors"
+                          >
+                            <CheckCircle2 size={14} />
+                            Enable
+                          </button>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {pagination && pagination.pages > 1 && (
+          <div className="flex items-center justify-center gap-3">
+            <button
+              disabled={page <= 1}
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              className="px-3 py-1.5 rounded-lg bg-white/5 border border-white/10 text-sm font-bold text-white/70 disabled:opacity-30"
+            >
+              Previous
+            </button>
+            <span className="text-sm font-bold text-white/50">
+              Page {pagination.page} of {pagination.pages}
+            </span>
+            <button
+              disabled={page >= pagination.pages}
+              onClick={() => setPage((p) => p + 1)}
+              className="px-3 py-1.5 rounded-lg bg-white/5 border border-white/10 text-sm font-bold text-white/70 disabled:opacity-30"
+            >
+              Next
+            </button>
+          </div>
+        )}
+      </div>
+
+      {isCreating && (
+        <CurrencyFormModal
+          onClose={() => setIsCreating(false)}
+          onSaved={() => {
+            setIsCreating(false);
+            mutate(key);
+          }}
+        />
+      )}
+
+      {editTarget && (
+        <CurrencyFormModal
+          currency={editTarget}
+          onClose={() => setEditTarget(null)}
+          onSaved={() => {
+            setEditTarget(null);
+            mutate(key);
+          }}
+        />
+      )}
+
+      {disableTarget && (
+        <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 backdrop-blur-sm px-4">
+          <div className="w-full max-w-md rounded-2xl border border-white/10 bg-[#1D0F3B] p-6 shadow-2xl">
+            <h2 className="text-xl font-black mb-1">
+              Disable {disableTarget.code}?
+            </h2>
+            <p className="text-sm text-white/50 font-bold mb-4">
+              Every product priced in {disableTarget.code} disappears from the
+              storefront for anyone browsing in it — including products with a
+              fixed {disableTarget.code} price. No prices are deleted, so
+              re-enabling restores everything exactly as it was.
+            </p>
+            <div className="flex justify-end gap-3">
+              <button
+                onClick={() => setDisableTarget(null)}
+                className="px-4 py-2 rounded-xl text-white/60 hover:text-white font-bold text-sm"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => setEnabled(disableTarget, false)}
+                className="px-4 py-2 rounded-xl bg-rose-500 text-black font-black text-sm uppercase tracking-wider hover:bg-rose-400 transition-colors"
+              >
+                Disable {disableTarget.code}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+function CurrencyFormModal({
+  currency,
+  onClose,
+  onSaved,
+}: {
+  currency?: Currency;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const isEditing = Boolean(currency);
+  const [code, setCode] = useState(currency?.code ?? "");
+  const [symbol, setSymbol] = useState(currency?.symbol ?? "");
+  const [decimalPlaces, setDecimalPlaces] = useState(
+    String(currency?.decimal_places ?? 2),
+  );
+  const [formError, setFormError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  async function submit() {
+    setFormError(null);
+    setIsSaving(true);
+
+    // The code is immutable: it is the reference every exchange rate and price
+    // override points at, so editing only ever sends the display fields.
+    const response = isEditing
+      ? await fetch(`/api/v1/backoffice/currencies/${currency!.code}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            symbol,
+            decimal_places: Number(decimalPlaces),
+          }),
+        })
+      : await fetch("/api/v1/backoffice/currencies", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            code,
+            symbol,
+            decimal_places: Number(decimalPlaces),
+          }),
+        });
+
+    setIsSaving(false);
+
+    if (!response.ok) {
+      const body = await response.json().catch(() => null);
+      setFormError(body?.message || "Failed to save currency.");
+      return;
+    }
+
+    onSaved();
+  }
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 backdrop-blur-sm px-4">
+      <div className="w-full max-w-md rounded-2xl border border-white/10 bg-[#1D0F3B] p-6 shadow-2xl">
+        <h2 className="text-xl font-black mb-4">
+          {isEditing ? `Edit ${currency!.code}` : "New Currency"}
+        </h2>
+
+        {formError && (
+          <div className="mb-4 px-4 py-3 rounded-xl bg-rose-500/10 border border-rose-500/30 text-rose-300 text-sm font-bold">
+            {formError}
+          </div>
+        )}
+
+        <div className="flex flex-col gap-4">
+          <label className="flex flex-col gap-1">
+            <span className="text-xs font-black uppercase tracking-wider text-white/40">
+              ISO 4217 code
+            </span>
+            <input
+              type="text"
+              value={isEditing ? currency!.code : code}
+              onChange={(e) => setCode(e.target.value.toUpperCase())}
+              disabled={isEditing}
+              maxLength={3}
+              placeholder="BRL"
+              className="rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-bold text-white placeholder:text-white/30 outline-none focus:bg-white/10 focus:border-white/20 disabled:opacity-40"
+            />
+            {isEditing && (
+              <span className="text-xs font-bold text-white/30">
+                The code can&apos;t change — rates and price overrides point at
+                it.
+              </span>
+            )}
+          </label>
+
+          <label className="flex flex-col gap-1">
+            <span className="text-xs font-black uppercase tracking-wider text-white/40">
+              Symbol
+            </span>
+            <input
+              type="text"
+              value={symbol}
+              onChange={(e) => setSymbol(e.target.value)}
+              maxLength={8}
+              placeholder="R$"
+              className="rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-bold text-white placeholder:text-white/30 outline-none focus:bg-white/10 focus:border-white/20"
+            />
+          </label>
+
+          <label className="flex flex-col gap-1">
+            <span className="text-xs font-black uppercase tracking-wider text-white/40">
+              Decimal places
+            </span>
+            <input
+              type="number"
+              min={0}
+              max={4}
+              value={decimalPlaces}
+              onChange={(e) => setDecimalPlaces(e.target.value)}
+              className="rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-bold text-white outline-none focus:bg-white/10 focus:border-white/20"
+            />
+            <span className="text-xs font-bold text-white/30">
+              How many decimals to display. Amounts are always stored at full
+              precision regardless.
+            </span>
+          </label>
+        </div>
+
+        <div className="flex justify-end gap-3 mt-6">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 rounded-xl text-white/60 hover:text-white font-bold text-sm"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={submit}
+            disabled={isSaving}
+            className="px-4 py-2 rounded-xl bg-indigo-500 text-black font-black text-sm uppercase tracking-wider hover:bg-indigo-400 transition-colors disabled:opacity-40"
+          >
+            {isSaving ? "Saving..." : isEditing ? "Save Changes" : "Create"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+BackofficeCurrenciesPage.getLayout = function getLayout(
+  page: React.ReactElement,
+) {
+  return <BackofficeLayout>{page}</BackofficeLayout>;
+};

--- a/pages/backoffice/exchange-rates/index.tsx
+++ b/pages/backoffice/exchange-rates/index.tsx
@@ -1,0 +1,440 @@
+import { useState } from "react";
+import Head from "next/head";
+import useSWR, { mutate } from "swr";
+import { Loader2, Plus } from "lucide-react";
+import { BackofficeLayout } from "components/backoffice/BackofficeLayout";
+
+interface ExchangeRate {
+  id: string;
+  base_currency: string;
+  quote_currency: string;
+  rate: string;
+  source: "AUTOMATIC" | "BULK" | "MANUAL";
+  effective_at: string;
+  created_at: string;
+}
+
+interface ExchangeRatesResponse {
+  exchange_rates: ExchangeRate[];
+  pagination: { page: number; limit: number; total: number; pages: number };
+}
+
+interface Currency {
+  code: string;
+  enabled: boolean;
+}
+
+interface CurrenciesResponse {
+  currencies: Currency[];
+}
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+const SOURCE_LABELS: Record<ExchangeRate["source"], string> = {
+  AUTOMATIC: "Automatic",
+  BULK: "Bulk",
+  MANUAL: "Manual",
+};
+
+export default function BackofficeExchangeRatesPage() {
+  const [baseFilter, setBaseFilter] = useState("");
+  const [quoteFilter, setQuoteFilter] = useState("");
+  const [page, setPage] = useState(1);
+  const [isRecording, setIsRecording] = useState(false);
+
+  const queryParams = new URLSearchParams();
+  if (baseFilter) queryParams.set("base_currency", baseFilter);
+  if (quoteFilter) queryParams.set("quote_currency", quoteFilter);
+  queryParams.set("page", String(page));
+  queryParams.set("limit", "20");
+
+  const key = `/api/v1/backoffice/exchange-rates?${queryParams.toString()}`;
+  const { data, isLoading, error } = useSWR<ExchangeRatesResponse>(
+    key,
+    fetcher,
+  );
+
+  const { data: currencyData } = useSWR<CurrenciesResponse>(
+    "/api/v1/backoffice/currencies?limit=100",
+    fetcher,
+  );
+  const currencyCodes = (currencyData?.currencies ?? []).map(
+    (currency) => currency.code,
+  );
+
+  const rates = data?.exchange_rates ?? [];
+  const pagination = data?.pagination;
+
+  return (
+    <>
+      <Head>
+        <title>Exchange Rates | Manifold Admin</title>
+      </Head>
+
+      <div className="flex flex-col gap-6">
+        <div className="flex items-center justify-between gap-4 flex-wrap">
+          <div>
+            <h1 className="text-3xl font-black">Exchange Rates</h1>
+            <p className="text-sm font-bold text-white/40 mt-1">
+              Rates are append-only. Recording a new one never replaces the old,
+              so a past conversion stays reproducible from the rate that was in
+              effect at the time.
+            </p>
+          </div>
+          <button
+            onClick={() => setIsRecording(true)}
+            className="flex items-center gap-2 px-4 py-2 rounded-xl bg-indigo-500 text-black font-black text-sm uppercase tracking-wider hover:bg-indigo-400 transition-colors"
+          >
+            <Plus size={16} />
+            Record Rate
+          </button>
+        </div>
+
+        <div className="flex items-center gap-3 flex-wrap">
+          <CurrencySelect
+            label="Base"
+            value={baseFilter}
+            codes={currencyCodes}
+            onChange={(value) => {
+              setBaseFilter(value);
+              setPage(1);
+            }}
+          />
+          <CurrencySelect
+            label="Quote"
+            value={quoteFilter}
+            codes={currencyCodes}
+            onChange={(value) => {
+              setQuoteFilter(value);
+              setPage(1);
+            }}
+          />
+        </div>
+
+        <div className="rounded-2xl border border-white/10 overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-white/5 text-white/50 text-xs uppercase tracking-wider">
+              <tr>
+                <th className="px-4 py-3 text-left">Pair</th>
+                <th className="px-4 py-3 text-left">Rate</th>
+                <th className="px-4 py-3 text-left">Source</th>
+                <th className="px-4 py-3 text-left">Effective</th>
+                <th className="px-4 py-3 text-left">Recorded</th>
+              </tr>
+            </thead>
+            <tbody>
+              {isLoading ? (
+                <tr>
+                  <td colSpan={5} className="px-4 py-12 text-center">
+                    <Loader2 className="animate-spin inline-block text-white/30" />
+                  </td>
+                </tr>
+              ) : error ? (
+                <tr>
+                  <td
+                    colSpan={5}
+                    className="px-4 py-12 text-center text-rose-300 font-bold"
+                  >
+                    Failed to load exchange rates.
+                  </td>
+                </tr>
+              ) : rates.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={5}
+                    className="px-4 py-12 text-center text-white/40 font-bold"
+                  >
+                    No exchange rates recorded yet.
+                  </td>
+                </tr>
+              ) : (
+                rates.map((rate) => {
+                  const isFuture = new Date(rate.effective_at) > new Date();
+                  return (
+                    <tr key={rate.id} className="border-t border-white/5">
+                      <td className="px-4 py-3 font-black text-white">
+                        {rate.base_currency} → {rate.quote_currency}
+                      </td>
+                      <td className="px-4 py-3 text-white/80 font-bold tabular-nums">
+                        {rate.rate}
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className="px-2 py-1 rounded-md bg-white/5 text-white/60 text-xs font-black uppercase tracking-wider">
+                          {SOURCE_LABELS[rate.source]}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-white/60">
+                        {new Date(rate.effective_at).toLocaleString()}
+                        {isFuture && (
+                          <span
+                            className="ml-2 px-2 py-0.5 rounded-md bg-amber-500/20 text-amber-300 text-xs font-black uppercase tracking-wider"
+                            title="Not in effect yet — today's prices still use the previous rate."
+                          >
+                            Scheduled
+                          </span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-white/40">
+                        {new Date(rate.created_at).toLocaleDateString()}
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {pagination && pagination.pages > 1 && (
+          <div className="flex items-center justify-center gap-3">
+            <button
+              disabled={page <= 1}
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              className="px-3 py-1.5 rounded-lg bg-white/5 border border-white/10 text-sm font-bold text-white/70 disabled:opacity-30"
+            >
+              Previous
+            </button>
+            <span className="text-sm font-bold text-white/50">
+              Page {pagination.page} of {pagination.pages}
+            </span>
+            <button
+              disabled={page >= pagination.pages}
+              onClick={() => setPage((p) => p + 1)}
+              className="px-3 py-1.5 rounded-lg bg-white/5 border border-white/10 text-sm font-bold text-white/70 disabled:opacity-30"
+            >
+              Next
+            </button>
+          </div>
+        )}
+      </div>
+
+      {isRecording && (
+        <RecordRateModal
+          codes={currencyCodes}
+          onClose={() => setIsRecording(false)}
+          onSaved={() => {
+            setIsRecording(false);
+            mutate(key);
+          }}
+        />
+      )}
+    </>
+  );
+}
+
+function CurrencySelect({
+  label,
+  value,
+  codes,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  codes: string[];
+  onChange: (value: string) => void;
+}) {
+  return (
+    <label className="flex items-center gap-2">
+      <span className="text-xs font-black uppercase tracking-wider text-white/40">
+        {label}
+      </span>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm font-bold text-white outline-none focus:bg-white/10 focus:border-white/20"
+      >
+        <option value="">Any</option>
+        {codes.map((code) => (
+          <option key={code} value={code} className="bg-[#1D0F3B]">
+            {code}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+function RecordRateModal({
+  codes,
+  onClose,
+  onSaved,
+}: {
+  codes: string[];
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [baseCurrency, setBaseCurrency] = useState("USD");
+  const [quoteCurrency, setQuoteCurrency] = useState("");
+  const [rate, setRate] = useState("");
+  const [source, setSource] = useState<ExchangeRate["source"]>("MANUAL");
+  const [effectiveAt, setEffectiveAt] = useState("");
+  const [formError, setFormError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  async function submit() {
+    setFormError(null);
+    setIsSaving(true);
+
+    const response = await fetch("/api/v1/backoffice/exchange-rates", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        base_currency: baseCurrency,
+        quote_currency: quoteCurrency,
+        rate: Number(rate),
+        source,
+        // Left empty means "in effect now"; the API defaults it.
+        ...(effectiveAt
+          ? { effective_at: new Date(effectiveAt).toISOString() }
+          : {}),
+      }),
+    });
+
+    setIsSaving(false);
+
+    if (!response.ok) {
+      const body = await response.json().catch(() => null);
+      setFormError(body?.message || "Failed to record rate.");
+      return;
+    }
+
+    onSaved();
+  }
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 backdrop-blur-sm px-4">
+      <div className="w-full max-w-md rounded-2xl border border-white/10 bg-[#1D0F3B] p-6 shadow-2xl">
+        <h2 className="text-xl font-black mb-1">Record Exchange Rate</h2>
+        <p className="text-sm font-bold text-white/40 mb-4">
+          This adds a new rate rather than editing any existing one.
+        </p>
+
+        {formError && (
+          <div className="mb-4 px-4 py-3 rounded-xl bg-rose-500/10 border border-rose-500/30 text-rose-300 text-sm font-bold">
+            {formError}
+          </div>
+        )}
+
+        <div className="flex flex-col gap-4">
+          <div className="grid grid-cols-2 gap-3">
+            <label className="flex flex-col gap-1">
+              <span className="text-xs font-black uppercase tracking-wider text-white/40">
+                Base
+              </span>
+              <select
+                value={baseCurrency}
+                onChange={(e) => setBaseCurrency(e.target.value)}
+                className="rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm font-bold text-white outline-none focus:bg-white/10 focus:border-white/20"
+              >
+                {codes.map((code) => (
+                  <option key={code} value={code} className="bg-[#1D0F3B]">
+                    {code}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="flex flex-col gap-1">
+              <span className="text-xs font-black uppercase tracking-wider text-white/40">
+                Quote
+              </span>
+              <select
+                value={quoteCurrency}
+                onChange={(e) => setQuoteCurrency(e.target.value)}
+                className="rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm font-bold text-white outline-none focus:bg-white/10 focus:border-white/20"
+              >
+                <option value="" className="bg-[#1D0F3B]">
+                  Select...
+                </option>
+                {codes.map((code) => (
+                  <option key={code} value={code} className="bg-[#1D0F3B]">
+                    {code}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          <label className="flex flex-col gap-1">
+            <span className="text-xs font-black uppercase tracking-wider text-white/40">
+              Rate
+            </span>
+            <input
+              type="number"
+              step="0.00000001"
+              min="0"
+              value={rate}
+              onChange={(e) => setRate(e.target.value)}
+              placeholder="5.43210000"
+              className="rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-bold text-white placeholder:text-white/30 outline-none focus:bg-white/10 focus:border-white/20 tabular-nums"
+            />
+            <span className="text-xs font-bold text-white/30">
+              How many {quoteCurrency || "quote"} units one {baseCurrency} buys.
+            </span>
+          </label>
+
+          <label className="flex flex-col gap-1">
+            <span className="text-xs font-black uppercase tracking-wider text-white/40">
+              Source
+            </span>
+            <select
+              value={source}
+              onChange={(e) =>
+                setSource(e.target.value as ExchangeRate["source"])
+              }
+              className="rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm font-bold text-white outline-none focus:bg-white/10 focus:border-white/20"
+            >
+              <option value="MANUAL" className="bg-[#1D0F3B]">
+                Manual
+              </option>
+              <option value="BULK" className="bg-[#1D0F3B]">
+                Bulk
+              </option>
+              <option value="AUTOMATIC" className="bg-[#1D0F3B]">
+                Automatic
+              </option>
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-1">
+            <span className="text-xs font-black uppercase tracking-wider text-white/40">
+              Effective from
+            </span>
+            <input
+              type="datetime-local"
+              value={effectiveAt}
+              onChange={(e) => setEffectiveAt(e.target.value)}
+              className="rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-bold text-white outline-none focus:bg-white/10 focus:border-white/20"
+            />
+            <span className="text-xs font-bold text-white/30">
+              Leave empty to take effect now. A future date is stored but
+              won&apos;t affect prices until it arrives.
+            </span>
+          </label>
+        </div>
+
+        <div className="flex justify-end gap-3 mt-6">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 rounded-xl text-white/60 hover:text-white font-bold text-sm"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={submit}
+            disabled={isSaving || !quoteCurrency || !rate}
+            className="px-4 py-2 rounded-xl bg-indigo-500 text-black font-black text-sm uppercase tracking-wider hover:bg-indigo-400 transition-colors disabled:opacity-40"
+          >
+            {isSaving ? "Recording..." : "Record Rate"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+BackofficeExchangeRatesPage.getLayout = function getLayout(
+  page: React.ReactElement,
+) {
+  return <BackofficeLayout>{page}</BackofficeLayout>;
+};


### PR DESCRIPTION
## Description

Screens for the endpoints added in #184, so currencies and rates are managed from the backoffice rather than with curl.

- `/backoffice/currencies` — list with enabled/disabled filter, create and edit modals, enable/disable
- `/backoffice/exchange-rates` — list filtered by currency pair, modal to record a new rate

Follows the existing backoffice conventions: `BackofficeLayout` + `getLayout`, SWR with `mutate` after writes, `lucide-react` icons, the same table/loading/empty/pagination structure as the users and games screens.

### Three decisions worth a look

**The currency code is disabled when editing**, with the reason shown inline. It is the reference every exchange rate and price override points at, so it can only be set at creation — the API enforces this, and the form now makes it visible rather than letting someone type into a field that will be ignored.

**Disabling a currency gets a full confirm dialog**, not a `window.confirm`. The copy states plainly that every product priced in that currency disappears from the storefront — *including* products with a fixed price in it — and that no prices are deleted, so re-enabling restores everything. Enabling uses the lighter `window.confirm`, since it only ever makes more visible.

**Rates effective in the future are badged "Scheduled".** A rate that exists but is not yet affecting prices is otherwise indistinguishable in the table from the live one, which is a good way to think a rate change took effect when it hasn't. The page header also states the append-only behaviour, so recording a rate doesn't read as editing one.

### Nav overflow fix

Growing `NAV_ITEMS` from five to seven pushed the last link into the right-hand controls — "Rates" rendered on top of "Back to Store". Caught while screenshotting, not by typecheck.

The desktop nav is now shrinkable and horizontally scrollable, matching the treatment the mobile strip already had, and "Back to Store" moves from `sm` to `2xl` so the full item list fits at common widths.

## Verification

Since this is UI, I rendered both pages in a headless browser against seeded data (an admin session, USD/BRL enabled, JPY disabled, three USD→BRL rates including one future-dated) rather than relying on typecheck alone. Confirmed: both pages load with real rows, the disabled currency shows its status and offers Enable, the future rate carries the Scheduled badge, and the disable dialog renders with the right copy. The nav fix was verified the same way.

No console errors from application code — the only ones are a favicon 404 and blocked external requests from this sandbox's egress proxy.

## Related issue

Part of #177 — task 4c in `docs/payments-tasks.md`. Follows #181, #182, #183, #184 and #185.

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📖 Documentation
- [ ] ♻️ Refactor
- [ ] 🧪 Tests

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] `npm run lint:eslint:check` passes
- [x] `npm run lint:prettier:check` passes
- [x] `npm run test` passes — **496/499, see below**
- [x] Added or updated tests where relevant

## Test results

`496 passed, 3 failed` across 95 suites — unchanged from #185, since this PR adds no tests. The 3 failures are the same two environmental suites as every PR in this sequence:

| Suite | Cause |
| --- | --- |
| `api/v1/status/get.test.ts` | Asserts the database version is `"16.0"` (the `postgres:16.0-alpine3.18` image). This run used a natively installed PostgreSQL 16.13. |
| `api/v1/items/games/steam-import/post.test.ts` (2 tests) | The public Steam API is unreachable from this environment. |

**No automated tests were added.** The repo has no frontend test setup — every existing backoffice screen (`pages/backoffice/users`, `games`, `studios`, `stores`) ships without component tests, and introducing a testing-library stack is a bigger decision than this PR should make on its own. The behaviour these screens depend on is covered by the API tests in #184. Worth raising separately if you want frontend coverage.

## Next

**4d — currency selection by region header.** Worth stating plainly: after six PRs, the storefront still shows the same USD price to everyone. All the pricing machinery exists and is now manageable, but `priceFor` takes a currency explicitly and nothing chooses it yet. 4d is what makes any of this visible to a buyer.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Whv49dfByzLEJjor8FbRbt)_