### PR TITLE
fix: reconcile admin-only features in the feature backfill

### DIFF
--- a/docs/payments-tasks.md
+++ b/docs/payments-tasks.md
@@ -117,7 +117,7 @@ sequenceDiagram
 Two things from the original task still apply to every PR that adds a feature:
 
 - `filterOutput` returns `{}` for unhandled features, so a missing branch silently empties the response body rather than failing loudly. Every new feature needs its own branch.
-- Adding to `ACTIVATED_USER_FEATURES` changes an array that four existing test files assert with whole-object equality, so those fixtures must be updated in the same PR. Adding to `ADMIN_ONLY_FEATURES` does not have that problem, but existing admins do not pick the new features up from `npm run features:backfill` — `feature_backfill.ts` does not reconcile admin-only features. Re-running `npm run admin:grant -- --email=<email>` is the fix; it computes the missing set from `ADMIN_ONLY_FEATURES` and is idempotent.
+- Adding to `ACTIVATED_USER_FEATURES` changes an array that four existing test files assert with whole-object equality, so those fixtures must be updated in the same PR. Adding to `ADMIN_ONLY_FEATURES` does not have that problem. Existing admins pick new admin features up from `npm run features:backfill` (or the backoffice "Reconcile feature grants" button) — `reconcileAll()` has an admin pass that tops up anyone already holding at least one admin-only feature. It cannot promote a non-admin. `npm run admin:grant -- --email=<email>` remains available for granting admin to a specific account.
 
 ---
 

--- a/models/authorization.ts
+++ b/models/authorization.ts
@@ -658,6 +658,7 @@ function filterOutput(user: Partial<User>, feature: string, resource: unknown) {
     }
     interface BackfillReportOutput {
       baseline: PassResult;
+      admins: PassResult;
       studio_owners: PassResult;
       studio_members: PassResult;
       store_owners: PassResult;

--- a/models/feature_backfill.ts
+++ b/models/feature_backfill.ts
@@ -12,6 +12,7 @@ interface PassResult {
 
 interface BackfillReport {
   baseline: PassResult;
+  admins: PassResult;
   studio_owners: PassResult;
   studio_members: PassResult;
   store_owners: PassResult;
@@ -84,6 +85,43 @@ async function reconcileBaseline(
       userId,
       eligibleUsers,
       authorization.ACTIVATED_USER_FEATURES,
+      result,
+      touchedIds,
+    );
+  }
+
+  return result;
+}
+
+// Tops up existing admins with any ADMIN_ONLY_FEATURES added since they were
+// granted. Without this pass, every new admin feature silently 403s for every
+// pre-existing admin until someone remembers to re-run `npm run admin:grant`
+// per account — and the backoffice's "Reconcile feature grants" button, which
+// looks like it covers everything, quietly did not.
+//
+// Eligibility is "already holds at least one admin-only feature", so this can
+// only ever close a gap for someone who is already an admin. It cannot promote
+// anyone: a user with no admin features is skipped entirely rather than
+// counted, since they are not a candidate in the first place.
+async function reconcileAdmins(
+  eligibleUsers: EligibleUsers,
+  touchedIds: Set<string>,
+): Promise<PassResult> {
+  const result = newPassResult();
+
+  for (const [userId, currentFeatures] of eligibleUsers) {
+    const isAlreadyAdmin = currentFeatures.some((feature) =>
+      authorization.ADMIN_ONLY_FEATURES.includes(feature),
+    );
+
+    if (!isAlreadyAdmin) {
+      continue;
+    }
+
+    await applyIfMissing(
+      userId,
+      eligibleUsers,
+      authorization.ADMIN_ONLY_FEATURES,
       result,
       touchedIds,
     );
@@ -211,7 +249,8 @@ function groupPermissionsByUser(
 }
 
 // Reconciles every activated, non-disabled user's global features against
-// the *current* code-level definitions of ACTIVATED_USER_FEATURES and the
+// the *current* code-level definitions of ACTIVATED_USER_FEATURES,
+// ADMIN_ONLY_FEATURES (for users who are already admins) and the
 // studio/store MEMBER_PERMISSIONS lists. Safe to re-run at any time (a no-op
 // wherever nothing is missing) — intended to be re-run after every future
 // change to those definitions, from the CLI script, a CI job, or the
@@ -222,6 +261,7 @@ async function reconcileAll(): Promise<BackfillReport> {
   const touchedIds = new Set<string>();
 
   const baseline = await reconcileBaseline(eligibleUsers, touchedIds);
+  const admins = await reconcileAdmins(eligibleUsers, touchedIds);
   const studio_owners = await reconcileStudioOwners(eligibleUsers, touchedIds);
   const studio_members = await reconcileStudioMembers(
     eligibleUsers,
@@ -232,6 +272,7 @@ async function reconcileAll(): Promise<BackfillReport> {
 
   return {
     baseline,
+    admins,
     studio_owners,
     studio_members,
     store_owners,

--- a/tests/integration/api/v1/backoffice/feature-backfill/post.test.ts
+++ b/tests/integration/api/v1/backoffice/feature-backfill/post.test.ts
@@ -42,6 +42,50 @@ describe("POST /api/v1/backoffice/feature-backfill", () => {
   });
 
   describe("Authenticated admin user", () => {
+    test("Tops up an existing admin missing a newer admin-only feature", async () => {
+      const staleAdmin = await orchestrator.createAdminUser();
+      // Simulate an admin granted before a newer admin feature shipped.
+      await user.setFeatures(
+        staleAdmin.id,
+        [
+          ...authorization.ACTIVATED_USER_FEATURES,
+          ...authorization.ADMIN_ONLY_FEATURES,
+        ].filter((feature) => feature !== "create:currency:any"),
+      );
+
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+
+      const response = await postBackfill(session.token);
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+      expect(responseBody.admins.updated).toBeGreaterThanOrEqual(1);
+
+      const updated = await orchestrator.getUserById(staleAdmin.id);
+      expect(updated.features).toEqual(
+        expect.arrayContaining(authorization.ADMIN_ONLY_FEATURES),
+      );
+    });
+
+    test("Never promotes a non-admin to admin", async () => {
+      const plainUser = await orchestrator.createUser();
+      await orchestrator.activateUser(plainUser.id);
+
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+
+      const response = await postBackfill(session.token);
+      expect(response.status).toBe(200);
+
+      // Eligibility for the admin pass is "already holds an admin-only
+      // feature", so a plain activated user must come out untouched.
+      const updated = await orchestrator.getUserById(plainUser.id);
+      for (const adminFeature of authorization.ADMIN_ONLY_FEATURES) {
+        expect(updated.features).not.toContain(adminFeature);
+      }
+    });
+
     test("Tops up a user missing a baseline feature", async () => {
       const target = await orchestrator.createUser();
       await orchestrator.activateUser(target.id);


### PR DESCRIPTION
## Description

`reconcileAll()` ran five passes — activated baseline, studio owners and members, store owners and members — and **never touched `ADMIN_ONLY_FEATURES`**.

The consequence: every new admin feature 403s for every pre-existing admin until someone remembers to re-run `npm run admin:grant` for each account individually. Meanwhile the backoffice's "Reconcile feature grants" button looks like it already covers this.

Reported after running the backoffice reconcile and still getting 403 on `POST /api/v1/backoffice/currencies`.

### Why this is a fix and not a feature

The gap was **documented rather than fixed** when the currency features landed in #184, and it caught the first person to hit it. The function's own docstring made a promise it didn't keep:

> intended to be re-run after every future change to those definitions, from the CLI script, a CI job, or the backoffice "Reconcile feature grants" button, **with no code changes needed here**

That was true for `ACTIVATED_USER_FEATURES` and the studio/store `MEMBER_PERMISSIONS`, and false for `ADMIN_ONLY_FEATURES`. Documenting a footgun is worse than removing it, and this will recur on every future admin feature.

## The safety property

The new `reconcileAdmins` pass **cannot promote anyone.**

Eligibility is "already holds at least one admin-only feature", so the pass can only ever close a gap for someone who is already an admin. A user with no admin features is skipped entirely — not even counted in `scanned`, since they were never a candidate.

This is the part worth reviewing carefully: a backfill that grants admin privileges by accident would be considerably worse than the bug it fixes. Both directions are covered by tests:

- **Tops up an existing admin** missing a newer admin-only feature — simulated by granting an admin everything except `create:currency:any`, then asserting the reconcile restores it.
- **Never promotes a non-admin** — a plain activated user is checked against every entry in `ADMIN_ONLY_FEATURES` individually and must hold none of them afterwards.

## Other changes

`BackfillReport` gains an `admins` entry, mirrored in the `filterOutput` branch for `update:user:features:any` so the report still serialises in full.

`docs/payments-tasks.md` updated — it previously told readers to work around this by re-running `admin:grant` per account.

## After merging

A single `npm run features:backfill`, or the backoffice button, brings every existing admin up to date. `npm run admin:grant -- --email=<email>` remains the tool for granting admin to a *new* account, which is a different job.

## Related

Follows #184, where the gap was introduced and documented. Part of #177.

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📖 Documentation
- [ ] ♻️ Refactor
- [ ] 🧪 Tests

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] `npm run lint:eslint:check` passes
- [x] `npm run lint:prettier:check` passes
- [x] `npm run test` passes — **508/511, see below**
- [x] Added or updated tests where relevant

## Test results

`508 passed, 3 failed` across 95 suites (+2 new tests). The 3 failures are the same two environmental suites as every PR in this sequence, both unrelated:

| Suite | Cause |
| --- | --- |
| `api/v1/status/get.test.ts` | Asserts the database version is `"16.0"` (the `postgres:16.0-alpine3.18` image). This run used a natively installed PostgreSQL 16.13. |
| `api/v1/items/games/steam-import/post.test.ts` (2 tests) | The public Steam API is unreachable from this environment. |

---
_Generated by [Claude Code](https://claude.ai/code/session_01Whv49dfByzLEJjor8FbRbt)_