### PR TITLE
chore: add a session start hook for Claude Code on the web

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -19,11 +19,11 @@ likely conclusion is "tests can't run here", which is wrong.
 
 ## What it substitutes
 
-| Container            | Substitute                         | Port(s)    |
-| -------------------- | ---------------------------------- | ---------- |
-| `postgres:16-alpine` | native PostgreSQL 16 binaries      | 6432       |
-| `sj26/mailcatcher`   | the `mailcatcher` Ruby gem         | 1025, 1080 |
-| `minio/minio`        | `moto[server]` (S3-compatible)     | 9000       |
+| Container            | Substitute                     | Port(s)    |
+| -------------------- | ------------------------------ | ---------- |
+| `postgres:16-alpine` | native PostgreSQL 16 binaries  | 6432       |
+| `sj26/mailcatcher`   | the `mailcatcher` Ruby gem     | 1025, 1080 |
+| `minio/minio`        | `moto[server]` (S3-compatible) | 9000       |
 
 Same protocols on the same ports, so no application code or test knows the
 difference. Credentials and ports come from `.env.development`, which is
@@ -32,7 +32,7 @@ committed.
 Each substitute is load-bearing:
 
 - **MailCatcher** — `orchestrator.waitForAllServices()` blocks on its HTTP API,
-  so *every* suite hangs without it. Note the orchestrator speaks MailCatcher's
+  so _every_ suite hangs without it. Note the orchestrator speaks MailCatcher's
   API (`/messages`, `/messages/:id.plain`), not MailHog's.
 - **S3** — the game-file suites fail in `beforeAll` on `clearStorage()` without
   an endpoint on 9000. `moto` covers presigned upload and download URLs.
@@ -57,7 +57,7 @@ Two suites fail in this environment for reasons unrelated to any change:
   which is unreachable through the egress proxy, so the endpoint correctly
   returns 503.
 
-Both pass in CI. Treat any *other* failure as real.
+Both pass in CI. Treat any _other_ failure as real.
 
 ## Maintenance
 

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -1,0 +1,72 @@
+# Session start hook
+
+`session-start.sh` runs at the start of every Claude Code **web** session and
+provisions everything `npm run test` needs. It exits immediately on a local
+machine (`CLAUDE_CODE_REMOTE` is unset), where the normal Docker path works.
+
+## Why it exists
+
+The repo's normal setup is `docker compose -f infra/compose.yaml up -d`, which
+brings up Postgres, MailCatcher and MinIO.
+
+**In Claude Code on the web the Docker daemon runs but image pulls are blocked
+by the egress policy.** `docker compose up` fails with a 403 from Docker Hub's
+blob CDN, so `npm run test` aborts before a single test runs and the suite
+looks unrunnable.
+
+Without this hook, every session rediscovers that from scratch — and the most
+likely conclusion is "tests can't run here", which is wrong.
+
+## What it substitutes
+
+| Container            | Substitute                         | Port(s)    |
+| -------------------- | ---------------------------------- | ---------- |
+| `postgres:16-alpine` | native PostgreSQL 16 binaries      | 6432       |
+| `sj26/mailcatcher`   | the `mailcatcher` Ruby gem         | 1025, 1080 |
+| `minio/minio`        | `moto[server]` (S3-compatible)     | 9000       |
+
+Same protocols on the same ports, so no application code or test knows the
+difference. Credentials and ports come from `.env.development`, which is
+committed.
+
+Each substitute is load-bearing:
+
+- **MailCatcher** — `orchestrator.waitForAllServices()` blocks on its HTTP API,
+  so *every* suite hangs without it. Note the orchestrator speaks MailCatcher's
+  API (`/messages`, `/messages/:id.plain`), not MailHog's.
+- **S3** — the game-file suites fail in `beforeAll` on `clearStorage()` without
+  an endpoint on 9000. `moto` covers presigned upload and download URLs.
+
+## Running the suite
+
+Use `npm run test:no-docker`. It is `npm run test` minus the `docker compose`
+step, which would fail here and abort everything.
+
+```bash
+npm run test:no-docker
+```
+
+## Known non-failures
+
+Two suites fail in this environment for reasons unrelated to any change:
+
+- `api/v1/status/get.test.ts` asserts the database version is `"16.0"`, the
+  version of the pinned container image. The native package reports its own
+  patch version.
+- `api/v1/items/games/steam-import/post.test.ts` needs the public Steam API,
+  which is unreachable through the egress proxy, so the endpoint correctly
+  returns 503.
+
+Both pass in CI. Treat any *other* failure as real.
+
+## Maintenance
+
+The hook is idempotent — every step is skipped when already satisfied, so it is
+safe to re-run by hand:
+
+```bash
+CLAUDE_CODE_REMOTE=true CLAUDE_PROJECT_DIR="$PWD" ./.claude/hooks/session-start.sh
+```
+
+It prefers Docker whenever Docker works, so it needs no change if the egress
+policy is relaxed later.

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Provisions everything `npm run test` needs.
+#
+# The repo's normal path is `docker compose -f infra/compose.yaml up -d`
+# (Postgres, MailCatcher, MinIO). In Claude Code on the web the Docker daemon
+# runs but image pulls are blocked by the egress policy, so compose fails and
+# the whole suite looks unrunnable. This falls back to native equivalents that
+# speak the same protocols on the same ports, so no application code or test
+# has to know the difference.
+#
+# Idempotent: every step is skipped when it is already satisfied.
+set -euo pipefail
+
+# Local machines have working Docker; leave them on the normal path.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+log() { echo "[session-start] $*"; }
+
+# Ports and credentials come from .env.development, which is committed.
+PGPORT=6432
+PGUSER_APP=local_user
+PGPASS_APP=local_password
+PGDB_APP=local_db
+PGDATA=/var/lib/postgresql/manifold
+PG_BIN=/usr/lib/postgresql/16/bin
+
+log "installing npm dependencies"
+npm install --no-audit --no-fund >/dev/null
+
+# --- Postgres ---------------------------------------------------------------
+if pg_isready -h 127.0.0.1 -p "$PGPORT" >/dev/null 2>&1; then
+  log "postgres already accepting connections on $PGPORT"
+elif docker compose -f infra/compose.yaml up -d >/dev/null 2>&1 &&
+     node infra/scripts/wait-for-postgres.js >/dev/null 2>&1; then
+  log "postgres started via docker compose"
+else
+  log "docker unavailable (image pulls are blocked here) — using native postgres"
+
+  if [ ! -s "$PGDATA/PG_VERSION" ]; then
+    mkdir -p "$PGDATA"
+    chown postgres:postgres "$PGDATA"
+    chmod 700 "$PGDATA"
+    su postgres -c "$PG_BIN/initdb -D $PGDATA -A trust -U postgres" >/dev/null
+  fi
+
+  su postgres -c \
+    "$PG_BIN/pg_ctl -D $PGDATA -l /tmp/postgres-manifold.log \
+     -o '-p $PGPORT -c listen_addresses=127.0.0.1' start" >/dev/null 2>&1 || true
+
+  for _ in $(seq 1 30); do
+    pg_isready -h 127.0.0.1 -p "$PGPORT" >/dev/null 2>&1 && break
+    sleep 1
+  done
+
+  psql -h 127.0.0.1 -p "$PGPORT" -U postgres -tc \
+    "SELECT 1 FROM pg_roles WHERE rolname='$PGUSER_APP'" | grep -q 1 ||
+    psql -h 127.0.0.1 -p "$PGPORT" -U postgres -c \
+      "CREATE USER $PGUSER_APP WITH PASSWORD '$PGPASS_APP' SUPERUSER CREATEDB" >/dev/null
+
+  psql -h 127.0.0.1 -p "$PGPORT" -U postgres -tc \
+    "SELECT 1 FROM pg_database WHERE datname='$PGDB_APP'" | grep -q 1 ||
+    psql -h 127.0.0.1 -p "$PGPORT" -U postgres -c \
+      "CREATE DATABASE $PGDB_APP OWNER $PGUSER_APP" >/dev/null
+fi
+
+# --- MailCatcher (SMTP 1025 / HTTP 1080) ------------------------------------
+# tests/orchestrator.js waitForAllServices() blocks on the HTTP API, so every
+# suite hangs without it. The orchestrator speaks MailCatcher's API, not
+# MailHog's, so the gem is the right substitute for the container.
+if curl -sf -o /dev/null --max-time 2 http://127.0.0.1:1080/messages; then
+  log "mailcatcher already listening"
+else
+  # The gem's binary is not necessarily on PATH — under rbenv it lands in
+  # Gem.bindir, which is the only reliable way to find it.
+  resolve_mailcatcher() {
+    command -v mailcatcher 2>/dev/null && return 0
+    local bindir
+    bindir=$(ruby -e 'print Gem.bindir' 2>/dev/null || echo "")
+    if [ -n "$bindir" ] && [ -x "$bindir/mailcatcher" ]; then
+      echo "$bindir/mailcatcher"
+      return 0
+    fi
+    return 1
+  }
+
+  MAILCATCHER=$(resolve_mailcatcher || echo "")
+  if [ -z "$MAILCATCHER" ] && command -v gem >/dev/null 2>&1; then
+    log "installing mailcatcher"
+    gem install mailcatcher --no-document >/dev/null 2>&1 || true
+    MAILCATCHER=$(resolve_mailcatcher || echo "")
+  fi
+
+  if [ -n "$MAILCATCHER" ]; then
+    nohup "$MAILCATCHER" --foreground --smtp-port 1025 --http-port 1080 \
+      --http-ip 127.0.0.1 >/tmp/mailcatcher.log 2>&1 &
+    log "mailcatcher started"
+  else
+    log "WARNING: mailcatcher unavailable — suites will hang in waitForAllServices"
+  fi
+fi
+
+# --- S3 on :9000 ------------------------------------------------------------
+# moto is S3-compatible and covers what infra/storage.ts uses, including
+# presigned upload and download URLs. Without it the game-file suites fail in
+# beforeAll on clearStorage().
+if curl -sf -o /dev/null --max-time 2 http://127.0.0.1:9000/; then
+  log "s3 endpoint already listening on 9000"
+else
+  python3 -c "import moto" >/dev/null 2>&1 ||
+    pip3 install --quiet --ignore-installed PyYAML "moto[server]" >/dev/null 2>&1 || true
+
+  if python3 -c "import moto" >/dev/null 2>&1; then
+    nohup python3 -m moto.server -p 9000 -H 127.0.0.1 >/tmp/moto.log 2>&1 &
+    log "s3 (moto) started"
+  else
+    log "WARNING: no S3 endpoint — game-file suites will fail on clearStorage()"
+  fi
+fi
+
+# --- Prisma -----------------------------------------------------------------
+log "generating prisma client and applying migrations"
+npx prisma generate >/dev/null
+npx prisma migrate deploy >/dev/null
+
+log "ready — run 'npm run test:no-docker' (npm run test would try docker compose)"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test": "npm run services:up && npm run prisma:generate && npm run migrate:dev && concurrently -n next,jest -k -s command-jest \"next dev\" \"jest --runInBand\"",
     "posttest": "npm run services:down",
     "test:watch": "jest --watchAll --runInBand --verbose",
+    "test:no-docker": "npm run prisma:generate && npx prisma migrate deploy && concurrently -n next,jest -k -s command-jest \"next dev\" \"jest --runInBand\"",
     "services:up": "docker compose -f infra/compose.yaml up -d",
     "services:stop": "docker compose -f infra/compose.yaml stop",
     "services:down": "docker compose -f infra/compose.yaml down",


### PR DESCRIPTION
## Description

Web sessions have a **working Docker daemon but blocked image pulls**. `docker compose -f infra/compose.yaml up -d` fails with a 403 from Docker Hub's blob CDN, and since `npm run test` runs compose first, it aborts before a single test executes.

The suite therefore *looks* unrunnable. Without this hook, every session rediscovers that from scratch, and the most likely conclusion is "tests can't run in this environment" — which is wrong, and which cost most of a session to work out the first time.

## What it does

Substitutes each container with a native equivalent speaking the same protocol on the same port, so no application code or test knows the difference:

| Container | Substitute | Ports |
| --- | --- | --- |
| `postgres:16.0-alpine3.18` | native PostgreSQL 16 binaries (`/usr/lib/postgresql/16`) | 6432 |
| `sj26/mailcatcher` | the `mailcatcher` Ruby gem | 1025, 1080 |
| `minio/minio` | `moto[server]`, S3-compatible | 9000 |

Credentials and ports come from `.env.development`, which is committed.

**Both substitutes are load-bearing, not nice-to-haves:**

- `orchestrator.waitForAllServices()` blocks on MailCatcher's HTTP API, so *every* suite hangs without it. Worth knowing: the orchestrator speaks **MailCatcher's** API (`/messages`, `/messages/:id.plain`), not MailHog's — the gem is the correct substitute, not a lookalike.
- The game-file suites fail in `beforeAll` on `clearStorage()` without an S3 endpoint on 9000. `moto` covers presigned upload and download URLs, which is what `infra/storage.ts` actually uses.

## Design notes

**Docker first, fallback second.** The hook tries `docker compose up` and only falls back when Postgres still isn't reachable. If the egress policy is relaxed later, it needs no change.

**Local machines are untouched.** It exits immediately unless `CLAUDE_CODE_REMOTE=true`, so normal development keeps using Docker.

**Idempotent.** Every step is skipped when already satisfied — re-running it is safe and fast, which matters because the container state is cached after the first run.

## `npm run test:no-docker`

Added because `npm run test` starts with `docker compose up`, and that step is precisely what aborts. The new script is the same command minus that step.

## Validation

Ran from a genuinely cold start — I stopped Postgres, MailCatcher and moto first rather than testing against services already up:

1. ✅ **Hook execution** — provisioned all three services from nothing, then re-ran and correctly reported `postgres already accepting connections`, confirming idempotency.
   - One bug found and fixed during validation: the gem's binary isn't on `PATH` under rbenv, and `gem environment gemdir` points at the user gem dir, not the executable dir. Now resolved via `ruby -e 'print Gem.bindir'`. The first run reported `WARNING: mailcatcher unavailable`, which is exactly the failure mode the hook exists to prevent, so it was worth catching.
2. ✅ **Linters** — `lint:eslint:check` and `lint:prettier:check` both pass. (`eslint` reports one pre-existing warning for an unused `Review` import in `pages/item/[slug].tsx`, unrelated and non-blocking.)
3. ✅ **Tests** — `npm run test:no-docker` ran the full suite: **508 passing, 3 failing**, the 3 being the known environmental pair documented below.

### Known non-failures

`.claude/hooks/README.md` documents these so a future session doesn't chase them:

- `api/v1/status/get.test.ts` asserts the database version is `"16.0"`, the pinned image's version. The native package reports its own patch level.
- `api/v1/items/games/steam-import/post.test.ts` needs the public Steam API, unreachable through the egress proxy, so the endpoint correctly returns 503.

Both pass in CI. **Any other failure should be treated as real.**

## Hook execution mode: synchronous

The hook runs synchronously, which is the safer default:

- **Pro:** dependencies and services are guaranteed ready before the session starts, so nothing races against a half-provisioned database.
- **Con:** session startup waits for it. First run is slower (gem and pip installs); later runs are fast because container state is cached and every step short-circuits.

Happy to switch it to async if you'd rather have faster startup and accept the race.

## After merging

Once this is on `main`, **all future web sessions pick it up automatically** — no per-session setup.

## Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📖 Documentation
- [ ] ♻️ Refactor
- [ ] 🧪 Tests
- [x] 🔧 Tooling

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] `npm run lint:eslint:check` passes
- [x] `npm run lint:prettier:check` passes
- [x] `npm run test` passes — 508/511 via `test:no-docker`, see above
- [x] Added or updated tests where relevant — n/a, tooling only

---
_Generated by [Claude Code](https://claude.ai/code/session_01Whv49dfByzLEJjor8FbRbt)_