### PR TITLE
feat: price the storefront in the visitor's currency

### DIFF
--- a/components/store/GameListItem.tsx
+++ b/components/store/GameListItem.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { DiscountBadge } from "components/store/DiscountBadge";
 import { discountBadgeColor } from "components/store/constants";
+import { DisplayPrice, formatBasePrice, formatPrice, isFree } from "lib/price";
 
 export type GameApi = {
   id: string;
@@ -11,6 +12,7 @@ export type GameApi = {
   launch_date: string;
   price: string;
   base_price?: string;
+  display_price?: DisplayPrice | null;
   discount_label?: string;
   developer_name: string;
   publisher_name?: string;
@@ -34,9 +36,8 @@ export function GameListItem({
   game: GameApi;
   storeSlug?: string;
 }) {
-  const isDemo = !game.price || Number(game.price) === 0;
-  const isDiscounted =
-    !isDemo && game.base_price && game.base_price !== game.price;
+  const isDemo = isFree(game);
+  const isDiscounted = !isDemo && formatBasePrice(game) !== null;
   const defaultGradient =
     "linear-gradient(135deg, var(--color-purple-dark) 0%, rgba(53,34,89,0.7) 100%)";
   const itemHref = storeSlug
@@ -75,17 +76,15 @@ export function GameListItem({
           <div className="flex items-end gap-1 w-fit">
             <div className="flex w-full h-full">
               <div className="flex items-center">
-                {!isDemo &&
-                  game.base_price !== game.price &&
-                  game.discount_label && (
-                    <DiscountBadge label={game.discount_label} size="small" />
-                  )}
+                {isDiscounted && game.discount_label && (
+                  <DiscountBadge label={game.discount_label} size="small" />
+                )}
               </div>
             </div>
             <div className="flex flex-col h-full justify-center pr-2">
-              {!isDemo && game.base_price && game.base_price !== game.price && (
+              {isDiscounted && (
                 <span className="text-sm md:text-xl font-bold text-white/30 line-through">
-                  ${game.base_price}
+                  {formatBasePrice(game)}
                 </span>
               )}
               <div
@@ -99,7 +98,7 @@ export function GameListItem({
                     : {}
                 }
               >
-                {isDemo ? "Free" : `$${game.price}`}
+                {isDemo ? "Free" : formatPrice(game)}
               </div>
             </div>
           </div>

--- a/components/store/StoreTopNav.tsx
+++ b/components/store/StoreTopNav.tsx
@@ -7,6 +7,7 @@ import { Store, Library, Search } from "lucide-react";
 import { DiscountBadge } from "./DiscountBadge";
 import { UserMenu } from "./UserMenu";
 import { type GameApi } from "components/store/GameListItem";
+import { formatPrice } from "lib/price";
 
 export type StoreNavContext = {
   slug: string;
@@ -160,7 +161,7 @@ export function StoreTopNav({ store }: { store?: StoreNavContext }) {
                                       : "rgba(255, 255, 255, 0.4)",
                                 }}
                               >
-                                {isDemo ? "Free" : `$${game.price}`}
+                                {isDemo ? "Free" : formatPrice(game)}
                               </p>
                               {!isDemo && game.base_price && (
                                 <p className="text-xs font-semibold line-through text-white/40">

--- a/components/store/Storefront.tsx
+++ b/components/store/Storefront.tsx
@@ -13,6 +13,7 @@ import { SectionDivider } from "components/store/SectionDivider";
 import { discountBadgeColor } from "components/store/constants";
 import { GameListItem, type GameApi } from "components/store/GameListItem";
 import { DiscoverOutlets } from "components/store/DiscoverOutlets";
+import { PricedItem, formatBasePrice, formatPrice, isFree } from "lib/price";
 
 function HeroBento({
   featured,
@@ -24,7 +25,8 @@ function HeroBento({
   if (!featured || featured.length < 3) return null;
   const [main, side1, side2] = featured;
 
-  const isDemo = (price: string) => !price || Number(price) === 0;
+  // Kept as a local alias so the many call sites below read the same as before.
+  const isDemo = (item: PricedItem) => isFree(item);
   const defaultGradient =
     "linear-gradient(135deg, var(--color-purple-dark) 0%, rgba(53,34,89,0.7) 100%)";
   const itemHref = (slug: string) =>
@@ -51,8 +53,8 @@ function HeroBento({
 
         <div className="absolute inset-0 bg-gradient-to-t from-[#1D0F3B]/90 via-[#1D0F3B]/20 to-transparent opacity-90 transition-opacity group-hover:opacity-100" />
 
-        {!isDemo(main.price) &&
-          main.base_price !== main.price &&
+        {!isDemo(main) &&
+          formatBasePrice(main) !== null &&
           main.discount_label && (
             <div className="absolute top-5 right-5 z-10 md:top-8 md:right-8 md:scale-120 origin-top-right">
               <DiscountBadge label={main.discount_label} />
@@ -69,11 +71,11 @@ function HeroBento({
           <div className="flex items-center gap-4 mt-2">
             <div className="flex items-center gap-3">
               <span
-                className={`text-xl md:text-3xl font-black bg-black/60 backdrop-blur-md px-3 py-1 md:px-4 md:py-1.5 rounded-xl shadow-2xl border uppercase ${!isDemo(main.price) && main.base_price && main.base_price !== main.price ? "" : "text-white border-white/20"}`}
+                className={`text-xl md:text-3xl font-black bg-black/60 backdrop-blur-md px-3 py-1 md:px-4 md:py-1.5 rounded-xl shadow-2xl border uppercase ${!isDemo(main) && formatBasePrice(main) !== null ? "" : "text-white border-white/20"}`}
                 style={
-                  !isDemo(main.price) &&
+                  !isDemo(main) &&
                   main.base_price &&
-                  main.base_price !== main.price
+                  formatBasePrice(main) !== null
                     ? {
                         color: discountBadgeColor,
                         borderColor: discountBadgeColor,
@@ -81,13 +83,13 @@ function HeroBento({
                     : {}
                 }
               >
-                {isDemo(main.price) ? "Free Demo" : `$${main.price}`}
+                {isDemo(main) ? "Free Demo" : formatPrice(main)}
               </span>
-              {!isDemo(main.price) &&
+              {!isDemo(main) &&
                 main.base_price &&
-                main.base_price !== main.price && (
+                formatBasePrice(main) !== null && (
                   <span className="text-sm md:text-lg text-white/40 line-through font-bold">
-                    ${main.base_price}
+                    {formatBasePrice(main)}
                   </span>
                 )}
             </div>
@@ -124,8 +126,8 @@ function HeroBento({
 
           <div className="absolute inset-0 bg-gradient-to-t from-[#1D0F3B]/80 via-[#1D0F3B]/20 to-transparent opacity-80" />
 
-          {!isDemo(game.price) &&
-            game.base_price !== game.price &&
+          {!isDemo(game) &&
+            formatBasePrice(game) !== null &&
             game.discount_label && (
               <div className="absolute top-5 right-5 z-10">
                 <DiscountBadge label={game.discount_label} />
@@ -138,11 +140,11 @@ function HeroBento({
             </h3>
             <div className="flex items-center gap-3">
               <span
-                className={`text-xl md:text-2xl font-bold bg-black/60 backdrop-blur-md px-3 py-1 rounded-lg border shadow-lg uppercase ${!isDemo(game.price) && game.base_price && game.base_price !== game.price ? "" : "text-white border-white/20"}`}
+                className={`text-xl md:text-2xl font-bold bg-black/60 backdrop-blur-md px-3 py-1 rounded-lg border shadow-lg uppercase ${!isDemo(game) && formatBasePrice(game) !== null ? "" : "text-white border-white/20"}`}
                 style={
-                  !isDemo(game.price) &&
+                  !isDemo(game) &&
                   game.base_price &&
-                  game.base_price !== game.price
+                  formatBasePrice(game) !== null
                     ? {
                         color: discountBadgeColor,
                         borderColor: discountBadgeColor,
@@ -150,11 +152,11 @@ function HeroBento({
                     : {}
                 }
               >
-                {isDemo(game.price) ? "Free Demo" : `$${game.price}`}
+                {isDemo(game) ? "Free Demo" : formatPrice(game)}
               </span>
-              {!isDemo(game.price) &&
+              {!isDemo(game) &&
                 game.base_price &&
-                game.base_price !== game.price && (
+                formatBasePrice(game) !== null && (
                   <span className="text-sm md:text-base text-white/40 line-through font-bold">
                     ${game.base_price}
                   </span>

--- a/docs/payments-architecture.md
+++ b/docs/payments-architecture.md
@@ -1,0 +1,214 @@
+# Payments — Storefront Pricing Architecture
+
+How a game gets a price in the visitor's currency, and why the pieces are split the way they are.
+
+Delivery plan and task status live in [`payments-tasks.md`](./payments-tasks.md). This document covers the runtime design of the pricing path only.
+
+---
+
+## The modules
+
+| Module                         | Responsibility                                   |
+| ------------------------------ | ------------------------------------------------ |
+| `models/region.ts`             | Which currency should this visitor see?          |
+| `models/pricing.ts`            | What does this game cost in that currency?       |
+| `models/storefront_pricing.ts` | Everything a storefront read needs, in one place |
+| `lib/price.ts`                 | How the frontend formats what came back          |
+
+## Why `storefront_pricing` exists
+
+Seven endpoints emit `read:public_game` output:
+
+| Endpoint                                 | Surface                  |
+| ---------------------------------------- | ------------------------ |
+| `GET /api/v1/games`                      | global catalogue         |
+| `GET /api/v1/items/games/[slug]`         | product detail           |
+| `GET /api/v1/stores/[slug]/featured`     | store storefront         |
+| `GET /api/v1/stores/[slug]/trending`     | store storefront         |
+| `GET /api/v1/stores/[slug]/new-releases` | store storefront         |
+| `GET /api/v1/stores/[slug]/search`       | store storefront         |
+| `GET /api/v1/library`                    | nested, owned items only |
+
+Localising each separately means the same five steps copied seven times, and the failure mode that creates is specific: **a storefront where the same game costs a different amount depending on which carousel you found it in.** A shop that never localises is more trustworthy than one that localises inconsistently.
+
+`GET /api/v1/library` is deliberately excluded. It lists games the user already owns, where a current price is not just irrelevant but misleading.
+
+## Request flow
+
+```mermaid
+sequenceDiagram
+    participant V as Visitor
+    participant E as Storefront endpoint
+    participant R as models/region
+    participant SP as models/storefront_pricing
+    participant P as models/pricing
+    participant DB as Postgres
+
+    V->>E: GET /api/v1/games<br/>x-vercel-ip-country: BR
+
+    rect rgb(238, 242, 255)
+        Note over E,DB: Phase 1 — before the query
+        E->>SP: idConstraintForRequest(req)
+        SP->>R: currencyForRequest(req)
+        R->>R: BR → BRL (static map)
+        R->>DB: is BRL registered and enabled?
+        DB-->>R: yes
+        R-->>SP: "BRL"
+        SP->>P: priceableGameIdConstraint("BRL")
+        P->>DB: newest USD→BRL rate in effect?
+        alt rate exists
+            DB-->>P: 5.50
+            P-->>SP: null (everything is priceable)
+        else no rate
+            DB-->>P: none
+            P->>DB: game_ids with a BRL override
+            P-->>SP: [id, id, ...] (only these)
+        end
+        SP-->>E: { currency, gameIds }
+    end
+
+    E->>DB: findAllPaginated({ ..., priceableGameIds })
+    DB-->>E: games + honest pagination
+
+    rect rgb(240, 253, 244)
+        Note over E,DB: Phase 2 — after the query
+        E->>SP: contextFor(currency, games)
+        SP->>P: displayPricesFor(games, "BRL")
+        P->>DB: currency row
+        P->>DB: newest rate
+        P->>DB: overrides for these game ids
+        Note right of P: 3 queries total,<br/>not 2 per game
+        P-->>SP: Map<gameId, DisplayPrice>
+        SP-->>E: context
+        E->>SP: filterAndPrice(user, games, context)
+        Note right of SP: authorization.filterOutput<br/>+ display_price attached
+    end
+
+    E-->>V: { games: [...], pagination, currency }
+```
+
+## Why two phases
+
+The constraint must go **inside** the query; pricing can only happen **after** it. Collapsing them breaks one or the other.
+
+```mermaid
+flowchart TB
+    subgraph bad["Filter after the query — rejected"]
+        direction TB
+        B1["Query page 1, limit 20"] --> B2["DB returns 20 games"]
+        B2 --> B3["Drop the 5 with no BRL price"]
+        B3 --> B4["Render 15 games<br/>pagination says 'of 20'"]
+        B4 --> B5(["Page sizes wobble, totals lie,<br/>later pages skip items entirely"])
+    end
+
+    subgraph good["Constrain inside the query — shipped"]
+        direction TB
+        G1["priceableGameIdConstraint(BRL)"] --> G2{"Rate for<br/>USD→BRL?"}
+        G2 -->|yes| G3["null — no constraint,<br/>whole catalogue priceable"]
+        G2 -->|no| G4["ids with a BRL override"]
+        G3 --> G5["findAllPaginated"]
+        G4 --> G5
+        G5 --> G6(["20 rows means 20 rows.<br/>Counts match reality"])
+    end
+```
+
+The common case costs nothing: every game has a USD base price, so **one exchange rate makes the whole catalogue priceable** and the constraint is `null`. The expensive branch only runs when a currency is enabled but has no rate — where, by definition, few games have overrides.
+
+## Resolving a single price
+
+```mermaid
+flowchart TD
+    S["displayPricesFor(games, currency)"] --> C{"Currency registered<br/>and enabled?"}
+    C -->|no, and it is USD| BASE["Use built-in defaults<br/>symbol $, 2 decimals"]
+    C -->|no, other currency| EMPTY(["Empty map —<br/>every game hidden"])
+    C -->|yes| OK["Use the registered row"]
+
+    BASE --> LOOP
+    OK --> LOOP["For each game"]
+
+    LOOP --> O{"Override for<br/>this currency?"}
+    O -->|yes| OV["amount = override<br/>base_amount = null"]
+    O -->|no| B{"Is this the<br/>base currency?"}
+    B -->|yes| BB["amount = game.price<br/>base_amount = game.base_price"]
+    B -->|no| RT{"Rate available?"}
+    RT -->|yes| CV["amount = price × rate<br/>base_amount = base_price × rate<br/>rounded half-up"]
+    RT -->|no| SKIP(["Absent from the map —<br/>caller must hide it"])
+
+    OV --> EQ
+    BB --> EQ
+    CV --> EQ["base_amount === amount?<br/>→ null, no discount to show"]
+```
+
+Two branches deserve special care when changing this:
+
+**`base_amount` is null on an override.** An override states an absolute local price with no localised "was" price, so showing the converted USD original beside it would invent a discount that was never offered. Under conversion both sides convert by the same rate, so a genuine discount survives — 40% off in USD is still 40% off in BRL.
+
+**The base currency works unregistered.** With zero currency rows the platform still sells in USD, and localisation is strictly additive on top of a working default. An earlier draft returned an empty map here, which would have emptied the entire storefront the moment it shipped unconfigured.
+
+## The shape of a storefront endpoint
+
+```ts
+const { currency, gameIds } =
+  await storefrontPricing.idConstraintForRequest(req);
+
+const { games, pagination } = await game.findAllPaginated({
+  priceableGameIds: gameIds,
+  ...result.data,
+  order: "featured",
+  curationWhere,
+});
+
+const context = await storefrontPricing.contextFor(currency, games);
+
+return res.status(200).json({
+  games: storefrontPricing.filterAndPrice(req.context.user, games, context),
+  pagination,
+  currency,
+});
+```
+
+`filterAndPrice` calls `authorization.filterOutput` internally — the security boundary is unchanged, just no longer duplicated at each call site.
+
+The detail endpoint differs, because it has no query to constrain:
+
+```mermaid
+flowchart LR
+    D["GET /items/games/[slug]"] --> F["findOnePublicBySlug"]
+    F --> P["contextFor + filterAndPrice"]
+    P --> Q{"Priced in the<br/>visitor's currency?"}
+    Q -->|yes| OK200["200 + display_price"]
+    Q -->|no| NF["404"]
+```
+
+The 404 is deliberate: a game with no local price is absent from every listing, so its detail page has to agree, or a shared link opens a product that cannot be bought and has no price to show.
+
+`filterAndPrice` drops unpriced games regardless of caller, so no path can leak a wrongly-priced game even if a future endpoint forgets to apply the constraint.
+
+## Response shape
+
+Additive. `price` stays the untouched USD base, so a client that has not been updated keeps working.
+
+```json
+{
+  "price": "12.00",
+  "base_price": "20.00",
+  "display_price": {
+    "amount": "66.00",
+    "base_amount": "110.00",
+    "currency": "BRL",
+    "symbol": "R$"
+  }
+}
+```
+
+`lib/price.ts` formats it, falling back to `price` with a `$` for any surface not yet passing through this path.
+
+## Adding a currency to a new market
+
+1. Register the currency in the backoffice (`/backoffice/currencies`).
+2. Record a USD→XXX rate (`/backoffice/exchange-rates`). At this point the whole catalogue is purchasable there.
+3. Optionally set per-game overrides for commercially-shaped prices, via `PUT /api/v1/items/games/[slug]/prices/[currency]`.
+
+If the country is not in `COUNTRY_CURRENCY` in `models/region.ts`, add it — that map is the only thing connecting a region to a currency.
+
+Between steps 1 and 2 the currency is enabled but has no rate, so **only games with an explicit override are visible** to visitors in that region. That is intentional, not a bug: it lets a market be opened progressively rather than all at once.

--- a/docs/payments-tasks.md
+++ b/docs/payments-tasks.md
@@ -11,8 +11,8 @@ Delivery plan for [#177](https://github.com/pedromello/manifoldpowered.com/issue
 | 4. Price resolution                      | ✅ done ([#183](https://github.com/pedromello/manifoldpowered.com/pull/183)) |
 | 4a. Admin currency + rate endpoints      | ✅ done ([#184](https://github.com/pedromello/manifoldpowered.com/pull/184)) |
 | 4b. Studio price override endpoints      | ✅ done                                                                      |
-| 4c. Backoffice UI for currencies + rates | ✅ done                                                                      |
-| 4d. Currency selection by region header  | next                                                                         |
+| 4c. Backoffice UI for currencies + rates | ✅ done ([#186](https://github.com/pedromello/manifoldpowered.com/pull/186)) |
+| 4d. Currency selection by region header  | ✅ done                                                                      |
 | 5–11 (ledger, payouts)                   | not started                                                                  |
 
 Each task is a separate small PR, landed in order, with `npm run test` passing on its own before merge — the same format as `docs/backoffice-tasks.md`.
@@ -300,11 +300,20 @@ Two details worth keeping if these screens are extended:
 
 ### 4d. Currency selection by region
 
-**TLDR:** Decide which currency a visitor sees, from a geolocation header.
+**TLDR:** Decide which currency a visitor sees, from a geolocation header. This is what finally makes the pricing work visible to a buyer.
 
-Nothing in the storefront reacts to any of the pricing work until this lands — `priceFor` takes the currency explicitly and nobody chooses it. Detection reads the hosting platform's region header, falling back to the base currency when the region is unknown or its currency is not enabled.
+`models/region.ts` reads Vercel's `x-vercel-ip-country` and maps it to a currency, falling back to the base currency whenever the region is unknown, unmapped, ungeolocatable (`XX`), or maps to a currency that is not enabled. The country→currency map is static in code rather than a table: it is a property of the world, not of the catalogue, so a database copy could only ever be edited to be wrong.
 
-Storefront and detail reads then have to use `resolvableGameIds`/`priceFor`, so a product with no resolvable price disappears rather than showing a price in the wrong currency.
+`models/storefront_pricing.ts` centralises what every storefront read needs, because seven endpoints require identical behaviour and a storefront that prices differently depending on which list a game came from is worse than one that never localises.
+
+Responses gain `display_price` (`amount`, `base_amount`, `currency`, `symbol`) alongside the untouched USD `price`, so the change is additive.
+
+**Two things worth remembering:**
+
+- **Filtering happens in the query, not after it.** `findAllPaginated` takes `priceableGameIds`; post-filtering a page of 20 could render 15 while pagination still claimed 20.
+- **The base currency works unregistered.** With no currency rows at all the platform still sells in USD, and localisation is purely additive. Treating an unregistered base currency as unpriceable would have emptied the entire storefront the moment this shipped unconfigured.
+
+**Done when:** a visitor in a mapped region with a rate sees local prices, and products with no price in their currency are absent from listings and 404 on detail. ✅
 
 ---
 

--- a/docs/payments-tasks.md
+++ b/docs/payments-tasks.md
@@ -2,18 +2,20 @@
 
 Delivery plan for [#177](https://github.com/pedromello/manifoldpowered.com/issues/177) (Milestone 3: Payment Structure — Sales and Payouts).
 
+For the runtime design of the pricing path — how a game gets a price in the visitor's currency, and why the modules are split the way they are — see [`payments-architecture.md`](./payments-architecture.md).
+
 **Status: in progress.** The design is also under public discussion, so tasks not yet started may still change.
 
-| Task                                     | State                                                                        |
-| ---------------------------------------- | ---------------------------------------------------------------------------- |
-| 2. Money → `Decimal(19,4)`               | ✅ done ([#181](https://github.com/pedromello/manifoldpowered.com/pull/181)) |
-| 3. Currency + exchange rate model        | ✅ done ([#182](https://github.com/pedromello/manifoldpowered.com/pull/182)) |
-| 4. Price resolution                      | ✅ done ([#183](https://github.com/pedromello/manifoldpowered.com/pull/183)) |
-| 4a. Admin currency + rate endpoints      | ✅ done ([#184](https://github.com/pedromello/manifoldpowered.com/pull/184)) |
-| 4b. Studio price override endpoints      | ✅ done                                                                      |
-| 4c. Backoffice UI for currencies + rates | ✅ done ([#186](https://github.com/pedromello/manifoldpowered.com/pull/186)) |
-| 4d. Currency selection by region header  | ✅ done                                                                      |
-| 5–11 (ledger, payouts)                   | not started                                                                  |
+| Task                                     | State                                                                          |
+| ---------------------------------------- | ------------------------------------------------------------------------------ |
+| 2. Money → `Decimal(19,4)`               | ✅ done ([#181](https://github.com/pedromello/manifoldpowered.com/pull/181))   |
+| 3. Currency + exchange rate model        | ✅ done ([#182](https://github.com/pedromello/manifoldpowered.com/pull/182))   |
+| 4. Price resolution                      | ✅ done ([#183](https://github.com/pedromello/manifoldpowered.com/pull/183))   |
+| 4a. Admin currency + rate endpoints      | ✅ done ([#184](https://github.com/pedromello/manifoldpowered.com/pull/184))   |
+| 4b. Studio price override endpoints      | ✅ done                                                                        |
+| 4c. Backoffice UI for currencies + rates | ✅ done ([#186](https://github.com/pedromello/manifoldpowered.com/pull/186))   |
+| 4d. Currency selection by region header  | ✅ done ([#188](https://github.com/pedromello/manifoldpowered.com/issues/188)) |
+| 5–11 (ledger, payouts)                   | not started                                                                    |
 
 Each task is a separate small PR, landed in order, with `npm run test` passing on its own before merge — the same format as `docs/backoffice-tasks.md`.
 

--- a/lib/price.ts
+++ b/lib/price.ts
@@ -1,0 +1,57 @@
+// Formatting for prices coming out of the storefront API.
+//
+// `display_price` is what the visitor should see, already resolved to their
+// currency by the server. `price`/`base_price` remain the USD base, so these
+// helpers fall back to them for any surface not yet passing through the
+// regional pricing path.
+
+export interface DisplayPrice {
+  amount: string;
+  base_amount: string | null;
+  currency: string;
+  symbol: string;
+}
+
+export interface PricedItem {
+  price: string;
+  base_price?: string | null;
+  display_price?: DisplayPrice | null;
+}
+
+const BASE_SYMBOL = "$";
+
+export function isFree(item: PricedItem): boolean {
+  const amount = item.display_price?.amount ?? item.price;
+  return !amount || Number(amount) === 0;
+}
+
+export function formatPrice(item: PricedItem): string {
+  if (item.display_price) {
+    return `${item.display_price.symbol}${item.display_price.amount}`;
+  }
+
+  return `${BASE_SYMBOL}${item.price}`;
+}
+
+// The struck-through "was" price, or null when there is no discount to show.
+export function formatBasePrice(item: PricedItem): string | null {
+  if (item.display_price) {
+    const { base_amount, amount, symbol } = item.display_price;
+
+    if (!base_amount || base_amount === amount) {
+      return null;
+    }
+
+    return `${symbol}${base_amount}`;
+  }
+
+  if (!item.base_price || item.base_price === item.price) {
+    return null;
+  }
+
+  return `${BASE_SYMBOL}${item.base_price}`;
+}
+
+export function hasDiscount(item: PricedItem): boolean {
+  return !isFree(item) && formatBasePrice(item) !== null;
+}

--- a/models/game.ts
+++ b/models/game.ts
@@ -576,6 +576,7 @@ async function findAllPaginated({
   min_price,
   max_price,
   curationWhere,
+  priceableGameIds,
 }: {
   page?: number;
   limit?: number;
@@ -585,6 +586,11 @@ async function findAllPaginated({
   min_price?: number;
   max_price?: number;
   curationWhere?: Prisma.GameWhereInput;
+  // Restricts results to games that can be priced in the visitor's currency.
+  // Applied in the query rather than filtered afterwards, so pagination counts
+  // stay honest — post-filtering a page of 20 could render 15. Null or
+  // undefined means every game is priceable, which is the common case.
+  priceableGameIds?: string[] | null;
 }) {
   const where: Prisma.GameWhereInput = {
     status: "ACTIVE",
@@ -610,8 +616,18 @@ async function findAllPaginated({
     };
   }
 
+  const andClauses: Prisma.GameWhereInput[] = [];
+
   if (curationWhere && Object.keys(curationWhere).length > 0) {
-    where.AND = [curationWhere];
+    andClauses.push(curationWhere);
+  }
+
+  if (priceableGameIds) {
+    andClauses.push({ id: { in: priceableGameIds } });
+  }
+
+  if (andClauses.length > 0) {
+    where.AND = andClauses;
   }
 
   const orderByMap = {

--- a/models/pricing.ts
+++ b/models/pricing.ts
@@ -9,6 +9,10 @@ import exchangeRate from "models/exchange_rate";
 // currency are derived from it.
 export const BASE_CURRENCY = "USD";
 
+// Used when the base currency has not been registered yet, so the storefront
+// works before any currency is configured. A registered USD row always wins.
+const BASE_CURRENCY_DEFAULTS = { symbol: "$", decimal_places: 2 };
+
 export const gamePriceOverrideSchema = z.object({
   currency: currencyCodeSchema,
   amount: z.coerce.number().min(0).max(1_000_000),
@@ -191,6 +195,169 @@ async function priceForOrFail(
   return resolved;
 }
 
+export interface DisplayPrice {
+  amount: string;
+  // The "was" price, for a struck-through discount. Null when there is nothing
+  // meaningful to compare against: an override states an absolute price with no
+  // localised original, so showing the USD original beside it would misprice
+  // the discount. Conversion preserves the ratio, so both sides convert.
+  base_amount: string | null;
+  currency: string;
+  symbol: string;
+}
+
+// Prices a batch of games in one currency with a fixed number of queries: one
+// for the currency, one for the rate, one for the overrides. Resolving each
+// game individually would issue two queries per game, which on a 20-item
+// storefront page is 40 round trips for information that does not vary.
+//
+// Games that cannot be priced are simply absent from the returned map. Callers
+// must treat a missing entry as "not purchasable here" and hide the item —
+// never fall back to the base currency, which would show a price in the wrong
+// denomination.
+async function displayPricesFor(
+  games: Pick<Game, "id" | "price" | "base_price">[],
+  currencyCode: string,
+  asOf: Date = new Date(),
+): Promise<Map<string, DisplayPrice>> {
+  const prices = new Map<string, DisplayPrice>();
+
+  if (games.length === 0) {
+    return prices;
+  }
+
+  const normalizedCode = currency.normalizeCode(currencyCode);
+
+  const registeredCurrency = await prisma.currency.findUnique({
+    where: { code: normalizedCode },
+  });
+
+  // The base currency works without being registered. Localisation is purely
+  // additive: with no currency rows at all the platform still sells in USD,
+  // and registering currencies and rates only ever adds places to sell. The
+  // alternative — treating an unregistered base currency as "unpriceable" —
+  // would empty the entire storefront the moment this shipped unconfigured.
+  const foundCurrency =
+    registeredCurrency?.enabled === true
+      ? registeredCurrency
+      : normalizedCode === BASE_CURRENCY
+        ? BASE_CURRENCY_DEFAULTS
+        : null;
+
+  if (!foundCurrency) {
+    return prices;
+  }
+
+  const overrides = await prisma.gamePriceOverride.findMany({
+    where: {
+      game_id: { in: games.map((game) => game.id) },
+      currency: normalizedCode,
+    },
+  });
+
+  const overrideByGameId = new Map(
+    overrides.map((override) => [override.game_id, override.amount]),
+  );
+
+  const rate =
+    normalizedCode === BASE_CURRENCY
+      ? null
+      : await exchangeRate.findLatest(BASE_CURRENCY, normalizedCode, asOf);
+
+  for (const game of games) {
+    const override = overrideByGameId.get(game.id);
+
+    const amount =
+      override ??
+      (normalizedCode === BASE_CURRENCY
+        ? game.price
+        : rate
+          ? game.price
+              .mul(rate.rate)
+              .toDecimalPlaces(
+                foundCurrency.decimal_places,
+                Prisma.Decimal.ROUND_HALF_UP,
+              )
+          : null);
+
+    if (amount === null) {
+      continue;
+    }
+
+    // An override has no localised "was" price, so no discount is shown.
+    const baseAmount =
+      override || !game.base_price
+        ? null
+        : normalizedCode === BASE_CURRENCY
+          ? game.base_price
+          : rate
+            ? game.base_price
+                .mul(rate.rate)
+                .toDecimalPlaces(
+                  foundCurrency.decimal_places,
+                  Prisma.Decimal.ROUND_HALF_UP,
+                )
+            : null;
+
+    const formattedAmount = amount.toFixed(foundCurrency.decimal_places);
+    const formattedBase = baseAmount
+      ? baseAmount.toFixed(foundCurrency.decimal_places)
+      : null;
+
+    prices.set(game.id, {
+      amount: formattedAmount,
+      // Equal means no discount, so there is nothing to strike through.
+      base_amount: formattedBase === formattedAmount ? null : formattedBase,
+      currency: normalizedCode,
+      symbol: foundCurrency.symbol,
+    });
+  }
+
+  return prices;
+}
+
+// The id constraint a storefront query needs so unpriceable games never enter
+// the result set in the first place.
+//
+// Returns null when no constraint is needed — the common case, since every
+// game has a base price and one rate makes the whole catalogue priceable.
+// Filtering after the query instead would corrupt pagination: a page of 20
+// could silently render 15.
+async function priceableGameIdConstraint(
+  currencyCode: string,
+  asOf: Date = new Date(),
+): Promise<string[] | null> {
+  const normalizedCode = currency.normalizeCode(currencyCode);
+
+  // Mirrors displayPricesFor: the base currency needs no registration, so the
+  // catalogue is fully priceable before anything is configured.
+  if (normalizedCode === BASE_CURRENCY) {
+    return null;
+  }
+
+  if (!(await isUsable(normalizedCode))) {
+    return [];
+  }
+
+  const rate = await exchangeRate.findLatest(
+    BASE_CURRENCY,
+    normalizedCode,
+    asOf,
+  );
+
+  if (rate) {
+    return null;
+  }
+
+  // No rate: only games explicitly priced in this currency are purchasable.
+  const overrides = await prisma.gamePriceOverride.findMany({
+    where: { currency: normalizedCode },
+    select: { game_id: true },
+  });
+
+  return overrides.map((override) => override.game_id);
+}
+
 // The ids from `gameIds` that can be priced in the given currency.
 //
 // Cheap in the common case: every game has a base price, so once a rate exists
@@ -278,6 +445,8 @@ const pricing = {
   priceFor,
   priceForOrFail,
   priceViewFor,
+  displayPricesFor,
+  priceableGameIdConstraint,
   resolvableGameIds,
   isUsable,
 };

--- a/models/region.ts
+++ b/models/region.ts
@@ -1,0 +1,126 @@
+import { NextApiRequest } from "next";
+import currency from "models/currency";
+import { BASE_CURRENCY } from "models/pricing";
+
+// Vercel sets this on every request from its edge network. Kept as the only
+// source so there is exactly one place to change if the platform changes.
+export const COUNTRY_HEADER = "x-vercel-ip-country";
+
+// ISO 3166-1 alpha-2 → ISO 4217. Deliberately a static map rather than a
+// table: it is a property of the world, not of our catalogue, so putting it in
+// the database would add an admin surface that can only ever be edited to be
+// wrong. A country that is absent falls back to the base currency, which is
+// also what happens when its currency exists but is disabled.
+const COUNTRY_CURRENCY: Record<string, string> = {
+  // Launch markets
+  US: "USD",
+  BR: "BRL",
+
+  // Rest of the Americas
+  AR: "ARS",
+  CA: "CAD",
+  CL: "CLP",
+  CO: "COP",
+  MX: "MXN",
+  PE: "PEN",
+  UY: "UYU",
+
+  // Eurozone
+  AT: "EUR",
+  BE: "EUR",
+  DE: "EUR",
+  ES: "EUR",
+  FI: "EUR",
+  FR: "EUR",
+  GR: "EUR",
+  IE: "EUR",
+  IT: "EUR",
+  NL: "EUR",
+  PT: "EUR",
+
+  // Rest of Europe
+  CH: "CHF",
+  CZ: "CZK",
+  DK: "DKK",
+  GB: "GBP",
+  NO: "NOK",
+  PL: "PLN",
+  SE: "SEK",
+  TR: "TRY",
+
+  // Asia-Pacific
+  AU: "AUD",
+  CN: "CNY",
+  ID: "IDR",
+  IN: "INR",
+  JP: "JPY",
+  KR: "KRW",
+  MY: "MYR",
+  NZ: "NZD",
+  PH: "PHP",
+  SG: "SGD",
+  TH: "THB",
+  TW: "TWD",
+  VN: "VND",
+
+  // Middle East and Africa
+  AE: "AED",
+  EG: "EGP",
+  IL: "ILS",
+  NG: "NGN",
+  SA: "SAR",
+  ZA: "ZAR",
+};
+
+function countryFromRequest(req: NextApiRequest): string | null {
+  const header = req.headers[COUNTRY_HEADER];
+  const value = Array.isArray(header) ? header[0] : header;
+
+  if (!value) {
+    return null;
+  }
+
+  const normalized = value.trim().toUpperCase();
+
+  // Vercel sends "XX" when it cannot geolocate the request.
+  if (!/^[A-Z]{2}$/.test(normalized) || normalized === "XX") {
+    return null;
+  }
+
+  return normalized;
+}
+
+export function currencyCodeForCountry(country: string | null): string {
+  if (!country) {
+    return BASE_CURRENCY;
+  }
+
+  return COUNTRY_CURRENCY[country] ?? BASE_CURRENCY;
+}
+
+// The currency a visitor should see prices in. Falls back to the base currency
+// whenever the region is unknown, unmapped, or maps to a currency we do not
+// currently sell in — never leaves the caller without a currency.
+async function currencyForRequest(req: NextApiRequest): Promise<string> {
+  const candidate = currencyCodeForCountry(countryFromRequest(req));
+
+  if (candidate === BASE_CURRENCY) {
+    return BASE_CURRENCY;
+  }
+
+  const isUsable = await currency
+    .findOneByCode(candidate)
+    .then((found) => found.enabled)
+    .catch(() => false);
+
+  return isUsable ? candidate : BASE_CURRENCY;
+}
+
+const region = {
+  COUNTRY_HEADER,
+  countryFromRequest,
+  currencyCodeForCountry,
+  currencyForRequest,
+};
+
+export default region;

--- a/models/storefront_pricing.ts
+++ b/models/storefront_pricing.ts
@@ -1,0 +1,68 @@
+import { NextApiRequest } from "next";
+import { Game } from "generated/prisma/client";
+import authorization from "models/authorization";
+import pricing, { DisplayPrice } from "models/pricing";
+import region from "models/region";
+
+// Everything a storefront read needs to price its results for the visitor,
+// resolved once per request. Kept in one place because seven read endpoints
+// need identical behaviour, and a storefront that prices games differently
+// depending on which list they came from is worse than one that never
+// localises at all.
+
+export interface StorefrontPricingContext {
+  currency: string;
+  displayPrices: Map<string, DisplayPrice>;
+}
+
+// The id constraint to apply to the query, so unpriceable games never enter the
+// result set and pagination stays honest. Null means "no constraint needed".
+async function idConstraintForRequest(req: NextApiRequest) {
+  const currency = await region.currencyForRequest(req);
+
+  return {
+    currency,
+    gameIds: await pricing.priceableGameIdConstraint(currency),
+  };
+}
+
+async function contextFor(
+  currency: string,
+  games: Pick<Game, "id" | "price" | "base_price">[],
+): Promise<StorefrontPricingContext> {
+  return {
+    currency,
+    displayPrices: await pricing.displayPricesFor(games, currency),
+  };
+}
+
+// Filters each game through authorization and attaches display_price.
+//
+// `price` is left untouched as the USD base — this is additive, so a client
+// that has not been updated keeps working, and one that has can render the
+// local amount with the right symbol.
+//
+// A game with no resolvable price is dropped. The query constraint above
+// normally prevents that, but a detail read has no constraint to apply, and
+// dropping here means no code path can leak a game priced in the wrong
+// currency.
+function filterAndPrice<T extends Game>(
+  user: Parameters<typeof authorization.filterOutput>[0],
+  games: T[],
+  context: StorefrontPricingContext,
+) {
+  return games
+    .filter((game) => context.displayPrices.has(game.id))
+    .map((game) => ({
+      ...authorization.filterOutput(user, "read:public_game", game),
+      display_price: context.displayPrices.get(game.id),
+    }));
+}
+
+const storefrontPricing = {
+  idConstraintForRequest,
+  contextFor,
+  filterAndPrice,
+};
+
+export default storefrontPricing;

--- a/pages/api/v1/games/index.ts
+++ b/pages/api/v1/games/index.ts
@@ -2,7 +2,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { createRouter } from "next-connect";
 import controller from "infra/controller";
 import game, { gameQuerySchema } from "models/game";
-import authorization from "models/authorization";
+import storefrontPricing from "models/storefront_pricing";
 import { ValidationError } from "infra/errors";
 
 export default createRouter<NextApiRequest, NextApiResponse>()
@@ -23,17 +23,20 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
 
   const { order, sort_by, ...rest } = result.data;
 
+  const { currency, gameIds } =
+    await storefrontPricing.idConstraintForRequest(req);
+
   const { games, pagination } = await game.findAllPaginated({
     ...rest,
     order: sort_by ?? order ?? "newest",
+    priceableGameIds: gameIds,
   });
 
-  const secureOutputValues = games.map((gameItem) =>
-    authorization.filterOutput(req.context.user, "read:public_game", gameItem),
-  );
+  const context = await storefrontPricing.contextFor(currency, games);
 
   return res.status(200).json({
-    games: secureOutputValues,
+    games: storefrontPricing.filterAndPrice(req.context.user, games, context),
     pagination,
+    currency,
   });
 }

--- a/pages/api/v1/items/games/[slug]/index.ts
+++ b/pages/api/v1/items/games/[slug]/index.ts
@@ -3,6 +3,8 @@ import { createRouter } from "next-connect";
 import controller from "infra/controller";
 import game from "models/game";
 import authorization from "models/authorization";
+import storefrontPricing from "models/storefront_pricing";
+import region from "models/region";
 import { ForbiddenError, NotFoundError } from "infra/errors";
 
 export default createRouter<NextApiRequest, NextApiResponse>()
@@ -23,13 +25,26 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
     });
   }
 
-  const secureOutputValues = authorization.filterOutput(
+  const currency = await region.currencyForRequest(req);
+  const context = await storefrontPricing.contextFor(currency, [foundGame]);
+  const [pricedGame] = storefrontPricing.filterAndPrice(
     req.context.user,
-    "read:public_game",
-    foundGame,
+    [foundGame],
+    context,
   );
 
-  return res.status(200).json(secureOutputValues);
+  // A game with no price in the visitor's currency is not purchasable by them,
+  // so it is absent from every listing. Its detail page has to agree —
+  // otherwise a shared link would show a product that cannot be bought, with
+  // no price to display.
+  if (!pricedGame) {
+    throw new NotFoundError({
+      message: `The game with slug "${slug}" is not available in ${currency}.`,
+      action: "Check back later, or browse the games available in your region.",
+    });
+  }
+
+  return res.status(200).json(pricedGame);
 }
 
 async function patchHandler(req: NextApiRequest, res: NextApiResponse) {

--- a/pages/api/v1/stores/[slug]/featured/index.ts
+++ b/pages/api/v1/stores/[slug]/featured/index.ts
@@ -4,7 +4,7 @@ import controller from "infra/controller";
 import store from "models/store";
 import game from "models/game";
 import storeCuration from "models/store_curation";
-import authorization from "models/authorization";
+import storefrontPricing from "models/storefront_pricing";
 import { ValidationError } from "infra/errors";
 import { z } from "zod";
 
@@ -36,18 +36,21 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
     foundStore.id,
   );
 
+  const { currency, gameIds } =
+    await storefrontPricing.idConstraintForRequest(req);
+
   const { games, pagination } = await game.findAllPaginated({
+    priceableGameIds: gameIds,
     ...result.data,
     order: "featured",
     curationWhere,
   });
 
-  const secureOutputValues = games.map((gameItem) =>
-    authorization.filterOutput(req.context.user, "read:public_game", gameItem),
-  );
+  const context = await storefrontPricing.contextFor(currency, games);
 
   return res.status(200).json({
-    games: secureOutputValues,
+    games: storefrontPricing.filterAndPrice(req.context.user, games, context),
     pagination,
+    currency,
   });
 }

--- a/pages/api/v1/stores/[slug]/new-releases/index.ts
+++ b/pages/api/v1/stores/[slug]/new-releases/index.ts
@@ -4,7 +4,7 @@ import controller from "infra/controller";
 import store from "models/store";
 import game from "models/game";
 import storeCuration from "models/store_curation";
-import authorization from "models/authorization";
+import storefrontPricing from "models/storefront_pricing";
 import { ValidationError } from "infra/errors";
 import { z } from "zod";
 
@@ -36,18 +36,21 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
     foundStore.id,
   );
 
+  const { currency, gameIds } =
+    await storefrontPricing.idConstraintForRequest(req);
+
   const { games, pagination } = await game.findAllPaginated({
+    priceableGameIds: gameIds,
     ...result.data,
     order: "new_releases",
     curationWhere,
   });
 
-  const secureOutputValues = games.map((gameItem) =>
-    authorization.filterOutput(req.context.user, "read:public_game", gameItem),
-  );
+  const context = await storefrontPricing.contextFor(currency, games);
 
   return res.status(200).json({
-    games: secureOutputValues,
+    games: storefrontPricing.filterAndPrice(req.context.user, games, context),
     pagination,
+    currency,
   });
 }

--- a/pages/api/v1/stores/[slug]/search/index.ts
+++ b/pages/api/v1/stores/[slug]/search/index.ts
@@ -4,7 +4,7 @@ import controller from "infra/controller";
 import store from "models/store";
 import game, { gameQuerySchema } from "models/game";
 import storeCuration from "models/store_curation";
-import authorization from "models/authorization";
+import storefrontPricing from "models/storefront_pricing";
 import { ValidationError } from "infra/errors";
 
 export default createRouter<NextApiRequest, NextApiResponse>()
@@ -32,18 +32,21 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
     foundStore.id,
   );
 
+  const { currency, gameIds } =
+    await storefrontPricing.idConstraintForRequest(req);
+
   const { games, pagination } = await game.findAllPaginated({
+    priceableGameIds: gameIds,
     ...rest,
     order: sort_by ?? order ?? "newest",
     curationWhere,
   });
 
-  const secureOutputValues = games.map((gameItem) =>
-    authorization.filterOutput(req.context.user, "read:public_game", gameItem),
-  );
+  const context = await storefrontPricing.contextFor(currency, games);
 
   return res.status(200).json({
-    games: secureOutputValues,
+    games: storefrontPricing.filterAndPrice(req.context.user, games, context),
     pagination,
+    currency,
   });
 }

--- a/pages/api/v1/stores/[slug]/trending/index.ts
+++ b/pages/api/v1/stores/[slug]/trending/index.ts
@@ -4,7 +4,7 @@ import controller from "infra/controller";
 import store from "models/store";
 import game from "models/game";
 import storeCuration from "models/store_curation";
-import authorization from "models/authorization";
+import storefrontPricing from "models/storefront_pricing";
 import { ValidationError } from "infra/errors";
 import { z } from "zod";
 
@@ -36,18 +36,21 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
     foundStore.id,
   );
 
+  const { currency, gameIds } =
+    await storefrontPricing.idConstraintForRequest(req);
+
   const { games, pagination } = await game.findAllPaginated({
+    priceableGameIds: gameIds,
     ...result.data,
     order: "trending",
     curationWhere,
   });
 
-  const secureOutputValues = games.map((gameItem) =>
-    authorization.filterOutput(req.context.user, "read:public_game", gameItem),
-  );
+  const context = await storefrontPricing.contextFor(currency, games);
 
   return res.status(200).json({
-    games: secureOutputValues,
+    games: storefrontPricing.filterAndPrice(req.context.user, games, context),
     pagination,
+    currency,
   });
 }

--- a/pages/item/[slug].tsx
+++ b/pages/item/[slug].tsx
@@ -43,6 +43,7 @@ import {
 } from "components/store/ReviewCard";
 import { ReviewSummary } from "components/store/ReviewSummary";
 import webserver from "infra/webserver";
+import { DisplayPrice, formatBasePrice, formatPrice } from "lib/price";
 
 type GameApi = {
   id: string;
@@ -53,6 +54,7 @@ type GameApi = {
   launch_date: string;
   price: string;
   base_price?: string;
+  display_price?: DisplayPrice | null;
   discount_label?: string;
   developer_name: string;
   publisher_name?: string;
@@ -440,9 +442,9 @@ export default function GameDetailsPage({ game }: { game: GameApi }) {
               <div className="flex flex-col gap-6">
                 <div className="flex items-center justify-between">
                   <div className="flex flex-col">
-                    {!isDemo && game.base_price && (
+                    {!isDemo && formatBasePrice(game) && (
                       <span className="text-xl font-bold text-white/30 line-through">
-                        ${game.base_price}
+                        {formatBasePrice(game)}
                       </span>
                     )}
                     <span
@@ -451,7 +453,7 @@ export default function GameDetailsPage({ game }: { game: GameApi }) {
                         color: discountBadgeColor,
                       }}
                     >
-                      {isDemo ? "Free" : `$${game.price}`}
+                      {isDemo ? "Free" : formatPrice(game)}
                     </span>
                   </div>
                   {!isDemo && game.discount_label && (

--- a/pages/studio/[slug]/index.tsx
+++ b/pages/studio/[slug]/index.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import { Loader2, Building2, Copy, Check, Gamepad2 } from "lucide-react";
 import { ReviewSummary } from "components/store/ReviewSummary";
 import { type GameApi } from "components/store/GameListItem";
+import { formatPrice, isFree } from "lib/price";
 
 interface Studio {
   id: string;
@@ -138,7 +139,7 @@ export default function StudioPage() {
 function StudioGameCard({ game }: { game: GameApi }) {
   const [copied, setCopied] = useState(false);
 
-  const isDemo = !game.price || Number(game.price) === 0;
+  const isDemo = isFree(game);
   const defaultGradient =
     "linear-gradient(135deg, var(--color-purple-dark) 0%, rgba(53,34,89,0.7) 100%)";
 
@@ -181,7 +182,7 @@ function StudioGameCard({ game }: { game: GameApi }) {
         </div>
 
         <div className="flex items-center gap-3 text-xs text-white/40 font-bold">
-          <span>{isDemo ? "Free" : `$${game.price}`}</span>
+          <span>{isDemo ? "Free" : formatPrice(game)}</span>
           <span className="text-white/20">•</span>
           <span>{launchDate}</span>
         </div>

--- a/tests/integration/api/v1/games/get.test.ts
+++ b/tests/integration/api/v1/games/get.test.ts
@@ -1,5 +1,7 @@
 import webserver from "infra/webserver";
 import orchestrator from "tests/orchestrator";
+import gameModel from "models/game";
+import currencyModel from "models/currency";
 
 beforeAll(async () => {
   await orchestrator.waitForAllServices();
@@ -183,6 +185,125 @@ describe("GET /api/v1/games", () => {
           "Budget Bundle",
         ]);
       });
+    });
+  });
+  describe("Regional pricing", () => {
+    async function setupPricedGame(priceInUsd = 10) {
+      await orchestrator.clearDatabaseRows();
+      await orchestrator.createCurrency({ code: "USD", symbol: "$" });
+      await orchestrator.createCurrency({ code: "BRL", symbol: "R$" });
+
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const game = await orchestrator.createGame(owner.id, {
+        price: priceInUsd,
+      });
+      await gameModel.setStatus(game.id, "ACTIVE");
+
+      return game;
+    }
+
+    function listAs(country?: string) {
+      return fetch(`${webserver.getOrigin()}/api/v1/games`, {
+        headers: country ? { "x-vercel-ip-country": country } : {},
+      });
+    }
+
+    test("Without a region header should price in the base currency", async () => {
+      await setupPricedGame(10);
+
+      const response = await listAs();
+      expect(response.status).toBe(200);
+
+      const body = await response.json();
+      expect(body.currency).toBe("USD");
+      expect(body.games[0].display_price).toEqual({
+        amount: "10.00",
+        base_amount: null,
+        currency: "USD",
+        symbol: "$",
+      });
+      // price stays the USD base, so this is additive for existing clients.
+      expect(body.games[0].price).toBe("10.00");
+    });
+
+    test("With a Brazilian region and a rate should price in BRL", async () => {
+      await setupPricedGame(10);
+      await orchestrator.createExchangeRate({ rate: 5.5 });
+
+      const body = await (await listAs("BR")).json();
+
+      expect(body.currency).toBe("BRL");
+      expect(body.games[0].display_price).toEqual({
+        amount: "55.00",
+        base_amount: null,
+        currency: "BRL",
+        symbol: "R$",
+      });
+    });
+
+    test("An override wins over the rate", async () => {
+      const game = await setupPricedGame(10);
+      await orchestrator.createExchangeRate({ rate: 5.5 });
+      await orchestrator.setGamePriceOverride(game.id, "BRL", 49.9);
+
+      const body = await (await listAs("BR")).json();
+
+      expect(body.games[0].display_price.amount).toBe("49.90");
+    });
+
+    test("With no rate and no override the game is hidden from the region", async () => {
+      await setupPricedGame(10);
+
+      const body = await (await listAs("BR")).json();
+
+      expect(body.currency).toBe("BRL");
+      expect(body.games).toHaveLength(0);
+      // Pagination reflects the constrained query rather than a filtered page.
+      expect(body.pagination.total).toBe(0);
+    });
+
+    test("With no rate, only games priced explicitly in BRL are listed", async () => {
+      const priced = await setupPricedGame(10);
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const unpriced = await orchestrator.createGame(owner.id, { price: 20 });
+      await gameModel.setStatus(unpriced.id, "ACTIVE");
+
+      await orchestrator.setGamePriceOverride(priced.id, "BRL", 49.9);
+
+      const body = await (await listAs("BR")).json();
+
+      expect(body.games.map((g) => g.id)).toEqual([priced.id]);
+      expect(body.pagination.total).toBe(1);
+    });
+
+    test("A disabled currency falls back to the base currency", async () => {
+      await setupPricedGame(10);
+      await orchestrator.createExchangeRate({ rate: 5.5 });
+      await currencyModel.setEnabled("BRL", false);
+
+      const body = await (await listAs("BR")).json();
+
+      expect(body.currency).toBe("USD");
+      expect(body.games[0].display_price.currency).toBe("USD");
+    });
+
+    test("An unmapped region falls back to the base currency", async () => {
+      await setupPricedGame(10);
+
+      const body = await (await listAs("AQ")).json();
+
+      expect(body.currency).toBe("USD");
+    });
+
+    test("An ungeolocatable request falls back to the base currency", async () => {
+      await setupPricedGame(10);
+
+      // Vercel sends XX when it cannot place the request.
+      const body = await (await listAs("XX")).json();
+
+      expect(body.currency).toBe("USD");
     });
   });
 });

--- a/tests/integration/api/v1/items/games/[slug]/get.test.ts
+++ b/tests/integration/api/v1/items/games/[slug]/get.test.ts
@@ -1,4 +1,5 @@
 import orchestrator from "tests/orchestrator";
+import gameModel from "models/game";
 import webserver from "infra/webserver";
 
 beforeAll(async () => {
@@ -75,6 +76,63 @@ describe("GET /api/v1/items/games/[slug]", () => {
 
       expect(responseBody.id).toBe(game.id);
       expect(responseBody.slug).toBe(game.slug);
+    });
+  });
+  describe("Regional pricing", () => {
+    test("Should attach display_price in the visitor's currency", async () => {
+      await orchestrator.clearDatabaseRows();
+      await orchestrator.createCurrency({ code: "USD", symbol: "$" });
+      await orchestrator.createCurrency({ code: "BRL", symbol: "R$" });
+      await orchestrator.createExchangeRate({ rate: 5.5 });
+
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const game = await orchestrator.createGame(owner.id, { price: 10 });
+      await gameModel.setStatus(game.id, "ACTIVE");
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/items/games/${game.slug}`,
+        { headers: { "x-vercel-ip-country": "BR" } },
+      );
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+      expect(responseBody.display_price).toEqual({
+        amount: "55.00",
+        base_amount: null,
+        currency: "BRL",
+        symbol: "R$",
+      });
+    });
+
+    test("Should return 404 where the game has no price in that currency", async () => {
+      await orchestrator.clearDatabaseRows();
+      await orchestrator.createCurrency({ code: "USD", symbol: "$" });
+      await orchestrator.createCurrency({ code: "BRL", symbol: "R$" });
+      // No rate and no override: not purchasable in BRL.
+
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const game = await orchestrator.createGame(owner.id, { price: 10 });
+      await gameModel.setStatus(game.id, "ACTIVE");
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/items/games/${game.slug}`,
+        { headers: { "x-vercel-ip-country": "BR" } },
+      );
+
+      // The detail page has to agree with the listings that hide it.
+      expect(response.status).toBe(404);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        message: `The game with slug "${game.slug}" is not available in BRL.`,
+        name: "NotFoundError",
+        action:
+          "Check back later, or browse the games available in your region.",
+        status_code: 404,
+      });
     });
   });
 });


### PR DESCRIPTION
## Description

Reads Vercel's `x-vercel-ip-country` and maps it to a currency, so a visitor in a mapped region sees local prices.

**This is the PR that makes the previous five visible to a buyer.** Until now the storefront showed the same USD price to everyone — all the machinery existed and was manageable, but nothing chose a currency.

A Brazilian visitor now sees `R$66.00` struck through from `R$110.00`, with the `-40%` badge intact. No dollar amounts leak through.

### `models/region.ts`

Owns the country→currency map, **static in code rather than a table**: it is a property of the world, not of our catalogue, so a database copy could only ever be edited to be wrong. Falls back to the base currency when the region is unknown, unmapped, ungeolocatable (Vercel sends `XX`), or maps to a currency that is not enabled.

### `models/storefront_pricing.ts`

Centralises what every storefront read needs. Seven endpoints emit `read:public_game` output, and a storefront that prices differently depending on which list a game came from is worse than one that never localises at all.

Batched deliberately: one query for the currency, one for the rate, one for the overrides. Resolving each game individually would be two queries per game — 40 round trips on a 20-item page for information that doesn't vary.

**📐 [Detailed architecture diagrams in the comment below](https://github.com/pedromello/manifoldpowered.com/pull/187#issuecomment-5147522362)** — request flow, why the two-phase design, the price resolution decision tree, and the per-endpoint diff. Also in #188 and `docs/payments-architecture.md`.

### API shape

Additive. `price` remains the untouched USD base, so a client that has not been updated keeps working:

```json
{
  "price": "12.00",
  "base_price": "20.00",
  "display_price": {
    "amount": "66.00",
    "base_amount": "110.00",
    "currency": "BRL",
    "symbol": "R$"
  }
}
```

## Three decisions worth a look

**Filtering happens in the query, not after it.** `findAllPaginated` now takes `priceableGameIds`. Post-filtering a page of 20 could render 15 while pagination still claimed 20 — the constraint has to be in the query for the counts to stay honest.

**The base currency works unregistered.** With no currency rows at all the platform still sells in USD; localisation is purely additive on top. I originally had an unregistered base currency mean "unpriceable", which would have **emptied the entire storefront the moment this shipped unconfigured**. Caught while running the existing suite, which went red across every storefront test.

**`base_amount` is null when the price comes from an override.** An override states an absolute price with no localised original, so showing the converted USD original beside it would misprice the discount. Under conversion both sides convert, so the ratio is preserved — a 40% discount survives into BRL.

## Detail reads 404 when unavailable

A game with no price in the visitor's currency is absent from every listing, so its detail page has to agree. Otherwise a shared link shows a product that cannot be bought, with no price to display.

## Related issues

Closes #188. Part of #177 — task 4d in `docs/payments-tasks.md`. Follows #181, #182, #183, #184, #185 and #186.

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📖 Documentation
- [ ] ♻️ Refactor
- [ ] 🧪 Tests

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] `npm run lint:eslint:check` passes
- [x] `npm run lint:prettier:check` passes
- [x] `npm run test` passes — **506/509, see below**
- [x] Added or updated tests where relevant

## Test results

`506 passed, 3 failed` across 95 suites (+10 new tests). The 3 failures are the same two environmental suites as every PR in this sequence:

| Suite | Cause |
| --- | --- |
| `api/v1/status/get.test.ts` | Asserts the database version is `"16.0"` (the `postgres:16.0-alpine3.18` image). This run used a natively installed PostgreSQL 16.13. |
| `api/v1/items/games/steam-import/post.test.ts` (2 tests) | The public Steam API is unreachable from this environment. |

New cases cover: no header → base currency, BR + rate → BRL, override winning over rate, the game hidden when there is neither (with `pagination.total` reflecting the constrained query, not a filtered page), only overridden games listed when no rate exists, disabled currency → fallback, unmapped region → fallback, `XX` → fallback, `display_price` on detail, and detail 404 when unpriceable.

Also verified end to end in a browser at both `USD` and `BR`, since the frontend changes have no automated coverage — the repo has no frontend test setup, same as noted in #186.

## Next

This closes the pricing arc. The remaining work in `docs/payments-tasks.md` is tasks 5–11: the ledger, the payout provider interface, maturation and clawback, and the payout run.

Worth flagging before that starts: **the ledger design still assumes answers from #175** (tax posture), which is unanswered. Tasks 5 and 6 — the ledger schema and the zero-sum accounting core — are safe to build regardless, since they record facts rather than decide tax treatment. The payout-side tasks are where the open questions start to bite.