### PR TITLE
feat: add the affiliate ledger schema and accounting core

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ The `tests/orchestrator.js` file is the core utility for test environment setup.
 - Comparing two `Decimal` instances needs `.equals()`. `toBe` compares references and always fails.
 - Never do money arithmetic in JavaScript numbers. Use the `Decimal` methods (`.mul()`, `.toDecimalPlaces()`).
 
-For how prices are resolved per currency, see [`docs/payments-architecture.md`](./docs/payments-architecture.md).
+For how prices are resolved per currency, see [`docs/payments-architecture.md`](./docs/payments-architecture.md). For how money movements are recorded — the zero-sum rule, the sign convention, and why ledger rows are never updated — see [`docs/ledger-architecture.md`](./docs/ledger-architecture.md).
 
 ### MVC Architecture
 

--- a/docs/ledger-architecture.md
+++ b/docs/ledger-architecture.md
@@ -59,6 +59,12 @@ await ledger.balancesFor(affiliateId); //  -10.0000  what the ledger holds
 await ledger.payableBalancesFor(affiliateId); //  +10.0000  what we owe them
 ```
 
+A payout run wants both the sign flip _and_ the hold, so it calls
+`maturedPayableBalancesFor()`. That function exists specifically because the
+obvious name for the number it needs — `maturedBalancesFor` — returns the raw
+ledger sign, and a payout run reaching for the obviously-named function and
+transferring a negative amount is the worst bug this model could ship.
+
 ## Balances are per currency
 
 An affiliate can hold a BRL balance and a USD balance at the same time. They are
@@ -88,7 +94,19 @@ original was still held. The matured balance would then show the commission as
 payable with nothing offsetting it — a clawback that silently claws nothing
 back. Copying the hold makes the pair cancel at the same instant.
 
-A set can only be reversed once. Further corrections are new balanced sets.
+A set can only be reversed once, and a reversal cannot itself be reversed.
+Further corrections are new balanced sets. The unique index on
+`reverses_entry_id` is what actually enforces the first rule: `reverse()` checks
+before writing, but two concurrent chargeback handlers would both pass that
+check, and a commission clawed back twice leaves the affiliate owing us money
+with no `UPDATE` available to repair it.
+
+**`isSourceReversed()` is introspection, not a payability test.** It only sees
+corrections made through `reverse()`; one written as a fresh `ADJUSTMENT` set
+carries no back-pointer and is invisible to it. The number that is always right
+is the balance — a reversal negates the original _and_ copies its `matures_at`,
+so a cancelled commission already nets to zero in `maturedPayableBalancesFor`
+without anyone having to ask.
 
 ## Referencing the source
 
@@ -171,6 +189,34 @@ and there is no `UPDATE` available to repair it.
 
 `sumByCurrency()` is exported and pure, so a caller assembling a set can check
 it balances before attempting the write.
+
+## Which accounts may name a user
+
+`AFFILIATE_COMMISSION` and `PAYOUT` must carry an `owner_id`. Every other
+account is the platform's own and must not.
+
+Both directions are enforced in `record()`, and both matter. An unowned account
+naming a storefront owner would be a database row asserting that an affiliate
+received consumer funds — the one fact the affiliate characterisation depends on
+never being true (`docs/legal/phase-0-checklist.md`). An owned account with _no_
+owner is a liability owed to nobody: balances are looked up by owner, so the row
+would sit in the books invisible to every read path.
+
+With no foreign keys, `owner_id` is also checked against `User` before the
+write, for the same reason currency codes are — an id that matches nothing
+becomes a commission that never appears in any statement or payout.
+
+## What is not modelled here
+
+- **Idempotency.** Nothing stops the same sale being recorded twice; a
+  duplicated payment webhook would write a second balanced set and the affiliate
+  would be owed double. `(source_type, source_id)` cannot simply be unique
+  because reversals share it. This needs deciding before checkout writes to the
+  ledger — see the open questions in `payments-tasks.md`.
+- **Platform-side reads.** `balancesFor` requires an owner, and all three
+  platform accounts have `owner_id NULL`, so "what was our revenue this month"
+  has no read path yet. Task 11 is affiliate-facing only, so no task currently
+  covers this.
 
 ## Currencies the ledger will accept
 

--- a/docs/ledger-architecture.md
+++ b/docs/ledger-architecture.md
@@ -1,0 +1,184 @@
+# Payments — Ledger Architecture
+
+How money movements are recorded, and the one rule everything else depends on.
+
+Delivery plan and task status live in [`payments-tasks.md`](./payments-tasks.md).
+The pricing path — how a game gets a price in the visitor's currency — is in
+[`payments-architecture.md`](./payments-architecture.md). This document covers
+the ledger only.
+
+---
+
+## The rule
+
+**A set of entries is rejected unless it sums to zero within every currency it
+touches.**
+
+That is the whole design. Money is never created or destroyed by a write, only
+moved between accounts, so a bug that loses money fails at write time instead of
+surfacing in a payout three weeks later. Everything below exists to keep that
+rule true.
+
+Two consequences worth stating plainly:
+
+- **Nothing is ever updated.** A correction is a new, negated set of entries.
+  `LedgerEntry` has no `updated_at` for the same reason `Sale` and
+  `AdminActionLog` don't.
+- **Balances are never stored.** A balance is a `SUM` over rows, computed on
+  read. A stored balance is a second source of truth that can drift from the
+  entries, and reconciling the two is a problem this design simply doesn't have.
+
+## Sign convention
+
+**Positive is money the platform received or holds. Negative is money it owes
+or has spent.**
+
+One sale of 100.00 — a code that cost 70.00, with 10.00 of affiliate
+commission:
+
+| `account_type`         | `owner_id` |    `amount` |
+| ---------------------- | ---------- | ----------: |
+| `CONSUMER_PAYMENT`     | —          | `+100.0000` |
+| `SUPPLIER_COST`        | —          |  `-70.0000` |
+| `AFFILIATE_COMMISSION` | affiliate  |  `-10.0000` |
+| `PLATFORM_REVENUE`     | —          |  `-20.0000` |
+|                        |            |  `0.0000` ✓ |
+
+A single signed column cannot make "cash in is positive" and "commission owed
+is positive" both true — under a zero-sum constraint the two have opposite
+signs, because one is an asset and the other a liability. This codebase keeps
+cash-in positive, which means **a commission balance is negative while we owe
+it.**
+
+Every user-facing read therefore flips the sign, and does it in exactly one
+place: `ledger.payableBalancesFor()`. Nothing else should negate a balance by
+hand — one call site forgetting to would pay an affiliate backwards.
+
+```ts
+await ledger.balancesFor(affiliateId); //  -10.0000  what the ledger holds
+await ledger.payableBalancesFor(affiliateId); //  +10.0000  what we owe them
+```
+
+## Balances are per currency
+
+An affiliate can hold a BRL balance and a USD balance at the same time. They are
+never added together, and `balancesFor` returns one row per currency rather than
+a single number, so there is no shape in which they could be.
+
+The zero-sum rule is per currency too. A set holding `USD +100` and `BRL -100`
+is **unbalanced**, not balanced — summing across currencies would hide exactly
+the error the rule exists to catch. Converting between them is itself a pair of
+entries carrying the rate that produced them.
+
+## Reversal, and why `matures_at` is copied
+
+A commission is held for 30 days so refunds and chargebacks can resolve
+(`matures_at`). `reverse()` writes the mirror image of a set — same accounts,
+same currency, same rate snapshot, negated amounts — with each new row naming
+the row it cancels via `reverses_entry_id`.
+
+It also copies the original's `matures_at`, which is load-bearing:
+
+```
+matured balance = SUM(amount) WHERE matures_at IS NULL OR matures_at <= now
+```
+
+A reversal with a null hold would count as immediately available while the
+original was still held. The matured balance would then show the commission as
+payable with nothing offsetting it — a clawback that silently claws nothing
+back. Copying the hold makes the pair cancel at the same instant.
+
+A set can only be reversed once. Further corrections are new balanced sets.
+
+## Referencing the source
+
+`source_type` + `source_id` is a polymorphic reference, the same shape as
+`AdminActionLog.target_type`/`target_id`. It points at a `Sale` today and will
+point at an `Order` once checkout exists.
+
+`source_type` is deliberately **not** a database enum: extending it must not
+cost a migration. The allowed values live in `LEDGER_SOURCE_TYPES` in
+`models/ledger.ts`, which is where referential integrity lives in a schema with
+no foreign keys.
+
+`account_type` **is** an enum, because a new account is a real accounting
+decision rather than a data-shape change, and the database is the only place
+integrity can be enforced without foreign keys. Adding one is a one-line
+`ALTER TYPE ADD VALUE`.
+
+## The chart of accounts
+
+| Account                | Meaning                                             |
+| ---------------------- | --------------------------------------------------- |
+| `CONSUMER_PAYMENT`     | Gross collected from a buyer; funds a sale          |
+| `SUPPLIER_COST`        | What the delivered code cost us                     |
+| `AFFILIATE_COMMISSION` | Owed to a storefront owner, held until `matures_at` |
+| `PLATFORM_REVENUE`     | What is left for the platform                       |
+| `PAYOUT`               | A commission balance actually sent to an affiliate  |
+
+Deliberately absent, and why:
+
+- **Tax withholding accounts** — the tax posture
+  ([#175](https://github.com/pedromello/manifoldpowered.com/issues/175)) is
+  unanswered, and the platform is global, so anything fiscal has to be generic
+  rather than modelled for one country. The ledger records facts; tax rules
+  decide what to do with those facts. Adding the accounts later does not reshape
+  anything.
+- **A supplier prepaid wallet** — Reloadly runs on a prefunded balance, so
+  top-ups and draws deserve their own accounts. They need a platform cash
+  account to balance against, and neither is writable until checkout exists.
+- **A processor reserve** — high-risk categories often carry a rolling reserve,
+  but the terms aren't known yet (`docs/legal/phase-0-checklist.md`).
+
+## Rounding is refused, not applied
+
+Storage is `Decimal(19,4)`. An amount carrying more scale than that is
+**rejected** rather than rounded.
+
+Rounding at write time can turn a set that validated as balanced into one that
+lands unbalanced — four entries each shaved by a hundredth of a cent net to
+something that is no longer zero. Refusing the write pushes the decision back to
+the caller, who knows which side should absorb the remainder.
+
+## What a caller writes
+
+```ts
+await ledger.record({
+  source_type: "SALE",
+  source_id: sale.id,
+  entries: [
+    { account_type: "CONSUMER_PAYMENT", amount: gross, currency: "BRL" },
+    { account_type: "SUPPLIER_COST", amount: cost.negated(), currency: "BRL" },
+    {
+      account_type: "AFFILIATE_COMMISSION",
+      owner_id: store.owner_id,
+      amount: commission.negated(),
+      currency: "BRL",
+      matures_at: maturityFor(sale),
+    },
+    {
+      account_type: "PLATFORM_REVENUE",
+      amount: revenue.negated(),
+      currency: "BRL",
+    },
+  ],
+});
+```
+
+Every row lands under one generated `entry_group_id`, in a single statement, or
+none of them do. A partially written set would break the invariant permanently,
+and there is no `UPDATE` available to repair it.
+
+`sumByCurrency()` is exported and pure, so a caller assembling a set can check
+it balances before attempting the write.
+
+## Currencies the ledger will accept
+
+Registered, or the base currency.
+
+`models/pricing` deliberately lets the platform sell in USD before any currency
+row exists, so localisation is purely additive. A ledger that disagreed would
+leave an unconfigured install unable to record a single sale.
+
+A registered but **disabled** currency is accepted too. Turning a currency off
+stops us pricing in it; it does not un-happen the sales already made in it.

--- a/docs/payments-tasks.md
+++ b/docs/payments-tasks.md
@@ -15,7 +15,9 @@ For the runtime design of the pricing path — how a game gets a price in the vi
 | 4b. Studio price override endpoints      | ✅ done                                                                        |
 | 4c. Backoffice UI for currencies + rates | ✅ done ([#186](https://github.com/pedromello/manifoldpowered.com/pull/186))   |
 | 4d. Currency selection by region header  | ✅ done ([#188](https://github.com/pedromello/manifoldpowered.com/issues/188)) |
-| 5–11 (ledger, payouts)                   | not started                                                                    |
+| 5. Ledger schema                         | ✅ done                                                                        |
+| 6. Ledger model                          | ✅ done                                                                        |
+| 7–11 (providers, payouts)                | not started                                                                    |
 
 Each task is a separate small PR, landed in order, with `npm run test` passing on its own before merge — the same format as `docs/backoffice-tasks.md`.
 
@@ -179,15 +181,17 @@ A disabled currency behaves exactly like an unregistered one, so turning a curre
 
 ---
 
-### 5. Ledger, payout account and payout schema
+### 5. Ledger schema
 
-**TLDR:** Three new tables, all money as `Decimal(19,4)`, all carrying an explicit currency, no foreign keys.
+**TLDR:** One new table, money as `Decimal(19,4)`, carrying an explicit currency, no foreign keys.
 
-`LedgerEntry` is append-only (no `updated_at`), carries a **signed** amount, and references its source polymorphically (`source_type` + `source_id`) so it can point at a `Sale` today and an `Order` later without a migration. `Payout` gets a uniqueness constraint on `(user_id, period_start, period_end)` so a re-run can't double-pay.
+**Scope narrowed during delivery.** This task originally covered three tables — `LedgerEntry`, `PayoutAccount` and `Payout`. Only `LedgerEntry` shipped here. `PayoutAccount`'s field list is exactly what the tax posture ([#175](https://github.com/pedromello/manifoldpowered.com/issues/175)) determines, so building it now would mean guessing at encrypted-at-rest tax identifiers and then migrating a table that already holds payout details. `PayoutAccount` moves to task 8 and `Payout` to task 10, which are where they are first used.
+
+`LedgerEntry` is append-only (no `updated_at`), carries a **signed** amount, and references its source polymorphically (`source_type` + `source_id`) so it can point at a `Sale` today and an `Order` later without a migration. When `Payout` lands it gets a uniqueness constraint on `(user_id, period_start, period_end)` so a re-run can't double-pay.
 
 **Every money row stores its currency, and any row produced by a conversion also stores the rate used.** Without the rate snapshot, a sale converted at last month's rate cannot be reconciled or audited later.
 
-**Done when:** migration created via `npm run migrate:create` and the suite passes.
+**Done when:** migration created via `npm run migrate:create` and the suite passes. ✅
 
 ---
 
@@ -199,7 +203,13 @@ A disabled currency behaves exactly like an unregistered one, so turning a curre
 
 Balances are **per currency**. A single affiliate can hold a BRL balance and a USD balance simultaneously; they are never silently added together.
 
-**Done when:** balance and matured-balance queries work per currency, the zero-sum rule has unit tests, and the orchestrator can seed ledger entries.
+**Done when:** balance and matured-balance queries work per currency, the zero-sum rule has unit tests, and the orchestrator can seed ledger entries. ✅
+
+The runtime design — the sign convention, why a reversal copies `matures_at`, and why over-scale amounts are refused rather than rounded — is documented in [`ledger-architecture.md`](./ledger-architecture.md).
+
+**Decided while building this.** A single signed column cannot make both "cash in is positive" and "commission owed is positive" true under a zero-sum rule, because one is an asset and the other a liability. Cash-in stays positive, so **a commission balance is negative while it is owed**, and `ledger.payableBalancesFor()` is the single place that sign is flipped for anything a person reads. The shorthand in the "One sale, end to end" diagram above (`supplier_cost −, platform_revenue +, affiliate_commission +`) predates that decision and was never a complete balanced set.
+
+**Still open, and it belongs to task 10 rather than here.** The 30-day hold is a per-sale rolling maturation (`matures_at`), while Steam — the model this is patterned on — pays a fixed date after a calendar month closes: month M's sales are paid on M+1's 30th, so the hold varies from 30 to 60 days per sale and 30 days is the floor. Run a monthly payout against a rolling 30-day maturation and the two produce nearly identical payment dates, so nothing here needs to change. What differs is which statement a sale lands on: a calendar-month period keyed on sale date is far easier for an affiliate to reconcile than "everything that happened to mature since the last run". `matures_at` records _when a commission is safe to pay_ and stays independent of whichever rule computes it, so task 10 can choose the period without touching the ledger.
 
 ---
 

--- a/docs/payments-tasks.md
+++ b/docs/payments-tasks.md
@@ -96,7 +96,7 @@ sequenceDiagram
     M->>S: Order gift card
     S-->>M: Redeem code
     M-->>C: Reveal code (timestamp recorded)
-    M->>L: supplier_cost −, platform_revenue +,<br/>affiliate_commission + (matures_at = now + 30d)
+    M->>L: consumer_payment +, supplier_cost −,<br/>affiliate_commission − (matures_at = now + 30d),<br/>platform_revenue −
     Note over L: Entries must sum to zero, per currency
 
     alt Chargeback within 30 days
@@ -207,7 +207,9 @@ Balances are **per currency**. A single affiliate can hold a BRL balance and a U
 
 The runtime design — the sign convention, why a reversal copies `matures_at`, and why over-scale amounts are refused rather than rounded — is documented in [`ledger-architecture.md`](./ledger-architecture.md).
 
-**Decided while building this.** A single signed column cannot make both "cash in is positive" and "commission owed is positive" true under a zero-sum rule, because one is an asset and the other a liability. Cash-in stays positive, so **a commission balance is negative while it is owed**, and `ledger.payableBalancesFor()` is the single place that sign is flipped for anything a person reads. The shorthand in the "One sale, end to end" diagram above (`supplier_cost −, platform_revenue +, affiliate_commission +`) predates that decision and was never a complete balanced set.
+**Decided while building this.** A single signed column cannot make both "cash in is positive" and "commission owed is positive" true under a zero-sum rule, because one is an asset and the other a liability. Cash-in stays positive, so **a commission balance is negative while it is owed**, and `ledger.payableBalancesFor()` is the single place that sign is flipped for anything a person reads. The "One sale, end to end" diagram above has been corrected to match — its earlier shorthand (`supplier_cost −, platform_revenue +, affiliate_commission +`) omitted the consumer payment and so was never a complete balanced set.
+
+**Also decided here, and provisionally.** Commission is booked as a liability at the moment of sale, which means `PLATFORM_REVENUE` holds the residual margin rather than gross revenue. `docs/legal/business-description.md` describes commission as "an ordinary marketing expense" paid out of Manifold's own revenue, and phase-0 item 3 asks counsel to settle accrued-liability versus unearned treatment. Accruing at sale is the only option that lets the set balance at write time, but the account name and the disclosure wording should be reconciled once that answer lands.
 
 **Still open, and it belongs to task 10 rather than here.** The 30-day hold is a per-sale rolling maturation (`matures_at`), while Steam — the model this is patterned on — pays a fixed date after a calendar month closes: month M's sales are paid on M+1's 30th, so the hold varies from 30 to 60 days per sale and 30 days is the floor. Run a monthly payout against a rolling 30-day maturation and the two produce nearly identical payment dates, so nothing here needs to change. What differs is which statement a sale lands on: a calendar-month period keyed on sale date is far easier for an affiliate to reconcile than "everything that happened to mature since the last run". `matures_at` records _when a commission is safe to pay_ and stays independent of whichever rule computes it, so task 10 can choose the period without touching the ledger.
 
@@ -331,10 +333,12 @@ Responses gain `display_price` (`amount`, `base_amount`, `currency`, `symbol`) a
 
 ## Open questions
 
-1. **FX cost bearer** — when a sale is collected in BRL and commission is paid in USD, who absorbs the conversion spread? Currently assigned to the affiliate in the agreement draft.
-2. **Rate staleness** — how old is too old? A rate table with no freshness policy will eventually sell something at a two-month-old rate.
-3. **Scope** — ledger and payouts first, with checkout and an `Order` model later. Is the polymorphic source reference the right seam?
-4. **Tax fields** — deferred until the tax position is written, with payouts hard-gated meanwhile.
-5. **Scheduling** — batch jobs are manually triggered (script / workflow / admin endpoint) because there's no scheduler.
+0. **Write idempotency** — nothing prevents the same sale being recorded to the ledger twice, so a duplicated payment webhook would owe an affiliate double. `(source_type, source_id)` cannot be unique because reversals share it. Raised during task 5 and deliberately not guessed at: it is a schema decision, so it wants settling before checkout writes the first real entry.
+1. **Platform-side reporting** — balances are read per owner, and platform accounts have no owner, so there is no read path for platform revenue or supplier cost. Task 11 is affiliate-facing only, so no task currently covers it.
+2. **FX cost bearer** — when a sale is collected in BRL and commission is paid in USD, who absorbs the conversion spread? Currently assigned to the affiliate in the agreement draft.
+3. **Rate staleness** — how old is too old? A rate table with no freshness policy will eventually sell something at a two-month-old rate.
+4. **Scope** — ledger and payouts first, with checkout and an `Order` model later. Is the polymorphic source reference the right seam?
+5. **Tax fields** — deferred until the tax position is written, with payouts hard-gated meanwhile.
+6. **Scheduling** — batch jobs are manually triggered (script / workflow / admin endpoint) because there's no scheduler.
 
 **Resolved:** money representation is `Decimal(19,4)`; USD is the base currency; price resolution is override-first with conversion as fallback.

--- a/models/ledger.ts
+++ b/models/ledger.ts
@@ -1,0 +1,506 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "infra/database";
+import { z } from "zod";
+import { LedgerAccountType, Prisma } from "generated/prisma/client";
+import { NotFoundError, ValidationError } from "infra/errors";
+import currency, { currencyCodeSchema } from "models/currency";
+import { BASE_CURRENCY } from "models/pricing";
+
+// Storage is Decimal(19,4). Amounts are rejected rather than rounded when they
+// carry more scale than this, because rounding at write time can turn a set
+// that validated as balanced into one that lands unbalanced — the exact class
+// of bug the zero-sum rule exists to catch.
+const MONEY_SCALE = 4;
+
+const ledgerAccountTypeValues = [
+  "CONSUMER_PAYMENT",
+  "SUPPLIER_COST",
+  "AFFILIATE_COMMISSION",
+  "PLATFORM_REVENUE",
+  "PAYOUT",
+] as const;
+
+// What a set of entries can point at. A plain string column rather than an
+// enum, so pointing at an Order once checkout exists costs no migration. The
+// list is enforced here instead, which is where referential integrity lives in
+// a schema with no foreign keys.
+export const LEDGER_SOURCE_TYPES = ["SALE", "PAYOUT", "ADJUSTMENT"] as const;
+
+export type LedgerSourceType = (typeof LEDGER_SOURCE_TYPES)[number];
+
+// What a caller may hand us for a money amount or a rate.
+export type DecimalInput = Prisma.Decimal | number | string;
+
+function isDecimalLike(value: number | string) {
+  try {
+    new Prisma.Decimal(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// A Prisma.Decimal is accepted from callers but converted to its string form
+// before validation. Putting the class itself into a Zod union widens the
+// inferred input to `unknown`, which makes every field alongside it look
+// optional — so the conversion happens here and the schemas stay over
+// number | string.
+function toDecimalInput(value: unknown) {
+  return value instanceof Prisma.Decimal ? value.toFixed() : value;
+}
+
+// Validation happens on the raw input and the transform comes last, so the
+// schema's input type stays number | string. Ending on a refine instead would
+// leave Zod unable to infer that input, and every field sharing the object
+// with it would silently become optional.
+const ledgerAmountSchema = z
+  .union([z.number(), z.string()])
+  .superRefine((value, ctx) => {
+    if (!isDecimalLike(value)) {
+      ctx.addIssue({ code: "custom", message: "amount must be a number" });
+      return;
+    }
+
+    const amount = new Prisma.Decimal(value);
+
+    if (!amount.isFinite()) {
+      ctx.addIssue({ code: "custom", message: "amount must be finite" });
+      return;
+    }
+
+    // A zero entry is trivially balanced and moves nothing, so it is always a
+    // mistake — usually a commission that should not have been written at all.
+    if (amount.isZero()) {
+      ctx.addIssue({ code: "custom", message: "amount must not be zero" });
+    }
+
+    if (amount.decimalPlaces() > MONEY_SCALE) {
+      ctx.addIssue({
+        code: "custom",
+        message: `amount must have at most ${MONEY_SCALE} decimal places`,
+      });
+    }
+  })
+  .transform((value) => new Prisma.Decimal(value));
+
+const exchangeRateSchema = z
+  .union([z.number(), z.string()])
+  .superRefine((value, ctx) => {
+    if (!isDecimalLike(value)) {
+      ctx.addIssue({
+        code: "custom",
+        message: "exchange_rate must be a number",
+      });
+      return;
+    }
+
+    const rate = new Prisma.Decimal(value);
+
+    if (!rate.isFinite() || !rate.isPositive()) {
+      ctx.addIssue({
+        code: "custom",
+        message: "exchange_rate must be a positive number",
+      });
+    }
+  })
+  .transform((value) => new Prisma.Decimal(value));
+
+export const ledgerEntrySchema = z
+  .object({
+    account_type: z.enum(ledgerAccountTypeValues),
+    // Null for platform accounts, which belong to no user.
+    owner_id: z.uuid().nullish().default(null),
+    amount: ledgerAmountSchema,
+    currency: currencyCodeSchema,
+    exchange_rate: exchangeRateSchema.nullish().default(null),
+    exchange_rate_from_currency: currencyCodeSchema.nullish().default(null),
+    // Null means the amount is available immediately, with no hold.
+    matures_at: z.coerce.date().nullish().default(null),
+    description: z.string().trim().min(1).max(255).nullish().default(null),
+  })
+  .refine(
+    (entry) =>
+      (entry.exchange_rate === null) ===
+      (entry.exchange_rate_from_currency === null),
+    {
+      message:
+        "exchange_rate and exchange_rate_from_currency must be set together",
+      path: ["exchange_rate"],
+    },
+  )
+  .refine((entry) => entry.exchange_rate_from_currency !== entry.currency, {
+    message: "exchange_rate_from_currency must differ from currency",
+    path: ["exchange_rate_from_currency"],
+  });
+
+// Widened from the schema's input so callers can pass the Prisma.Decimal they
+// already hold — a converted price, a commission from .mul() — without
+// stringifying it first.
+export type LedgerEntryDto = Omit<
+  z.input<typeof ledgerEntrySchema>,
+  "amount" | "exchange_rate"
+> & {
+  amount: DecimalInput;
+  exchange_rate?: DecimalInput | null;
+};
+
+export const recordLedgerEntriesSchema = z.object({
+  source_type: z.enum(LEDGER_SOURCE_TYPES),
+  source_id: z.string().trim().min(1),
+  // Every entry in a set must balance against the others, and a single entry
+  // can only do that by being zero — which is already rejected above.
+  entries: z
+    .array(ledgerEntrySchema)
+    .min(2, "a balanced set needs at least two entries"),
+});
+
+export interface RecordLedgerEntriesDto {
+  source_type: LedgerSourceType;
+  source_id: string;
+  entries: LedgerEntryDto[];
+}
+
+// What the schema produces once parsed. Spelled out rather than inferred:
+// this project compiles with strictNullChecks off, and Zod decides a piped
+// schema's key is optional by asking whether `undefined` extends its output —
+// which is true of everything under that setting. `amount` would come back
+// optional despite the schema requiring it, so the shape is declared here and
+// the parse result is narrowed to it.
+interface ParsedLedgerEntry {
+  account_type: LedgerAccountType;
+  owner_id: string | null;
+  amount: Prisma.Decimal;
+  currency: string;
+  exchange_rate: Prisma.Decimal | null;
+  exchange_rate_from_currency: string | null;
+  matures_at: Date | null;
+  description: string | null;
+}
+
+export interface CurrencyBalance {
+  currency: string;
+  amount: Prisma.Decimal;
+}
+
+interface BalanceOptions {
+  // Defaults to the commission account because that is the only balance an
+  // affiliate holds. Pass PAYOUT to see what has been settled to them instead.
+  account_type?: LedgerAccountType;
+  matured_only?: boolean;
+  as_of?: Date;
+}
+
+// Totals a set of entries per currency. Pure, so a caller assembling a set can
+// check it balances before attempting the write — and so the invariant itself
+// is testable without a database.
+export function sumByCurrency(
+  entries: Array<{ amount: Prisma.Decimal; currency: string }>,
+): Map<string, Prisma.Decimal> {
+  const totals = new Map<string, Prisma.Decimal>();
+
+  for (const entry of entries) {
+    const normalizedCode = currency.normalizeCode(entry.currency);
+    const runningTotal = totals.get(normalizedCode) ?? new Prisma.Decimal(0);
+
+    totals.set(normalizedCode, runningTotal.add(entry.amount));
+  }
+
+  return totals;
+}
+
+// Writes one balanced set of entries. The set is rejected unless it sums to
+// zero within every currency it touches, which is what makes the ledger
+// auditable: money is never created or destroyed by a write, only moved, and a
+// bug that loses money fails here rather than in a payout weeks later.
+//
+// Currencies are never mixed in a single sum. A set spanning BRL and USD must
+// balance in each independently — the conversion between them is itself a pair
+// of entries carrying the rate that produced it.
+async function record(recordDto: RecordLedgerEntriesDto) {
+  const result = recordLedgerEntriesSchema.safeParse({
+    ...recordDto,
+    entries: (recordDto.entries ?? []).map((entry) => ({
+      ...entry,
+      amount: toDecimalInput(entry.amount),
+      exchange_rate: toDecimalInput(entry.exchange_rate),
+    })),
+  });
+
+  if (!result.success) {
+    throw new ValidationError({
+      message: "One or more ledger entries are invalid",
+      action: "Check the fields and try again",
+      context: result.error.issues,
+    });
+  }
+
+  const { source_type, source_id } = result.data;
+  const entries = result.data.entries as ParsedLedgerEntry[];
+
+  // Balance first: it is pure, and an unbalanced set is never worth a database
+  // round trip to check its currencies.
+  assertBalanced(entries);
+
+  await validateCurrenciesAreRecordable(
+    entries.flatMap((entry) =>
+      [entry.currency, entry.exchange_rate_from_currency].filter(
+        (code): code is string => code !== null,
+      ),
+    ),
+  );
+
+  const entryGroupId = randomUUID();
+
+  return await prisma.ledgerEntry.createManyAndReturn({
+    data: entries.map((entry) => ({
+      entry_group_id: entryGroupId,
+      account_type: entry.account_type,
+      owner_id: entry.owner_id,
+      amount: entry.amount,
+      currency: currency.normalizeCode(entry.currency),
+      exchange_rate: entry.exchange_rate,
+      exchange_rate_from_currency: entry.exchange_rate_from_currency,
+      source_type,
+      source_id,
+      matures_at: entry.matures_at,
+      description: entry.description,
+    })),
+  });
+}
+
+// Undoes a set by writing its mirror image, never by touching the original.
+// History stays intact and the reversal is itself auditable: the two sets
+// together sum to zero, and every new row names the row it cancels.
+//
+// The reversal keeps the original's source, currency, rate snapshot and
+// matures_at. Copying matures_at is what makes a clawback work — a null there
+// would count the reversal as immediately available while the original was
+// still held, so a matured-balance query would show the commission as payable
+// with nothing offsetting it.
+async function reverse(
+  entryGroupId: string,
+  { description }: { description?: string } = {},
+) {
+  const originalEntries = await findByGroup(entryGroupId);
+
+  if (originalEntries.length === 0) {
+    throw new NotFoundError({
+      message: `No ledger entries were found for the group "${entryGroupId}".`,
+      action: "Check the entry group id and try again.",
+    });
+  }
+
+  const alreadyReversed = await prisma.ledgerEntry.findFirst({
+    where: {
+      reverses_entry_id: { in: originalEntries.map((entry) => entry.id) },
+    },
+  });
+
+  if (alreadyReversed) {
+    throw new ValidationError({
+      message: `The ledger entry group "${entryGroupId}" has already been reversed.`,
+      action:
+        "Record a new balanced set if a further correction is needed, rather than reversing this one twice.",
+    });
+  }
+
+  const reversalGroupId = randomUUID();
+
+  const reversalEntries = originalEntries.map((entry) => ({
+    entry_group_id: reversalGroupId,
+    account_type: entry.account_type,
+    owner_id: entry.owner_id,
+    amount: entry.amount.negated(),
+    currency: entry.currency,
+    exchange_rate: entry.exchange_rate,
+    exchange_rate_from_currency: entry.exchange_rate_from_currency,
+    source_type: entry.source_type,
+    source_id: entry.source_id,
+    matures_at: entry.matures_at,
+    reverses_entry_id: entry.id,
+    description:
+      description ?? `Reversal of ${entry.description ?? entry.account_type}`,
+  }));
+
+  // Negating a balanced set cannot unbalance it, but the invariant is cheap to
+  // re-check and this is the one place entries are written without going
+  // through record().
+  assertBalanced(reversalEntries);
+
+  return await prisma.ledgerEntry.createManyAndReturn({
+    data: reversalEntries,
+  });
+}
+
+// Signed balances straight from the ledger, one row per currency. Never summed
+// across currencies: an affiliate can hold a BRL balance and a USD balance at
+// once and they are not comparable, let alone addable.
+//
+// Under the sign convention these are negative while the platform owes them.
+// Use payableBalancesFor for anything user-facing.
+async function balancesFor(
+  ownerId: string,
+  {
+    account_type = LedgerAccountType.AFFILIATE_COMMISSION,
+    matured_only = false,
+    as_of = new Date(),
+  }: BalanceOptions = {},
+): Promise<CurrencyBalance[]> {
+  const where: Prisma.LedgerEntryWhereInput = {
+    owner_id: ownerId,
+    account_type,
+  };
+
+  if (matured_only) {
+    // A null hold means the amount was never held in the first place, so it
+    // has always been matured.
+    where.OR = [{ matures_at: null }, { matures_at: { lte: as_of } }];
+  }
+
+  const grouped = await prisma.ledgerEntry.groupBy({
+    by: ["currency"],
+    where,
+    _sum: { amount: true },
+    orderBy: { currency: "asc" },
+  });
+
+  return grouped.map((row) => ({
+    currency: row.currency,
+    amount: row._sum.amount ?? new Prisma.Decimal(0),
+  }));
+}
+
+// The signed balance in one currency. Zero when the owner has no entries in it,
+// so callers never have to distinguish "no rows" from "nets to nothing".
+async function balanceFor(
+  ownerId: string,
+  currencyCode: string,
+  options: BalanceOptions = {},
+): Promise<Prisma.Decimal> {
+  const normalizedCode = currency.normalizeCode(currencyCode);
+  const balances = await balancesFor(ownerId, options);
+
+  return (
+    balances.find((balance) => balance.currency === normalizedCode)?.amount ??
+    new Prisma.Decimal(0)
+  );
+}
+
+// Only what has cleared its hold. This is the number a payout run may pay
+// against; the rest is still inside the window where a refund or chargeback
+// can take it back.
+async function maturedBalancesFor(
+  ownerId: string,
+  options: Omit<BalanceOptions, "matured_only"> = {},
+): Promise<CurrencyBalance[]> {
+  return await balancesFor(ownerId, { ...options, matured_only: true });
+}
+
+// The single place the sign is flipped for anything a person reads.
+//
+// The ledger stores what the platform holds, so a commission it owes is
+// negative there. An affiliate looking at their statement expects the opposite,
+// and a payout run expects to transfer a positive amount. Every such caller
+// goes through here rather than negating by hand, because one call site
+// forgetting to would pay backwards.
+async function payableBalancesFor(
+  ownerId: string,
+  options: BalanceOptions = {},
+): Promise<CurrencyBalance[]> {
+  const balances = await balancesFor(ownerId, options);
+
+  return balances.map((balance) => ({
+    currency: balance.currency,
+    amount: balance.amount.negated(),
+  }));
+}
+
+async function findByGroup(entryGroupId: string) {
+  return await prisma.ledgerEntry.findMany({
+    where: { entry_group_id: entryGroupId },
+    orderBy: { created_at: "asc" },
+  });
+}
+
+// Everything ever written about one source, reversals included, since a
+// reversal keeps the source of the set it cancels.
+async function findBySource(sourceType: string, sourceId: string) {
+  return await prisma.ledgerEntry.findMany({
+    where: { source_type: sourceType, source_id: sourceId },
+    orderBy: { created_at: "asc" },
+  });
+}
+
+// Whether anything written against this source has since been reversed. The
+// maturation job uses this to decide a commission is safe to pay.
+async function isSourceReversed(sourceType: string, sourceId: string) {
+  const reversal = await prisma.ledgerEntry.findFirst({
+    where: {
+      source_type: sourceType,
+      source_id: sourceId,
+      reverses_entry_id: { not: null },
+    },
+    select: { id: true },
+  });
+
+  return reversal !== null;
+}
+
+// The invariant. Every currency in the set must net to exactly zero.
+function assertBalanced(
+  entries: Array<{ amount: Prisma.Decimal; currency: string }>,
+) {
+  const totals = sumByCurrency(entries);
+
+  const unbalanced = [...totals.entries()]
+    .filter(([, total]) => !total.isZero())
+    .map(([code, total]) => `${code} ${total.toFixed(MONEY_SCALE)}`);
+
+  if (unbalanced.length > 0) {
+    throw new ValidationError({
+      message: `Ledger entries must sum to zero within each currency, but this set left ${unbalanced.join(", ")}.`,
+      action:
+        "Add the missing entries so every currency in the set nets to zero, and try again.",
+    });
+  }
+}
+
+// No foreign keys, so a currency code that matches nothing would become a row
+// that silently never appears in any balance.
+//
+// The base currency is accepted whether or not it has been registered, exactly
+// as models/pricing treats it. The platform sells in USD before any currency
+// is configured, so a ledger that refused to record those sales would make an
+// unconfigured install unable to write a single entry. A registered but
+// disabled currency is fine too: turning a currency off stops us pricing in it,
+// it does not un-happen the sales already made in it.
+async function validateCurrenciesAreRecordable(codes: string[]) {
+  const codesToCheck = codes.filter(
+    (code) => currency.normalizeCode(code) !== BASE_CURRENCY,
+  );
+
+  const unregisteredCodes = await currency.findUnregisteredCodes(codesToCheck);
+
+  if (unregisteredCodes.length > 0) {
+    throw new ValidationError({
+      message: `The following currencies are not registered: ${unregisteredCodes.join(", ")}.`,
+      action: "Register the currency before recording ledger entries in it.",
+    });
+  }
+}
+
+const ledger = {
+  LEDGER_SOURCE_TYPES,
+  record,
+  reverse,
+  balancesFor,
+  balanceFor,
+  maturedBalancesFor,
+  payableBalancesFor,
+  findByGroup,
+  findBySource,
+  isSourceReversed,
+  sumByCurrency,
+};
+
+export default ledger;

--- a/models/ledger.ts
+++ b/models/ledger.ts
@@ -12,13 +12,38 @@ import { BASE_CURRENCY } from "models/pricing";
 // of bug the zero-sum rule exists to catch.
 const MONEY_SCALE = 4;
 
-const ledgerAccountTypeValues = [
-  "CONSUMER_PAYMENT",
-  "SUPPLIER_COST",
-  "AFFILIATE_COMMISSION",
-  "PLATFORM_REVENUE",
-  "PAYOUT",
-] as const;
+// Exchange rates are Decimal(19,8) and are refused past that scale for the same
+// reason: a rate silently rounded on the way in no longer reproduces the amount
+// it converted, which is exactly what the snapshot exists to allow.
+const RATE_SCALE = 8;
+
+// How long a commission is held after payment so refunds and chargebacks can
+// resolve. This is a control the payment processor disclosure relies on
+// (docs/legal/business-description.md), so it lives here rather than being
+// picked separately by each caller that writes a commission.
+export const COMMISSION_HOLD_DAYS = 30;
+
+// Upper bounds, so an out-of-range amount fails as a ValidationError here
+// instead of as a numeric overflow from Postgres. Decimal(19,4) leaves 15
+// integer digits; these sit well inside that and match the ceilings already
+// used by models/pricing and models/exchange_rate.
+const MAX_AMOUNT = 1_000_000_000_000;
+const MAX_RATE = 1_000_000_000;
+
+// Descriptions are VarChar(255). A derived reversal description is truncated to
+// fit rather than being allowed to overflow the column, which would surface as
+// an unhandled Postgres 22001 rather than anything a caller could act on.
+const MAX_DESCRIPTION_LENGTH = 255;
+
+// Accounts that belong to a specific user. Every other account is the
+// platform's own and must carry no owner: a CONSUMER_PAYMENT row naming a
+// storefront owner would be a record asserting an affiliate received consumer
+// funds, which is the single fact the affiliate characterisation depends on
+// never being true (docs/legal/phase-0-checklist.md).
+const OWNED_ACCOUNT_TYPES: LedgerAccountType[] = [
+  LedgerAccountType.AFFILIATE_COMMISSION,
+  LedgerAccountType.PAYOUT,
+];
 
 // What a set of entries can point at. A plain string column rather than an
 // enum, so pointing at an Order once checkout exists costs no migration. The
@@ -80,10 +105,17 @@ const ledgerAmountSchema = z
         message: `amount must have at most ${MONEY_SCALE} decimal places`,
       });
     }
+
+    if (amount.abs().greaterThan(MAX_AMOUNT)) {
+      ctx.addIssue({
+        code: "custom",
+        message: `amount must be between -${MAX_AMOUNT} and ${MAX_AMOUNT}`,
+      });
+    }
   })
   .transform((value) => new Prisma.Decimal(value));
 
-const exchangeRateSchema = z
+const ledgerExchangeRateSchema = z
   .union([z.number(), z.string()])
   .superRefine((value, ctx) => {
     if (!isDecimalLike(value)) {
@@ -101,18 +133,36 @@ const exchangeRateSchema = z
         code: "custom",
         message: "exchange_rate must be a positive number",
       });
+      return;
+    }
+
+    if (rate.decimalPlaces() > RATE_SCALE) {
+      ctx.addIssue({
+        code: "custom",
+        message: `exchange_rate must have at most ${RATE_SCALE} decimal places`,
+      });
+    }
+
+    if (rate.greaterThan(MAX_RATE)) {
+      ctx.addIssue({
+        code: "custom",
+        message: `exchange_rate must not exceed ${MAX_RATE}`,
+      });
     }
   })
   .transform((value) => new Prisma.Decimal(value));
 
 export const ledgerEntrySchema = z
   .object({
-    account_type: z.enum(ledgerAccountTypeValues),
+    // Taken from the generated enum rather than a hand-copied list, so adding
+    // an account really is just ALTER TYPE plus a regenerate. A duplicated list
+    // would leave the database accepting a value that record() then rejects.
+    account_type: z.enum(LedgerAccountType),
     // Null for platform accounts, which belong to no user.
     owner_id: z.uuid().nullish().default(null),
     amount: ledgerAmountSchema,
     currency: currencyCodeSchema,
-    exchange_rate: exchangeRateSchema.nullish().default(null),
+    exchange_rate: ledgerExchangeRateSchema.nullish().default(null),
     exchange_rate_from_currency: currencyCodeSchema.nullish().default(null),
     // Null means the amount is available immediately, with no hold.
     matures_at: z.coerce.date().nullish().default(null),
@@ -187,13 +237,16 @@ interface BalanceOptions {
   // affiliate holds. Pass PAYOUT to see what has been settled to them instead.
   account_type?: LedgerAccountType;
   matured_only?: boolean;
-  as_of?: Date;
+  // Named for what it does: it only has an effect when matured_only is set.
+  // A plain `as_of` would read like a point-in-time balance, which this model
+  // cannot produce.
+  matured_as_of?: Date;
 }
 
 // Totals a set of entries per currency. Pure, so a caller assembling a set can
 // check it balances before attempting the write — and so the invariant itself
 // is testable without a database.
-export function sumByCurrency(
+function sumByCurrency(
   entries: Array<{ amount: Prisma.Decimal; currency: string }>,
 ): Map<string, Prisma.Decimal> {
   const totals = new Map<string, Prisma.Decimal>();
@@ -237,9 +290,9 @@ async function record(recordDto: RecordLedgerEntriesDto) {
   const { source_type, source_id } = result.data;
   const entries = result.data.entries as ParsedLedgerEntry[];
 
-  // Balance first: it is pure, and an unbalanced set is never worth a database
-  // round trip to check its currencies.
+  // Pure checks first: neither is worth a database round trip to discover.
   assertBalanced(entries);
+  assertOwnershipMatchesAccounts(entries);
 
   await validateCurrenciesAreRecordable(
     entries.flatMap((entry) =>
@@ -247,6 +300,12 @@ async function record(recordDto: RecordLedgerEntriesDto) {
         (code): code is string => code !== null,
       ),
     ),
+  );
+
+  await validateOwnersExist(
+    entries
+      .map((entry) => entry.owner_id)
+      .filter((ownerId): ownerId is string => ownerId !== null),
   );
 
   const entryGroupId = randomUUID();
@@ -257,7 +316,9 @@ async function record(recordDto: RecordLedgerEntriesDto) {
       account_type: entry.account_type,
       owner_id: entry.owner_id,
       amount: entry.amount,
-      currency: currency.normalizeCode(entry.currency),
+      // Already uppercased by currencyCodeSchema, on both this and the
+      // exchange_rate_from_currency below.
+      currency: entry.currency,
       exchange_rate: entry.exchange_rate,
       exchange_rate_from_currency: entry.exchange_rate_from_currency,
       source_type,
@@ -290,6 +351,17 @@ async function reverse(
     });
   }
 
+  // Reversing a reversal would reinstate the original set while leaving every
+  // "has this been reversed" check still answering yes. A correction on top of
+  // a correction is a new balanced set, not another mirror.
+  if (originalEntries.some((entry) => entry.reverses_entry_id)) {
+    throw new ValidationError({
+      message: `The ledger entry group "${entryGroupId}" is itself a reversal and cannot be reversed.`,
+      action:
+        "Record a new balanced set to correct this, rather than reversing a reversal.",
+    });
+  }
+
   const alreadyReversed = await prisma.ledgerEntry.findFirst({
     where: {
       reverses_entry_id: { in: originalEntries.map((entry) => entry.id) },
@@ -318,8 +390,12 @@ async function reverse(
     source_id: entry.source_id,
     matures_at: entry.matures_at,
     reverses_entry_id: entry.id,
-    description:
-      description ?? `Reversal of ${entry.description ?? entry.account_type}`,
+    // Truncated, not left to overflow: an original sitting near the 255-char
+    // limit would otherwise push the derived text past the column and fail the
+    // whole reversal on a Postgres 22001.
+    description: (
+      description ?? `Reversal of ${entry.description ?? entry.account_type}`
+    ).slice(0, MAX_DESCRIPTION_LENGTH),
   }));
 
   // Negating a balanced set cannot unbalance it, but the invariant is cheap to
@@ -327,9 +403,28 @@ async function reverse(
   // through record().
   assertBalanced(reversalEntries);
 
-  return await prisma.ledgerEntry.createManyAndReturn({
-    data: reversalEntries,
-  });
+  try {
+    return await prisma.ledgerEntry.createManyAndReturn({
+      data: reversalEntries,
+    });
+  } catch (error) {
+    // The check above is read-then-write, so two concurrent chargeback
+    // handlers can both find no reversal and both try to write one. The
+    // unique index on reverses_entry_id is what actually stops the second.
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      throw new ValidationError({
+        message: `The ledger entry group "${entryGroupId}" has already been reversed.`,
+        action:
+          "Record a new balanced set if a further correction is needed, rather than reversing this one twice.",
+        cause: error,
+      });
+    }
+
+    throw error;
+  }
 }
 
 // Signed balances straight from the ledger, one row per currency. Never summed
@@ -343,9 +438,20 @@ async function balancesFor(
   {
     account_type = LedgerAccountType.AFFILIATE_COMMISSION,
     matured_only = false,
-    as_of = new Date(),
+    matured_as_of = new Date(),
   }: BalanceOptions = {},
 ): Promise<CurrencyBalance[]> {
+  // Prisma drops an undefined field from `where`, so a missing owner id would
+  // silently widen this to every owner plus every platform row and return a
+  // number that looks like a balance. strictNullChecks is off here, so nothing
+  // upstream would have caught it.
+  if (!ownerId) {
+    throw new ValidationError({
+      message: "An owner id is required to read a ledger balance.",
+      action: "Pass the id of the user whose balance you want.",
+    });
+  }
+
   const where: Prisma.LedgerEntryWhereInput = {
     owner_id: ownerId,
     account_type,
@@ -354,7 +460,7 @@ async function balancesFor(
   if (matured_only) {
     // A null hold means the amount was never held in the first place, so it
     // has always been matured.
-    where.OR = [{ matures_at: null }, { matures_at: { lte: as_of } }];
+    where.OR = [{ matures_at: null }, { matures_at: { lte: matured_as_of } }];
   }
 
   const grouped = await prisma.ledgerEntry.groupBy({
@@ -396,6 +502,21 @@ async function maturedBalancesFor(
   return await balancesFor(ownerId, { ...options, matured_only: true });
 }
 
+// When a commission paid at `paidAt` becomes payable. The hold is the
+// platform's chargeback defence, so the length lives in one constant rather
+// than being restated by every caller that writes a commission entry.
+//
+// This answers "when is this safe to pay", which is independent of which
+// statement period the payment eventually lands in — that is the payout run's
+// decision and does not change this column.
+function maturityFor(paidAt: Date = new Date()): Date {
+  const maturesAt = new Date(paidAt.getTime());
+
+  maturesAt.setUTCDate(maturesAt.getUTCDate() + COMMISSION_HOLD_DAYS);
+
+  return maturesAt;
+}
+
 // The single place the sign is flipped for anything a person reads.
 //
 // The ledger stores what the platform holds, so a commission it owes is
@@ -403,6 +524,9 @@ async function maturedBalancesFor(
 // and a payout run expects to transfer a positive amount. Every such caller
 // goes through here rather than negating by hand, because one call site
 // forgetting to would pay backwards.
+// Note the account_type option reads differently here: a negated PAYOUT balance
+// means "already sent to them", not "owed to them". Only AFFILIATE_COMMISSION —
+// the default — reads as a debt.
 async function payableBalancesFor(
   ownerId: string,
   options: BalanceOptions = {},
@@ -415,25 +539,53 @@ async function payableBalancesFor(
   }));
 }
 
+// What a payout run may actually pay: cleared its hold, and signed the way a
+// person expects.
+//
+// This exists because the obvious name for that number is maturedBalancesFor,
+// which returns the raw ledger sign — negative while owed. A payout run
+// reaching for the obviously-named function and transferring a negative amount
+// is the worst bug this model could ship, so the convenient name is also the
+// safe one.
+async function maturedPayableBalancesFor(
+  ownerId: string,
+  options: Omit<BalanceOptions, "matured_only"> = {},
+): Promise<CurrencyBalance[]> {
+  return await payableBalancesFor(ownerId, { ...options, matured_only: true });
+}
+
 async function findByGroup(entryGroupId: string) {
   return await prisma.ledgerEntry.findMany({
     where: { entry_group_id: entryGroupId },
-    orderBy: { created_at: "asc" },
+    // Every row in a set shares one CURRENT_TIMESTAMP, so created_at alone is a
+    // total tie and the returned order would be whatever the heap gives back.
+    orderBy: [{ created_at: "asc" }, { id: "asc" }],
   });
 }
 
 // Everything ever written about one source, reversals included, since a
 // reversal keeps the source of the set it cancels.
-async function findBySource(sourceType: string, sourceId: string) {
+async function findBySource(sourceType: LedgerSourceType, sourceId: string) {
   return await prisma.ledgerEntry.findMany({
     where: { source_type: sourceType, source_id: sourceId },
-    orderBy: { created_at: "asc" },
+    // Every row in a set shares one CURRENT_TIMESTAMP, so created_at alone is a
+    // total tie and the returned order would be whatever the heap gives back.
+    orderBy: [{ created_at: "asc" }, { id: "asc" }],
   });
 }
 
-// Whether anything written against this source has since been reversed. The
-// maturation job uses this to decide a commission is safe to pay.
-async function isSourceReversed(sourceType: string, sourceId: string) {
+// Whether anything written against this source was cancelled by reverse().
+//
+// This is introspection, not a payability test, and must not be used as one.
+// It only sees corrections made through reverse() — a correction written as a
+// fresh balanced ADJUSTMENT set carries no back-pointer and is invisible here.
+// The number that is always right is the balance: a reversal negates the
+// original and copies its matures_at, so a cancelled commission already nets to
+// zero in maturedPayableBalancesFor without anyone having to ask this question.
+async function isSourceReversed(
+  sourceType: LedgerSourceType,
+  sourceId: string,
+) {
   const reversal = await prisma.ledgerEntry.findFirst({
     where: {
       source_type: sourceType,
@@ -465,6 +617,58 @@ function assertBalanced(
   }
 }
 
+// Which accounts may name a user, and which must not.
+//
+// An owned account with no owner is a liability owed to nobody: balancesFor
+// looks entries up by owner, so the row is invisible to every read path while
+// still sitting in the books. An unowned account naming a user is worse — see
+// OWNED_ACCOUNT_TYPES above.
+function assertOwnershipMatchesAccounts(entries: ParsedLedgerEntry[]) {
+  for (const entry of entries) {
+    const isOwnedAccount = OWNED_ACCOUNT_TYPES.includes(entry.account_type);
+
+    if (isOwnedAccount && !entry.owner_id) {
+      throw new ValidationError({
+        message: `A ${entry.account_type} entry must name the user it belongs to.`,
+        action: "Set owner_id on this entry and try again.",
+      });
+    }
+
+    if (!isOwnedAccount && entry.owner_id) {
+      throw new ValidationError({
+        message: `A ${entry.account_type} entry is a platform account and must not name a user.`,
+        action: "Remove owner_id from this entry and try again.",
+      });
+    }
+  }
+}
+
+// Same reasoning as the currency check below: with no foreign keys, an owner id
+// that matches no user becomes a commission that never appears in any statement
+// or payout, and nothing fails until someone notices the money is missing.
+async function validateOwnersExist(ownerIds: string[]) {
+  const uniqueIds = [...new Set(ownerIds)];
+
+  if (uniqueIds.length === 0) {
+    return;
+  }
+
+  const foundUsers = await prisma.user.findMany({
+    where: { id: { in: uniqueIds } },
+    select: { id: true },
+  });
+
+  const foundIds = new Set(foundUsers.map((user) => user.id));
+  const missingIds = uniqueIds.filter((ownerId) => !foundIds.has(ownerId));
+
+  if (missingIds.length > 0) {
+    throw new ValidationError({
+      message: `The following ledger entry owners do not exist: ${missingIds.join(", ")}.`,
+      action: "Check the owner_id of each entry and try again.",
+    });
+  }
+}
+
 // No foreign keys, so a currency code that matches nothing would become a row
 // that silently never appears in any balance.
 //
@@ -491,12 +695,15 @@ async function validateCurrenciesAreRecordable(codes: string[]) {
 
 const ledger = {
   LEDGER_SOURCE_TYPES,
+  COMMISSION_HOLD_DAYS,
   record,
   reverse,
+  maturityFor,
   balancesFor,
   balanceFor,
   maturedBalancesFor,
   payableBalancesFor,
+  maturedPayableBalancesFor,
   findByGroup,
   findBySource,
   isSourceReversed,

--- a/prisma/migrations/20260804223856_add_ledger_entries/migration.sql
+++ b/prisma/migrations/20260804223856_add_ledger_entries/migration.sql
@@ -22,13 +22,16 @@ CREATE TABLE "ledger_entries" (
 );
 
 -- CreateIndex
-CREATE UNIQUE INDEX "ledger_entries_reverses_entry_id_key" ON "ledger_entries"("reverses_entry_id");
-
--- CreateIndex
 CREATE INDEX "ledger_entries_entry_group_id_idx" ON "ledger_entries"("entry_group_id");
 
 -- CreateIndex
-CREATE INDEX "ledger_entries_owner_id_account_type_currency_matures_at_idx" ON "ledger_entries"("owner_id", "account_type", "currency", "matures_at");
+CREATE INDEX "ledger_entries_owner_id_account_type_currency_idx" ON "ledger_entries"("owner_id", "account_type", "currency");
 
 -- CreateIndex
 CREATE INDEX "ledger_entries_source_type_source_id_idx" ON "ledger_entries"("source_type", "source_id");
+
+-- CreateIndex
+CREATE INDEX "ledger_entries_matures_at_idx" ON "ledger_entries"("matures_at");
+
+-- CreateIndex
+CREATE INDEX "ledger_entries_reverses_entry_id_idx" ON "ledger_entries"("reverses_entry_id");

--- a/prisma/migrations/20260804223856_add_ledger_entries/migration.sql
+++ b/prisma/migrations/20260804223856_add_ledger_entries/migration.sql
@@ -1,0 +1,37 @@
+-- CreateEnum
+CREATE TYPE "LedgerAccountType" AS ENUM ('CONSUMER_PAYMENT', 'SUPPLIER_COST', 'AFFILIATE_COMMISSION', 'PLATFORM_REVENUE', 'PAYOUT');
+
+-- CreateTable
+CREATE TABLE "ledger_entries" (
+    "id" TEXT NOT NULL,
+    "entry_group_id" TEXT NOT NULL,
+    "account_type" "LedgerAccountType" NOT NULL,
+    "owner_id" TEXT,
+    "amount" DECIMAL(19,4) NOT NULL,
+    "currency" VARCHAR(3) NOT NULL,
+    "exchange_rate" DECIMAL(19,8),
+    "exchange_rate_from_currency" VARCHAR(3),
+    "source_type" VARCHAR(50) NOT NULL,
+    "source_id" TEXT NOT NULL,
+    "matures_at" TIMESTAMP(3),
+    "reverses_entry_id" TEXT,
+    "description" VARCHAR(255),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ledger_entries_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ledger_entries_entry_group_id_idx" ON "ledger_entries"("entry_group_id");
+
+-- CreateIndex
+CREATE INDEX "ledger_entries_owner_id_account_type_currency_idx" ON "ledger_entries"("owner_id", "account_type", "currency");
+
+-- CreateIndex
+CREATE INDEX "ledger_entries_source_type_source_id_idx" ON "ledger_entries"("source_type", "source_id");
+
+-- CreateIndex
+CREATE INDEX "ledger_entries_matures_at_idx" ON "ledger_entries"("matures_at");
+
+-- CreateIndex
+CREATE INDEX "ledger_entries_reverses_entry_id_idx" ON "ledger_entries"("reverses_entry_id");

--- a/prisma/migrations/20260804230048_add_ledger_entries/migration.sql
+++ b/prisma/migrations/20260804230048_add_ledger_entries/migration.sql
@@ -22,16 +22,13 @@ CREATE TABLE "ledger_entries" (
 );
 
 -- CreateIndex
+CREATE UNIQUE INDEX "ledger_entries_reverses_entry_id_key" ON "ledger_entries"("reverses_entry_id");
+
+-- CreateIndex
 CREATE INDEX "ledger_entries_entry_group_id_idx" ON "ledger_entries"("entry_group_id");
 
 -- CreateIndex
-CREATE INDEX "ledger_entries_owner_id_account_type_currency_idx" ON "ledger_entries"("owner_id", "account_type", "currency");
+CREATE INDEX "ledger_entries_owner_id_account_type_currency_matures_at_idx" ON "ledger_entries"("owner_id", "account_type", "currency", "matures_at");
 
 -- CreateIndex
 CREATE INDEX "ledger_entries_source_type_source_id_idx" ON "ledger_entries"("source_type", "source_id");
-
--- CreateIndex
-CREATE INDEX "ledger_entries_matures_at_idx" ON "ledger_entries"("matures_at");
-
--- CreateIndex
-CREATE INDEX "ledger_entries_reverses_entry_id_idx" ON "ledger_entries"("reverses_entry_id");

--- a/prisma/migrations/20260805000500_tighten_ledger_entry_indexes/migration.sql
+++ b/prisma/migrations/20260805000500_tighten_ledger_entry_indexes/migration.sql
@@ -1,0 +1,25 @@
+-- Index changes for ledger_entries, split out because 20260804223856 had
+-- already been applied by a deployment and a migration cannot be edited once
+-- it has run anywhere.
+--
+-- No column changes: only the indexes differ.
+
+-- reverses_entry_id becomes unique so an entry can be cancelled exactly once.
+-- models/ledger.reverse() checks before writing, but that check is
+-- read-then-write: two concurrent chargeback handlers would both pass it and
+-- claw the same commission back twice, and with no UPDATE available on an
+-- append-only table a ledger wrong in that direction cannot be repaired.
+DROP INDEX "ledger_entries_reverses_entry_id_idx";
+
+CREATE UNIQUE INDEX "ledger_entries_reverses_entry_id_key" ON "ledger_entries"("reverses_entry_id");
+
+-- The balance query groups by owner, account and currency, and the matured
+-- variant adds a maturity filter on top. Carrying matures_at as the last column
+-- serves both from one index, and makes the standalone index on matures_at dead
+-- weight — no query filters on maturity without an owner, so nothing would ever
+-- choose it.
+DROP INDEX "ledger_entries_matures_at_idx";
+
+DROP INDEX "ledger_entries_owner_id_account_type_currency_idx";
+
+CREATE INDEX "ledger_entries_owner_id_account_type_currency_matures_at_idx" ON "ledger_entries"("owner_id", "account_type", "currency", "matures_at");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -396,6 +396,89 @@ model ExchangeRate {
   @@map("exchange_rates")
 }
 
+// The chart of accounts. New accounts — tax withholding, a supplier prepaid
+// wallet, a processor reserve — are added here as enum values without
+// reshaping the table, which is why this is an enum while source_type below,
+// whose values must be extensible without a migration at all, is not.
+enum LedgerAccountType {
+  CONSUMER_PAYMENT // gross collected from a buyer; funds a sale
+  SUPPLIER_COST // what the delivered code cost us
+  AFFILIATE_COMMISSION // owed to a storefront owner, held until matures_at
+  PLATFORM_REVENUE // what is left for the platform
+  PAYOUT // a commission balance actually sent to an affiliate
+}
+
+// Append-only double-entry ledger. Every money movement is written as a set of
+// entries sharing an entry_group_id which sums to zero within each currency,
+// so a bug that loses money fails at write time instead of surfacing in a
+// payout three weeks later. Nothing here is ever updated: a correction is a
+// new, negated entry (see models/ledger.reverse).
+//
+// Sign convention: positive is money the platform received or holds, negative
+// is money it owes or has spent. One sale of 100.00 with a 70.00 supplier cost
+// and a 10.00 affiliate commission is therefore:
+//
+//   CONSUMER_PAYMENT      +100.0000
+//   SUPPLIER_COST          -70.0000
+//   AFFILIATE_COMMISSION   -10.0000
+//   PLATFORM_REVENUE       -20.0000
+//                          ---------
+//                            0.0000
+//
+// A commission balance is consequently negative while we owe it. models/ledger
+// exposes that flip in one place (payableBalancesFor) so no read path has to
+// remember to negate.
+model LedgerEntry {
+  id String @id @default(uuid())
+
+  // The balanced set this entry was written as part of. Summing to zero is a
+  // property of a set rather than of a row, so the set needs its own identity.
+  entry_group_id String
+
+  account_type LedgerAccountType
+
+  // Logical reference to User.id — the affiliate a commission or payout
+  // belongs to. Null for platform accounts, which belong to no user.
+  owner_id String?
+
+  amount   Decimal @db.Decimal(19, 4)
+  currency String  @db.VarChar(3) // Logical reference to Currency.code
+
+  // Set only when this amount was produced by converting from another
+  // currency, and then always as a pair: a rate cannot be reconciled later
+  // without knowing which pair it applied to.
+  exchange_rate               Decimal? @db.Decimal(19, 8)
+  exchange_rate_from_currency String?  @db.VarChar(3) // Logical reference to Currency.code
+
+  // Polymorphic reference to whatever produced this entry, the same shape as
+  // AdminActionLog.target_type/target_id. Deliberately not an enum: it has to
+  // reach a Sale today and an Order later without a migration.
+  source_type String @db.VarChar(50)
+  source_id   String
+
+  // When a held amount becomes payable; null means no hold. A reversing entry
+  // copies the original's value so a clawback cancels it at the same instant.
+  // Nulling it would leave the original matured with nothing offsetting it.
+  matures_at DateTime?
+
+  // Logical reference to LedgerEntry.id, set on rows written by reverse().
+  // Per-row rather than per-set so a partial refund can reverse part of a set
+  // later without a schema change.
+  reverses_entry_id String?
+
+  description String? @db.VarChar(255)
+
+  // No updated_at: ledger entries are append-only and never modified.
+  created_at DateTime @default(now())
+
+  @@index([entry_group_id])
+  @@index([owner_id, account_type, currency])
+  @@index([source_type, source_id])
+  @@index([matures_at])
+  @@index([reverses_entry_id])
+  @@map("ledger_entries")
+}
+
 // A price set explicitly by a developer/admin for one currency. Its presence
 // means "this is the price, do not convert" — it always wins over conversion
 // from the game's USD base price. This is also where commercially-shaped

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -462,9 +462,15 @@ model LedgerEntry {
   matures_at DateTime?
 
   // Logical reference to LedgerEntry.id, set on rows written by reverse().
-  // Per-row rather than per-set so a partial refund can reverse part of a set
-  // later without a schema change.
-  reverses_entry_id String?
+  //
+  // Unique, so an entry can be cancelled exactly once. reverse() checks first
+  // and reports a clear error, but two chargeback handlers racing would both
+  // pass that check and claw the same commission back twice — and with no
+  // UPDATE available, a ledger wrong in that direction cannot be repaired.
+  // Refunds in this business are all-or-nothing (see
+  // docs/legal/business-description.md), so nothing legitimate needs to reverse
+  // an entry in parts.
+  reverses_entry_id String? @unique
 
   description String? @db.VarChar(255)
 
@@ -472,10 +478,12 @@ model LedgerEntry {
   created_at DateTime @default(now())
 
   @@index([entry_group_id])
-  @@index([owner_id, account_type, currency])
+  // Leads on the balance query's grouping and carries matures_at as the last
+  // column, so the matured filter is served by the same index rather than a
+  // separate one on matures_at alone — which nothing would ever choose, since
+  // no query filters on maturity without an owner.
+  @@index([owner_id, account_type, currency, matures_at])
   @@index([source_type, source_id])
-  @@index([matures_at])
-  @@index([reverses_entry_id])
   @@map("ledger_entries")
 }
 

--- a/tests/integration/models/ledger.test.ts
+++ b/tests/integration/models/ledger.test.ts
@@ -16,6 +16,20 @@ async function registerBaseCurrencies() {
   await orchestrator.createCurrency({ code: "BRL", symbol: "R$" });
 }
 
+// Entries within a set share one created_at, so they come back in id order.
+// Assertions name the account they mean rather than an index.
+function amountOf(
+  entries: Array<{
+    account_type: string;
+    amount: { toFixed: (n: number) => string };
+  }>,
+  accountType: string,
+) {
+  return entries
+    .find((entry) => entry.account_type === accountType)
+    ?.amount.toFixed(4);
+}
+
 // A balanced two-entry set, the smallest thing the ledger will accept.
 function balancedPair(amount: number, currencyCode = "USD") {
   return [
@@ -308,6 +322,157 @@ describe("models/ledger.ts", () => {
     });
   });
 
+  // Which accounts may name a user. An unowned account naming an affiliate
+  // would be a record asserting a storefront owner received consumer funds,
+  // which is the fact the affiliate characterisation depends on never being
+  // true. An owned account with no owner is a liability owed to nobody.
+  describe(".record() ownership rules", () => {
+    test("rejects a platform account that names a user", async () => {
+      await registerBaseCurrencies();
+
+      const affiliate = await orchestrator.createUser();
+
+      await expect(
+        ledger.record({
+          source_type: "SALE",
+          source_id: randomUUID(),
+          entries: [
+            {
+              account_type: "CONSUMER_PAYMENT",
+              owner_id: affiliate.id,
+              amount: 100,
+              currency: "USD",
+            },
+            { account_type: "PLATFORM_REVENUE", amount: -100, currency: "USD" },
+          ],
+        }),
+      ).rejects.toMatchObject({
+        name: "ValidationError",
+        message:
+          "A CONSUMER_PAYMENT entry is a platform account and must not name a user.",
+        action: "Remove owner_id from this entry and try again.",
+        statusCode: 400,
+      });
+    });
+
+    test("rejects a commission that names nobody", async () => {
+      await registerBaseCurrencies();
+
+      await expect(
+        ledger.record({
+          source_type: "SALE",
+          source_id: randomUUID(),
+          entries: [
+            { account_type: "CONSUMER_PAYMENT", amount: 100, currency: "USD" },
+            {
+              account_type: "AFFILIATE_COMMISSION",
+              amount: -100,
+              currency: "USD",
+            },
+          ],
+        }),
+      ).rejects.toMatchObject({
+        name: "ValidationError",
+        message:
+          "A AFFILIATE_COMMISSION entry must name the user it belongs to.",
+        action: "Set owner_id on this entry and try again.",
+        statusCode: 400,
+      });
+    });
+
+    // No foreign keys, so an owner id matching no user would become a
+    // commission that never surfaces in any statement or payout.
+    test("rejects an owner that does not exist", async () => {
+      await registerBaseCurrencies();
+
+      const missingId = randomUUID();
+
+      await expect(
+        ledger.record({
+          source_type: "SALE",
+          source_id: randomUUID(),
+          entries: [
+            { account_type: "CONSUMER_PAYMENT", amount: 100, currency: "USD" },
+            {
+              account_type: "AFFILIATE_COMMISSION",
+              owner_id: missingId,
+              amount: -100,
+              currency: "USD",
+            },
+          ],
+        }),
+      ).rejects.toMatchObject({
+        name: "ValidationError",
+        message: `The following ledger entry owners do not exist: ${missingId}.`,
+        action: "Check the owner_id of each entry and try again.",
+        statusCode: 400,
+      });
+    });
+
+    // The majority of sales at launch: Sale.store_id is nullable, and null
+    // means the purchase came through the global storefront with no affiliate.
+    test("records a sale with no affiliate as a three-entry set", async () => {
+      await registerBaseCurrencies();
+
+      const saleId = randomUUID();
+      const entries = await orchestrator.recordLedgerSale({
+        source_id: saleId,
+      });
+
+      expect(entries).toHaveLength(3);
+      expect(entries.map((entry) => entry.account_type).sort()).toEqual([
+        "CONSUMER_PAYMENT",
+        "PLATFORM_REVENUE",
+        "SUPPLIER_COST",
+      ]);
+
+      // The whole margin stays with the platform when nobody referred the sale.
+      const revenue = entries.find(
+        (entry) => entry.account_type === "PLATFORM_REVENUE",
+      );
+      expect(revenue?.amount.toFixed(4)).toBe("-30.0000");
+    });
+  });
+
+  describe(".record() bounds", () => {
+    // Would otherwise overflow Decimal(19,4) and surface as a raw Postgres
+    // error rather than something a caller can act on.
+    test("rejects an amount beyond the storable range", async () => {
+      await registerBaseCurrencies();
+
+      await expect(
+        ledger.record({
+          source_type: "SALE",
+          source_id: randomUUID(),
+          entries: balancedPair(1e15),
+        }),
+      ).rejects.toMatchObject({ name: "ValidationError" });
+    });
+
+    // The rate snapshot exists so a conversion can be reproduced later, which
+    // a silently rounded rate would defeat.
+    test("rejects a rate with more than 8 decimal places", async () => {
+      await registerBaseCurrencies();
+
+      await expect(
+        ledger.record({
+          source_type: "ADJUSTMENT",
+          source_id: randomUUID(),
+          entries: [
+            {
+              account_type: "CONSUMER_PAYMENT",
+              amount: 550,
+              currency: "BRL",
+              exchange_rate: "5.123456789012",
+              exchange_rate_from_currency: "USD",
+            },
+            { account_type: "PLATFORM_REVENUE", amount: -550, currency: "BRL" },
+          ],
+        }),
+      ).rejects.toMatchObject({ name: "ValidationError" });
+    });
+  });
+
   describe(".record() with a conversion", () => {
     test("stores the rate and the currency it converted from", async () => {
       await registerBaseCurrencies();
@@ -423,8 +588,8 @@ describe("models/ledger.ts", () => {
 
       expect(reversal).toHaveLength(2);
       expect(reversal[0].entry_group_id).not.toBe(original[0].entry_group_id);
-      expect(reversal[0].amount.toFixed(4)).toBe("-100.0000");
-      expect(reversal[1].amount.toFixed(4)).toBe("100.0000");
+      expect(amountOf(reversal, "CONSUMER_PAYMENT")).toBe("-100.0000");
+      expect(amountOf(reversal, "PLATFORM_REVENUE")).toBe("100.0000");
     });
 
     test("leaves the original entries untouched", async () => {
@@ -441,7 +606,7 @@ describe("models/ledger.ts", () => {
       const stillThere = await ledger.findByGroup(original[0].entry_group_id);
 
       expect(stillThere).toHaveLength(2);
-      expect(stillThere[0].amount.toFixed(4)).toBe("100.0000");
+      expect(amountOf(stillThere, "CONSUMER_PAYMENT")).toBe("100.0000");
     });
 
     test("names the entry each reversing row cancels", async () => {
@@ -577,6 +742,80 @@ describe("models/ledger.ts", () => {
       });
     });
 
+    // Reversing a reversal would reinstate the original set while every
+    // "has this been reversed" check kept answering yes.
+    test("refuses to reverse a reversal", async () => {
+      await registerBaseCurrencies();
+
+      const original = await ledger.record({
+        source_type: "SALE",
+        source_id: randomUUID(),
+        entries: balancedPair(100),
+      });
+
+      const reversal = await ledger.reverse(original[0].entry_group_id);
+
+      await expect(
+        ledger.reverse(reversal[0].entry_group_id),
+      ).rejects.toMatchObject({
+        name: "ValidationError",
+        message: `The ledger entry group "${reversal[0].entry_group_id}" is itself a reversal and cannot be reversed.`,
+        statusCode: 400,
+      });
+    });
+
+    // The check in reverse() is read-then-write; the unique index on
+    // reverses_entry_id is what actually stops a concurrent second clawback.
+    test("survives two concurrent reversals of the same set", async () => {
+      await registerBaseCurrencies();
+
+      const affiliate = await orchestrator.createUser();
+      const sale = await orchestrator.recordLedgerSale({
+        affiliate_id: affiliate.id,
+      });
+
+      const outcomes = await Promise.allSettled([
+        ledger.reverse(sale[0].entry_group_id),
+        ledger.reverse(sale[0].entry_group_id),
+      ]);
+
+      expect(
+        outcomes.filter((outcome) => outcome.status === "fulfilled"),
+      ).toHaveLength(1);
+
+      // Exactly one clawback landed, so the affiliate is owed nothing rather
+      // than owing us the commission back.
+      expect((await ledger.balanceFor(affiliate.id, "USD")).toFixed(4)).toBe(
+        "0.0000",
+      );
+    });
+
+    // VarChar(255): an original sitting near the limit must not push the
+    // derived text over it.
+    test("truncates a derived description that would overflow", async () => {
+      await registerBaseCurrencies();
+
+      const longDescription = "x".repeat(255);
+
+      const original = await ledger.record({
+        source_type: "SALE",
+        source_id: randomUUID(),
+        entries: [
+          {
+            account_type: "CONSUMER_PAYMENT",
+            amount: 100,
+            currency: "USD",
+            description: longDescription,
+          },
+          { account_type: "PLATFORM_REVENUE", amount: -100, currency: "USD" },
+        ],
+      });
+
+      const reversal = await ledger.reverse(original[0].entry_group_id);
+
+      expect(reversal[0].description?.length).toBeLessThanOrEqual(255);
+    });
+
     test("throws NotFoundError for an unknown group", async () => {
       await registerBaseCurrencies();
 
@@ -652,6 +891,20 @@ describe("models/ledger.ts", () => {
       await orchestrator.recordLedgerSale({ affiliate_id: affiliate.id });
 
       expect(await ledger.balancesFor(otherAffiliate.id)).toEqual([]);
+    });
+
+    // Prisma drops an undefined field from `where`, so without this guard a
+    // missing owner id would return the platform-wide aggregate looking like
+    // one affiliate's balance.
+    test("refuses to compute a balance without an owner", async () => {
+      await registerBaseCurrencies();
+
+      await expect(ledger.balancesFor(undefined)).rejects.toMatchObject({
+        name: "ValidationError",
+        message: "An owner id is required to read a ledger balance.",
+        action: "Pass the id of the user whose balance you want.",
+        statusCode: 400,
+      });
     });
 
     test("only counts the requested account type", async () => {
@@ -787,12 +1040,12 @@ describe("models/ledger.ts", () => {
 
       expect(
         await ledger.maturedBalancesFor(affiliate.id, {
-          as_of: new Date("2026-09-29T00:00:00.000Z"),
+          matured_as_of: new Date("2026-09-29T00:00:00.000Z"),
         }),
       ).toEqual([]);
 
       const matured = await ledger.maturedBalancesFor(affiliate.id, {
-        as_of: new Date("2026-10-01T00:00:00.000Z"),
+        matured_as_of: new Date("2026-10-01T00:00:00.000Z"),
       });
 
       expect(matured[0].amount.toFixed(4)).toBe("-10.0000");
@@ -814,7 +1067,7 @@ describe("models/ledger.ts", () => {
       await ledger.reverse(sale[0].entry_group_id);
 
       const matured = await ledger.maturedBalancesFor(affiliate.id, {
-        as_of: new Date("2026-10-01T00:00:00.000Z"),
+        matured_as_of: new Date("2026-10-01T00:00:00.000Z"),
       });
 
       expect(matured[0].amount.toFixed(4)).toBe("0.0000");
@@ -860,12 +1113,236 @@ describe("models/ledger.ts", () => {
     });
   });
 
+  describe(".maturedPayableBalancesFor()", () => {
+    // The number a payout run pays against. maturedBalancesFor returns the raw
+    // ledger sign — negative while owed — so the obviously-named function for
+    // the highest-stakes caller has to be the one that is also correct.
+    test("reports a matured commission as positive", async () => {
+      await registerBaseCurrencies();
+
+      const affiliate = await orchestrator.createUser();
+      await orchestrator.recordLedgerSale({
+        affiliate_id: affiliate.id,
+        matures_at: new Date(Date.now() - DAY_IN_MS),
+      });
+
+      const payable = await ledger.maturedPayableBalancesFor(affiliate.id);
+
+      expect(payable[0].currency).toBe("USD");
+      expect(payable[0].amount.toFixed(4)).toBe("10.0000");
+    });
+
+    test("excludes a commission still inside its hold", async () => {
+      await registerBaseCurrencies();
+
+      const affiliate = await orchestrator.createUser();
+      await orchestrator.recordLedgerSale({
+        affiliate_id: affiliate.id,
+        matures_at: new Date(Date.now() + DAY_IN_MS),
+      });
+
+      expect(await ledger.maturedPayableBalancesFor(affiliate.id)).toEqual([]);
+    });
+  });
+
+  describe(".maturityFor()", () => {
+    test("is the hold length after the given moment", async () => {
+      const maturesAt = ledger.maturityFor(
+        new Date("2026-08-05T12:00:00.000Z"),
+      );
+
+      expect(maturesAt.toISOString()).toBe("2026-09-04T12:00:00.000Z");
+    });
+
+    test("holds for the documented number of days", async () => {
+      expect(ledger.COMMISSION_HOLD_DAYS).toBe(30);
+    });
+  });
+
+  // The hold is the platform's entire chargeback defence, so the instant it
+  // ends is the assertion that matters, not a day either side of it.
+  describe("the maturation boundary", () => {
+    test("is inclusive of the maturity instant", async () => {
+      await registerBaseCurrencies();
+
+      const affiliate = await orchestrator.createUser();
+      const maturesAt = new Date("2026-09-30T00:00:00.000Z");
+
+      await orchestrator.recordLedgerSale({
+        affiliate_id: affiliate.id,
+        matures_at: maturesAt,
+      });
+
+      const atTheInstant = await ledger.maturedPayableBalancesFor(
+        affiliate.id,
+        { matured_as_of: maturesAt },
+      );
+
+      expect(atTheInstant[0].amount.toFixed(4)).toBe("10.0000");
+    });
+
+    test("excludes the millisecond before", async () => {
+      await registerBaseCurrencies();
+
+      const affiliate = await orchestrator.createUser();
+      const maturesAt = new Date("2026-09-30T00:00:00.000Z");
+
+      await orchestrator.recordLedgerSale({
+        affiliate_id: affiliate.id,
+        matures_at: maturesAt,
+      });
+
+      const justBefore = await ledger.maturedPayableBalancesFor(affiliate.id, {
+        matured_as_of: new Date(maturesAt.getTime() - 1),
+      });
+
+      expect(justBefore).toEqual([]);
+    });
+  });
+
+  // The invariant is enforced per set at write time. This asserts the property
+  // it is supposed to produce: after an arbitrary mix of activity, the books as
+  // a whole are still zero in every currency.
+  describe("the ledger as a whole", () => {
+    test("nets to zero per currency after sales, reversals and a payout", async () => {
+      await registerBaseCurrencies();
+
+      const affiliate = await orchestrator.createUser();
+      const otherAffiliate = await orchestrator.createUser();
+
+      await orchestrator.recordLedgerSale({ affiliate_id: affiliate.id });
+      await orchestrator.recordLedgerSale({
+        affiliate_id: otherAffiliate.id,
+        currency: "BRL",
+        gross: 550,
+        supplier_cost: 385,
+        commission: 55,
+      });
+      await orchestrator.recordLedgerSale();
+
+      const reversed = await orchestrator.recordLedgerSale({
+        affiliate_id: affiliate.id,
+      });
+      await ledger.reverse(reversed[0].entry_group_id);
+
+      await ledger.record({
+        source_type: "PAYOUT",
+        source_id: randomUUID(),
+        entries: [
+          {
+            account_type: "AFFILIATE_COMMISSION",
+            owner_id: affiliate.id,
+            amount: 10,
+            currency: "USD",
+          },
+          {
+            account_type: "PAYOUT",
+            owner_id: affiliate.id,
+            amount: -10,
+            currency: "USD",
+          },
+        ],
+      });
+
+      const totals = await prisma.ledgerEntry.groupBy({
+        by: ["currency"],
+        _sum: { amount: true },
+      });
+
+      expect(totals).toHaveLength(2);
+      for (const total of totals) {
+        expect(total._sum.amount?.toFixed(4)).toBe("0.0000");
+      }
+    });
+  });
+
+  // The shape the architecture doc describes for a payout that has to cross
+  // currencies: two independently balanced pairs, each carrying the rate.
+  describe("a cross-currency conversion set", () => {
+    test("balances in both currencies and records the rate on both legs", async () => {
+      await registerBaseCurrencies();
+
+      const affiliate = await orchestrator.createUser();
+
+      // Earn a BRL commission first — there has to be a balance to convert.
+      await orchestrator.recordLedgerSale({
+        affiliate_id: affiliate.id,
+        currency: "BRL",
+        gross: 550,
+        supplier_cost: 385,
+        commission: 55,
+        matures_at: null,
+      });
+
+      const entries = await ledger.record({
+        source_type: "PAYOUT",
+        source_id: randomUUID(),
+        entries: [
+          // The BRL commission balance is settled...
+          {
+            account_type: "AFFILIATE_COMMISSION",
+            owner_id: affiliate.id,
+            amount: 55,
+            currency: "BRL",
+          },
+          {
+            account_type: "PAYOUT",
+            owner_id: affiliate.id,
+            amount: -55,
+            currency: "BRL",
+          },
+          // ...and re-expressed in the currency it will actually be paid in.
+          {
+            account_type: "PAYOUT",
+            owner_id: affiliate.id,
+            amount: 10,
+            currency: "USD",
+            exchange_rate: 5.5,
+            exchange_rate_from_currency: "BRL",
+          },
+          {
+            account_type: "AFFILIATE_COMMISSION",
+            owner_id: affiliate.id,
+            amount: -10,
+            currency: "USD",
+            exchange_rate: 5.5,
+            exchange_rate_from_currency: "BRL",
+          },
+        ],
+      });
+
+      expect(entries).toHaveLength(4);
+
+      const usdLegs = entries.filter((entry) => entry.currency === "USD");
+      expect(usdLegs).toHaveLength(2);
+      for (const leg of usdLegs) {
+        expect(leg.exchange_rate?.toFixed(8)).toBe("5.50000000");
+        expect(leg.exchange_rate_from_currency).toBe("BRL");
+      }
+
+      // The BRL balance is cleared and the USD balance now carries the debt.
+      expect((await ledger.balanceFor(affiliate.id, "BRL")).toFixed(4)).toBe(
+        "0.0000",
+      );
+      const payable = await ledger.payableBalancesFor(affiliate.id);
+      expect(
+        payable
+          .find((balance) => balance.currency === "USD")
+          ?.amount.toFixed(4),
+      ).toBe("10.0000");
+    });
+  });
+
   describe(".findBySource()", () => {
     test("returns every entry written against one source", async () => {
       await registerBaseCurrencies();
 
       const saleId = randomUUID();
-      await orchestrator.recordLedgerSale({ source_id: saleId });
+      const affiliate = await orchestrator.createUser();
+      await orchestrator.recordLedgerSale({
+        source_id: saleId,
+        affiliate_id: affiliate.id,
+      });
 
       const entries = await ledger.findBySource("SALE", saleId);
 

--- a/tests/integration/models/ledger.test.ts
+++ b/tests/integration/models/ledger.test.ts
@@ -1,0 +1,909 @@
+import { randomUUID } from "node:crypto";
+import orchestrator from "tests/orchestrator";
+import ledger from "models/ledger";
+import { prisma } from "infra/database";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+async function registerBaseCurrencies() {
+  await orchestrator.clearDatabaseRows();
+  await orchestrator.createCurrency({ code: "USD", symbol: "$" });
+  await orchestrator.createCurrency({ code: "BRL", symbol: "R$" });
+}
+
+// A balanced two-entry set, the smallest thing the ledger will accept.
+function balancedPair(amount: number, currencyCode = "USD") {
+  return [
+    {
+      account_type: "CONSUMER_PAYMENT" as const,
+      amount,
+      currency: currencyCode,
+    },
+    {
+      account_type: "PLATFORM_REVENUE" as const,
+      amount: -amount,
+      currency: currencyCode,
+    },
+  ];
+}
+
+describe("models/ledger.ts", () => {
+  describe(".record()", () => {
+    test("writes every entry in a balanced set under one group id", async () => {
+      await registerBaseCurrencies();
+
+      const entries = await ledger.record({
+        source_type: "SALE",
+        source_id: randomUUID(),
+        entries: balancedPair(100),
+      });
+
+      expect(entries).toHaveLength(2);
+      expect(entries[0].entry_group_id).toBe(entries[1].entry_group_id);
+      expect(entries[0].amount.toFixed(4)).toBe("100.0000");
+      expect(entries[1].amount.toFixed(4)).toBe("-100.0000");
+      expect(entries[0].created_at).toBeInstanceOf(Date);
+    });
+
+    test("stores the fields a sale entry carries", async () => {
+      await registerBaseCurrencies();
+
+      const affiliate = await orchestrator.createUser();
+      const saleId = randomUUID();
+      const maturesAt = new Date("2026-09-30T00:00:00.000Z");
+
+      const entries = await ledger.record({
+        source_type: "SALE",
+        source_id: saleId,
+        entries: [
+          {
+            account_type: "CONSUMER_PAYMENT",
+            amount: 100,
+            currency: "USD",
+            description: "Gross payment",
+          },
+          {
+            account_type: "AFFILIATE_COMMISSION",
+            owner_id: affiliate.id,
+            amount: -100,
+            currency: "USD",
+            matures_at: maturesAt,
+          },
+        ],
+      });
+
+      const commission = entries.find(
+        (entry) => entry.account_type === "AFFILIATE_COMMISSION",
+      );
+
+      expect(commission?.owner_id).toBe(affiliate.id);
+      expect(commission?.source_type).toBe("SALE");
+      expect(commission?.source_id).toBe(saleId);
+      expect(commission?.matures_at?.toISOString()).toBe(
+        "2026-09-30T00:00:00.000Z",
+      );
+
+      const payment = entries.find(
+        (entry) => entry.account_type === "CONSUMER_PAYMENT",
+      );
+
+      expect(payment?.owner_id).toBeNull();
+      expect(payment?.description).toBe("Gross payment");
+      expect(payment?.matures_at).toBeNull();
+    });
+
+    test("keeps the full 4-decimal scale", async () => {
+      await registerBaseCurrencies();
+
+      const entries = await ledger.record({
+        source_type: "SALE",
+        source_id: randomUUID(),
+        entries: balancedPair(0.0001),
+      });
+
+      expect(entries[0].amount.toFixed(4)).toBe("0.0001");
+      expect(entries[1].amount.toFixed(4)).toBe("-0.0001");
+    });
+
+    test("normalizes the currency code to uppercase", async () => {
+      await registerBaseCurrencies();
+
+      const entries = await ledger.record({
+        source_type: "SALE",
+        source_id: randomUUID(),
+        entries: balancedPair(100, "brl"),
+      });
+
+      expect(entries.map((entry) => entry.currency)).toEqual(["BRL", "BRL"]);
+    });
+
+    // The invariant this whole model exists for.
+    test("rejects a set that does not sum to zero", async () => {
+      await registerBaseCurrencies();
+
+      await expect(
+        ledger.record({
+          source_type: "SALE",
+          source_id: randomUUID(),
+          entries: [
+            { account_type: "CONSUMER_PAYMENT", amount: 100, currency: "USD" },
+            { account_type: "SUPPLIER_COST", amount: -70, currency: "USD" },
+          ],
+        }),
+      ).rejects.toMatchObject({
+        name: "ValidationError",
+        message:
+          "Ledger entries must sum to zero within each currency, but this set left USD 30.0000.",
+        action:
+          "Add the missing entries so every currency in the set nets to zero, and try again.",
+        statusCode: 400,
+      });
+    });
+
+    test("writes nothing when the set is unbalanced", async () => {
+      await registerBaseCurrencies();
+
+      await expect(
+        ledger.record({
+          source_type: "SALE",
+          source_id: randomUUID(),
+          entries: [
+            { account_type: "CONSUMER_PAYMENT", amount: 100, currency: "USD" },
+            { account_type: "SUPPLIER_COST", amount: -70, currency: "USD" },
+          ],
+        }),
+      ).rejects.toMatchObject({ name: "ValidationError" });
+
+      expect(await prisma.ledgerEntry.count()).toBe(0);
+    });
+
+    // Each currency has to balance on its own. A set that nets to zero only
+    // when the two are added together is not balanced.
+    test("rejects a set that balances only across currencies", async () => {
+      await registerBaseCurrencies();
+
+      await expect(
+        ledger.record({
+          source_type: "SALE",
+          source_id: randomUUID(),
+          entries: [
+            { account_type: "CONSUMER_PAYMENT", amount: 100, currency: "USD" },
+            { account_type: "PLATFORM_REVENUE", amount: -100, currency: "BRL" },
+          ],
+        }),
+      ).rejects.toMatchObject({
+        name: "ValidationError",
+        message:
+          "Ledger entries must sum to zero within each currency, but this set left USD 100.0000, BRL -100.0000.",
+      });
+    });
+
+    test("accepts a multi-currency set where each currency balances", async () => {
+      await registerBaseCurrencies();
+
+      const entries = await ledger.record({
+        source_type: "SALE",
+        source_id: randomUUID(),
+        entries: [...balancedPair(100, "USD"), ...balancedPair(550, "BRL")],
+      });
+
+      expect(entries).toHaveLength(4);
+    });
+
+    // Rounding at write time could turn a set that validated as balanced into
+    // one that lands unbalanced, so extra scale is refused rather than trimmed.
+    test("rejects an amount with more than 4 decimal places", async () => {
+      await registerBaseCurrencies();
+
+      const rejected = ledger.record({
+        source_type: "SALE",
+        source_id: randomUUID(),
+        entries: balancedPair(1.00005),
+      });
+
+      await expect(rejected).rejects.toMatchObject({
+        name: "ValidationError",
+        message: "One or more ledger entries are invalid",
+        action: "Check the fields and try again",
+        statusCode: 400,
+      });
+    });
+
+    test("rejects a zero amount", async () => {
+      await registerBaseCurrencies();
+
+      await expect(
+        ledger.record({
+          source_type: "SALE",
+          source_id: randomUUID(),
+          entries: [
+            { account_type: "CONSUMER_PAYMENT", amount: 0, currency: "USD" },
+            { account_type: "PLATFORM_REVENUE", amount: 0, currency: "USD" },
+          ],
+        }),
+      ).rejects.toMatchObject({ name: "ValidationError" });
+    });
+
+    test("rejects a single-entry set", async () => {
+      await registerBaseCurrencies();
+
+      await expect(
+        ledger.record({
+          source_type: "SALE",
+          source_id: randomUUID(),
+          entries: [
+            { account_type: "CONSUMER_PAYMENT", amount: 100, currency: "USD" },
+          ],
+        }),
+      ).rejects.toMatchObject({ name: "ValidationError" });
+    });
+
+    test("rejects an unknown source type", async () => {
+      await registerBaseCurrencies();
+
+      await expect(
+        ledger.record({
+          // @ts-expect-error deliberately outside the allowed source types
+          source_type: "INVOICE",
+          source_id: randomUUID(),
+          entries: balancedPair(100),
+        }),
+      ).rejects.toMatchObject({ name: "ValidationError" });
+    });
+
+    test("rejects an unregistered currency", async () => {
+      await registerBaseCurrencies();
+
+      await expect(
+        ledger.record({
+          source_type: "SALE",
+          source_id: randomUUID(),
+          entries: balancedPair(100, "JPY"),
+        }),
+      ).rejects.toMatchObject({
+        name: "ValidationError",
+        message: "The following currencies are not registered: JPY.",
+        action: "Register the currency before recording ledger entries in it.",
+        statusCode: 400,
+      });
+    });
+
+    // models/pricing lets the platform sell in USD before any currency row
+    // exists. If the ledger disagreed, an unconfigured install could not record
+    // a single sale.
+    test("accepts the base currency when no currency is registered", async () => {
+      await orchestrator.clearDatabaseRows();
+
+      const entries = await ledger.record({
+        source_type: "SALE",
+        source_id: randomUUID(),
+        entries: balancedPair(100, "USD"),
+      });
+
+      expect(entries).toHaveLength(2);
+    });
+
+    // Disabling a currency stops us pricing in it. It does not un-happen the
+    // sales already made in it.
+    test("accepts a registered but disabled currency", async () => {
+      await registerBaseCurrencies();
+      await orchestrator.createCurrency({
+        code: "EUR",
+        symbol: "€",
+        enabled: false,
+      });
+
+      const entries = await ledger.record({
+        source_type: "SALE",
+        source_id: randomUUID(),
+        entries: balancedPair(100, "EUR"),
+      });
+
+      expect(entries).toHaveLength(2);
+    });
+  });
+
+  describe(".record() with a conversion", () => {
+    test("stores the rate and the currency it converted from", async () => {
+      await registerBaseCurrencies();
+
+      const entries = await ledger.record({
+        source_type: "ADJUSTMENT",
+        source_id: randomUUID(),
+        entries: [
+          {
+            account_type: "CONSUMER_PAYMENT",
+            amount: 550,
+            currency: "BRL",
+            exchange_rate: 5.5,
+            exchange_rate_from_currency: "USD",
+          },
+          {
+            account_type: "PLATFORM_REVENUE",
+            amount: -550,
+            currency: "BRL",
+            exchange_rate: 5.5,
+            exchange_rate_from_currency: "USD",
+          },
+        ],
+      });
+
+      expect(entries[0].exchange_rate?.toFixed(8)).toBe("5.50000000");
+      expect(entries[0].exchange_rate_from_currency).toBe("USD");
+    });
+
+    // A rate with no pair cannot be reconciled later, so the two are refused
+    // unless they arrive together.
+    test("rejects a rate without the currency it converted from", async () => {
+      await registerBaseCurrencies();
+
+      await expect(
+        ledger.record({
+          source_type: "ADJUSTMENT",
+          source_id: randomUUID(),
+          entries: [
+            {
+              account_type: "CONSUMER_PAYMENT",
+              amount: 550,
+              currency: "BRL",
+              exchange_rate: 5.5,
+            },
+            {
+              account_type: "PLATFORM_REVENUE",
+              amount: -550,
+              currency: "BRL",
+            },
+          ],
+        }),
+      ).rejects.toMatchObject({ name: "ValidationError" });
+    });
+
+    test("rejects converting a currency into itself", async () => {
+      await registerBaseCurrencies();
+
+      await expect(
+        ledger.record({
+          source_type: "ADJUSTMENT",
+          source_id: randomUUID(),
+          entries: [
+            {
+              account_type: "CONSUMER_PAYMENT",
+              amount: 100,
+              currency: "USD",
+              exchange_rate: 1,
+              exchange_rate_from_currency: "USD",
+            },
+            { account_type: "PLATFORM_REVENUE", amount: -100, currency: "USD" },
+          ],
+        }),
+      ).rejects.toMatchObject({ name: "ValidationError" });
+    });
+
+    test("rejects an unregistered currency on the conversion side", async () => {
+      await registerBaseCurrencies();
+
+      await expect(
+        ledger.record({
+          source_type: "ADJUSTMENT",
+          source_id: randomUUID(),
+          entries: [
+            {
+              account_type: "CONSUMER_PAYMENT",
+              amount: 550,
+              currency: "BRL",
+              exchange_rate: 5.5,
+              exchange_rate_from_currency: "JPY",
+            },
+            { account_type: "PLATFORM_REVENUE", amount: -550, currency: "BRL" },
+          ],
+        }),
+      ).rejects.toMatchObject({
+        name: "ValidationError",
+        message: "The following currencies are not registered: JPY.",
+      });
+    });
+  });
+
+  describe(".reverse()", () => {
+    test("writes the mirror image of the original set", async () => {
+      await registerBaseCurrencies();
+
+      const original = await ledger.record({
+        source_type: "SALE",
+        source_id: randomUUID(),
+        entries: balancedPair(100),
+      });
+
+      const reversal = await ledger.reverse(original[0].entry_group_id);
+
+      expect(reversal).toHaveLength(2);
+      expect(reversal[0].entry_group_id).not.toBe(original[0].entry_group_id);
+      expect(reversal[0].amount.toFixed(4)).toBe("-100.0000");
+      expect(reversal[1].amount.toFixed(4)).toBe("100.0000");
+    });
+
+    test("leaves the original entries untouched", async () => {
+      await registerBaseCurrencies();
+
+      const original = await ledger.record({
+        source_type: "SALE",
+        source_id: randomUUID(),
+        entries: balancedPair(100),
+      });
+
+      await ledger.reverse(original[0].entry_group_id);
+
+      const stillThere = await ledger.findByGroup(original[0].entry_group_id);
+
+      expect(stillThere).toHaveLength(2);
+      expect(stillThere[0].amount.toFixed(4)).toBe("100.0000");
+    });
+
+    test("names the entry each reversing row cancels", async () => {
+      await registerBaseCurrencies();
+
+      const original = await ledger.record({
+        source_type: "SALE",
+        source_id: randomUUID(),
+        entries: balancedPair(100),
+      });
+
+      const reversal = await ledger.reverse(original[0].entry_group_id);
+
+      expect(reversal.map((entry) => entry.reverses_entry_id).sort()).toEqual(
+        original.map((entry) => entry.id).sort(),
+      );
+    });
+
+    test("keeps the original's source so both sets describe one event", async () => {
+      await registerBaseCurrencies();
+
+      const saleId = randomUUID();
+      const original = await ledger.record({
+        source_type: "SALE",
+        source_id: saleId,
+        entries: balancedPair(100),
+      });
+
+      await ledger.reverse(original[0].entry_group_id);
+
+      const everything = await ledger.findBySource("SALE", saleId);
+
+      expect(everything).toHaveLength(4);
+    });
+
+    // A null hold on the reversal would count it as immediately available
+    // while the original was still held, so a matured-balance query would show
+    // a commission as payable with nothing offsetting it.
+    test("copies the original's matures_at", async () => {
+      await registerBaseCurrencies();
+
+      const affiliate = await orchestrator.createUser();
+      const maturesAt = new Date(Date.now() + 30 * DAY_IN_MS);
+
+      const original = await ledger.record({
+        source_type: "SALE",
+        source_id: randomUUID(),
+        entries: [
+          { account_type: "CONSUMER_PAYMENT", amount: 10, currency: "USD" },
+          {
+            account_type: "AFFILIATE_COMMISSION",
+            owner_id: affiliate.id,
+            amount: -10,
+            currency: "USD",
+            matures_at: maturesAt,
+          },
+        ],
+      });
+
+      const reversal = await ledger.reverse(original[0].entry_group_id);
+
+      const reversedCommission = reversal.find(
+        (entry) => entry.account_type === "AFFILIATE_COMMISSION",
+      );
+
+      expect(reversedCommission?.matures_at?.toISOString()).toBe(
+        maturesAt.toISOString(),
+      );
+    });
+
+    test("carries the rate snapshot onto the reversal", async () => {
+      await registerBaseCurrencies();
+
+      const original = await ledger.record({
+        source_type: "ADJUSTMENT",
+        source_id: randomUUID(),
+        entries: [
+          {
+            account_type: "CONSUMER_PAYMENT",
+            amount: 550,
+            currency: "BRL",
+            exchange_rate: 5.5,
+            exchange_rate_from_currency: "USD",
+          },
+          {
+            account_type: "PLATFORM_REVENUE",
+            amount: -550,
+            currency: "BRL",
+            exchange_rate: 5.5,
+            exchange_rate_from_currency: "USD",
+          },
+        ],
+      });
+
+      const reversal = await ledger.reverse(original[0].entry_group_id);
+
+      expect(reversal[0].exchange_rate?.toFixed(8)).toBe("5.50000000");
+      expect(reversal[0].exchange_rate_from_currency).toBe("USD");
+    });
+
+    test("nets the source to zero once reversed", async () => {
+      await registerBaseCurrencies();
+
+      const affiliate = await orchestrator.createUser();
+      const sale = await orchestrator.recordLedgerSale({
+        affiliate_id: affiliate.id,
+      });
+
+      await ledger.reverse(sale[0].entry_group_id);
+
+      expect((await ledger.balanceFor(affiliate.id, "USD")).toFixed(4)).toBe(
+        "0.0000",
+      );
+    });
+
+    test("refuses to reverse the same set twice", async () => {
+      await registerBaseCurrencies();
+
+      const original = await ledger.record({
+        source_type: "SALE",
+        source_id: randomUUID(),
+        entries: balancedPair(100),
+      });
+
+      await ledger.reverse(original[0].entry_group_id);
+
+      await expect(
+        ledger.reverse(original[0].entry_group_id),
+      ).rejects.toMatchObject({
+        name: "ValidationError",
+        message: `The ledger entry group "${original[0].entry_group_id}" has already been reversed.`,
+        statusCode: 400,
+      });
+    });
+
+    test("throws NotFoundError for an unknown group", async () => {
+      await registerBaseCurrencies();
+
+      const unknownGroupId = randomUUID();
+
+      await expect(ledger.reverse(unknownGroupId)).rejects.toMatchObject({
+        name: "NotFoundError",
+        message: `No ledger entries were found for the group "${unknownGroupId}".`,
+        action: "Check the entry group id and try again.",
+        statusCode: 404,
+      });
+    });
+  });
+
+  describe(".balancesFor()", () => {
+    test("returns nothing for an owner with no entries", async () => {
+      await registerBaseCurrencies();
+
+      const affiliate = await orchestrator.createUser();
+
+      expect(await ledger.balancesFor(affiliate.id)).toEqual([]);
+    });
+
+    // Signed as stored: negative while the platform owes it.
+    test("sums the commission entries an owner holds", async () => {
+      await registerBaseCurrencies();
+
+      const affiliate = await orchestrator.createUser();
+      await orchestrator.recordLedgerSale({ affiliate_id: affiliate.id });
+      await orchestrator.recordLedgerSale({ affiliate_id: affiliate.id });
+
+      const balances = await ledger.balancesFor(affiliate.id);
+
+      expect(balances).toHaveLength(1);
+      expect(balances[0].currency).toBe("USD");
+      expect(balances[0].amount.toFixed(4)).toBe("-20.0000");
+    });
+
+    // The property the whole model is built around: two currencies, two
+    // balances, never one number.
+    test("keeps each currency as its own balance", async () => {
+      await registerBaseCurrencies();
+
+      const affiliate = await orchestrator.createUser();
+      await orchestrator.recordLedgerSale({
+        affiliate_id: affiliate.id,
+        commission: 10,
+      });
+      await orchestrator.recordLedgerSale({
+        affiliate_id: affiliate.id,
+        currency: "BRL",
+        gross: 550,
+        supplier_cost: 385,
+        commission: 55,
+      });
+
+      const balances = await ledger.balancesFor(affiliate.id);
+
+      expect(balances).toEqual([
+        { currency: "BRL", amount: expect.anything() },
+        { currency: "USD", amount: expect.anything() },
+      ]);
+      expect(balances[0].amount.toFixed(4)).toBe("-55.0000");
+      expect(balances[1].amount.toFixed(4)).toBe("-10.0000");
+    });
+
+    test("does not mix one owner's balance into another's", async () => {
+      await registerBaseCurrencies();
+
+      const affiliate = await orchestrator.createUser();
+      const otherAffiliate = await orchestrator.createUser();
+
+      await orchestrator.recordLedgerSale({ affiliate_id: affiliate.id });
+
+      expect(await ledger.balancesFor(otherAffiliate.id)).toEqual([]);
+    });
+
+    test("only counts the requested account type", async () => {
+      await registerBaseCurrencies();
+
+      const affiliate = await orchestrator.createUser();
+      await orchestrator.recordLedgerSale({ affiliate_id: affiliate.id });
+
+      const payouts = await ledger.balancesFor(affiliate.id, {
+        account_type: "PAYOUT",
+      });
+
+      expect(payouts).toEqual([]);
+    });
+  });
+
+  describe(".balanceFor()", () => {
+    test("returns zero when the owner has nothing in that currency", async () => {
+      await registerBaseCurrencies();
+
+      const affiliate = await orchestrator.createUser();
+      await orchestrator.recordLedgerSale({ affiliate_id: affiliate.id });
+
+      expect((await ledger.balanceFor(affiliate.id, "BRL")).toFixed(4)).toBe(
+        "0.0000",
+      );
+    });
+
+    test("is case-insensitive on the currency code", async () => {
+      await registerBaseCurrencies();
+
+      const affiliate = await orchestrator.createUser();
+      await orchestrator.recordLedgerSale({ affiliate_id: affiliate.id });
+
+      expect((await ledger.balanceFor(affiliate.id, "usd")).toFixed(4)).toBe(
+        "-10.0000",
+      );
+    });
+
+    // The clawback case from task 9: a reversal after the commission was paid
+    // out leaves a balance carried against future earnings.
+    test("carries a negative balance after a clawback", async () => {
+      await registerBaseCurrencies();
+
+      const affiliate = await orchestrator.createUser();
+      const sale = await orchestrator.recordLedgerSale({
+        affiliate_id: affiliate.id,
+      });
+
+      // Settle the commission, as a payout run would.
+      await ledger.record({
+        source_type: "PAYOUT",
+        source_id: randomUUID(),
+        entries: [
+          {
+            account_type: "AFFILIATE_COMMISSION",
+            owner_id: affiliate.id,
+            amount: 10,
+            currency: "USD",
+          },
+          {
+            account_type: "PAYOUT",
+            owner_id: affiliate.id,
+            amount: -10,
+            currency: "USD",
+          },
+        ],
+      });
+
+      expect((await ledger.balanceFor(affiliate.id, "USD")).toFixed(4)).toBe(
+        "0.0000",
+      );
+
+      // The sale is charged back after the money already left.
+      await ledger.reverse(sale[0].entry_group_id);
+
+      expect(
+        (await ledger.payableBalancesFor(affiliate.id))[0].amount.toFixed(4),
+      ).toBe("-10.0000");
+    });
+  });
+
+  describe(".maturedBalancesFor()", () => {
+    test("excludes a commission still inside its hold", async () => {
+      await registerBaseCurrencies();
+
+      const affiliate = await orchestrator.createUser();
+      await orchestrator.recordLedgerSale({
+        affiliate_id: affiliate.id,
+        matures_at: new Date(Date.now() + 30 * DAY_IN_MS),
+      });
+
+      expect(await ledger.maturedBalancesFor(affiliate.id)).toEqual([]);
+    });
+
+    test("includes a commission whose hold has passed", async () => {
+      await registerBaseCurrencies();
+
+      const affiliate = await orchestrator.createUser();
+      await orchestrator.recordLedgerSale({
+        affiliate_id: affiliate.id,
+        matures_at: new Date(Date.now() - DAY_IN_MS),
+      });
+
+      const matured = await ledger.maturedBalancesFor(affiliate.id);
+
+      expect(matured).toHaveLength(1);
+      expect(matured[0].amount.toFixed(4)).toBe("-10.0000");
+    });
+
+    test("treats a null hold as always matured", async () => {
+      await registerBaseCurrencies();
+
+      const affiliate = await orchestrator.createUser();
+      await orchestrator.recordLedgerSale({
+        affiliate_id: affiliate.id,
+        matures_at: null,
+      });
+
+      const matured = await ledger.maturedBalancesFor(affiliate.id);
+
+      expect(matured[0].amount.toFixed(4)).toBe("-10.0000");
+    });
+
+    test("counts a commission as of the given moment", async () => {
+      await registerBaseCurrencies();
+
+      const affiliate = await orchestrator.createUser();
+      await orchestrator.recordLedgerSale({
+        affiliate_id: affiliate.id,
+        matures_at: new Date("2026-09-30T00:00:00.000Z"),
+      });
+
+      expect(
+        await ledger.maturedBalancesFor(affiliate.id, {
+          as_of: new Date("2026-09-29T00:00:00.000Z"),
+        }),
+      ).toEqual([]);
+
+      const matured = await ledger.maturedBalancesFor(affiliate.id, {
+        as_of: new Date("2026-10-01T00:00:00.000Z"),
+      });
+
+      expect(matured[0].amount.toFixed(4)).toBe("-10.0000");
+    });
+
+    // A reversal copies the original's hold, so a clawed-back commission
+    // never becomes payable — the two cancel at the same instant.
+    test("a reversed commission never matures", async () => {
+      await registerBaseCurrencies();
+
+      const affiliate = await orchestrator.createUser();
+      const maturesAt = new Date("2026-09-30T00:00:00.000Z");
+
+      const sale = await orchestrator.recordLedgerSale({
+        affiliate_id: affiliate.id,
+        matures_at: maturesAt,
+      });
+
+      await ledger.reverse(sale[0].entry_group_id);
+
+      const matured = await ledger.maturedBalancesFor(affiliate.id, {
+        as_of: new Date("2026-10-01T00:00:00.000Z"),
+      });
+
+      expect(matured[0].amount.toFixed(4)).toBe("0.0000");
+    });
+  });
+
+  describe(".payableBalancesFor()", () => {
+    // The one place the sign flips. The ledger stores what the platform holds,
+    // so a commission it owes is negative there and positive here.
+    test("reports an owed commission as positive", async () => {
+      await registerBaseCurrencies();
+
+      const affiliate = await orchestrator.createUser();
+      await orchestrator.recordLedgerSale({ affiliate_id: affiliate.id });
+
+      const payable = await ledger.payableBalancesFor(affiliate.id);
+
+      expect(payable[0].currency).toBe("USD");
+      expect(payable[0].amount.toFixed(4)).toBe("10.0000");
+    });
+
+    test("keeps each currency separate", async () => {
+      await registerBaseCurrencies();
+
+      const affiliate = await orchestrator.createUser();
+      await orchestrator.recordLedgerSale({ affiliate_id: affiliate.id });
+      await orchestrator.recordLedgerSale({
+        affiliate_id: affiliate.id,
+        currency: "BRL",
+        gross: 550,
+        supplier_cost: 385,
+        commission: 55,
+      });
+
+      const payable = await ledger.payableBalancesFor(affiliate.id);
+
+      expect(payable.map((balance) => balance.currency)).toEqual([
+        "BRL",
+        "USD",
+      ]);
+      expect(payable[0].amount.toFixed(4)).toBe("55.0000");
+      expect(payable[1].amount.toFixed(4)).toBe("10.0000");
+    });
+  });
+
+  describe(".findBySource()", () => {
+    test("returns every entry written against one source", async () => {
+      await registerBaseCurrencies();
+
+      const saleId = randomUUID();
+      await orchestrator.recordLedgerSale({ source_id: saleId });
+
+      const entries = await ledger.findBySource("SALE", saleId);
+
+      expect(entries).toHaveLength(4);
+      expect(entries.map((entry) => entry.account_type).sort()).toEqual([
+        "AFFILIATE_COMMISSION",
+        "CONSUMER_PAYMENT",
+        "PLATFORM_REVENUE",
+        "SUPPLIER_COST",
+      ]);
+    });
+
+    test("returns nothing for an unknown source", async () => {
+      await registerBaseCurrencies();
+
+      expect(await ledger.findBySource("SALE", randomUUID())).toEqual([]);
+    });
+  });
+
+  describe(".isSourceReversed()", () => {
+    test("is false for a source that has not been reversed", async () => {
+      await registerBaseCurrencies();
+
+      const saleId = randomUUID();
+      await orchestrator.recordLedgerSale({ source_id: saleId });
+
+      expect(await ledger.isSourceReversed("SALE", saleId)).toBe(false);
+    });
+
+    test("is true once a reversal has been written", async () => {
+      await registerBaseCurrencies();
+
+      const saleId = randomUUID();
+      const sale = await orchestrator.recordLedgerSale({ source_id: saleId });
+
+      await ledger.reverse(sale[0].entry_group_id);
+
+      expect(await ledger.isSourceReversed("SALE", saleId)).toBe(true);
+    });
+  });
+});

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import retry from "async-retry";
 import * as database from "infra/database";
 import storage from "infra/storage";
@@ -15,6 +16,7 @@ import authorization from "models/authorization";
 import currency from "models/currency";
 import exchangeRate from "models/exchange_rate";
 import pricing from "models/pricing";
+import ledger from "models/ledger";
 
 const EMAIL_HTTP_URL = `http://${process.env.EMAIL_HTTP_HOST}:${process.env.EMAIL_HTTP_PORT}`;
 
@@ -262,6 +264,60 @@ const createExchangeRate = async (rateData = {}) => {
   });
 };
 
+// Ledger
+const recordLedgerEntries = async (entries, sourceData = {}) => {
+  return ledger.record({
+    source_type: sourceData.source_type || "SALE",
+    source_id: sourceData.source_id || randomUUID(),
+    entries,
+  });
+};
+
+// The shape almost every ledger test needs: one sale distributed across the
+// four accounts it touches, already balanced. Amounts follow the sign
+// convention in models/ledger — positive is money the platform received,
+// negative is money it owes or spent.
+const recordLedgerSale = async (saleData = {}) => {
+  const gross = saleData.gross === undefined ? 100 : saleData.gross;
+  const supplierCost =
+    saleData.supplier_cost === undefined ? 70 : saleData.supplier_cost;
+  const commission =
+    saleData.commission === undefined ? 10 : saleData.commission;
+  const currencyCode = saleData.currency || "USD";
+  const maturesAt =
+    saleData.matures_at === undefined
+      ? new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)
+      : saleData.matures_at;
+
+  return recordLedgerEntries(
+    [
+      {
+        account_type: "CONSUMER_PAYMENT",
+        amount: gross,
+        currency: currencyCode,
+      },
+      {
+        account_type: "SUPPLIER_COST",
+        amount: -supplierCost,
+        currency: currencyCode,
+      },
+      {
+        account_type: "AFFILIATE_COMMISSION",
+        owner_id: saleData.affiliate_id,
+        amount: -commission,
+        currency: currencyCode,
+        matures_at: maturesAt,
+      },
+      {
+        account_type: "PLATFORM_REVENUE",
+        amount: -(gross - supplierCost - commission),
+        currency: currencyCode,
+      },
+    ],
+    { source_type: "SALE", source_id: saleData.source_id },
+  );
+};
+
 const orchestrator = {
   waitForAllServices,
   clearDatabase,
@@ -292,6 +348,8 @@ const orchestrator = {
   createCurrency,
   createExchangeRate,
   setGamePriceOverride,
+  recordLedgerEntries,
+  recordLedgerSale,
 };
 
 export default orchestrator;

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -17,6 +17,7 @@ import currency from "models/currency";
 import exchangeRate from "models/exchange_rate";
 import pricing from "models/pricing";
 import ledger from "models/ledger";
+import { Prisma } from "generated/prisma/client";
 
 const EMAIL_HTTP_URL = `http://${process.env.EMAIL_HTTP_HOST}:${process.env.EMAIL_HTTP_PORT}`;
 
@@ -274,48 +275,68 @@ const recordLedgerEntries = async (entries, sourceData = {}) => {
 };
 
 // The shape almost every ledger test needs: one sale distributed across the
-// four accounts it touches, already balanced. Amounts follow the sign
-// convention in models/ledger — positive is money the platform received,
-// negative is money it owes or spent.
+// accounts it touches, already balanced. Amounts follow the sign convention in
+// models/ledger — positive is money the platform received, negative is money it
+// owes or spent.
+//
+// With no affiliate_id this writes a three-entry set and no commission at all,
+// which is the global-storefront sale (Sale.store_id is nullable, and null
+// means no store attribution). Emitting an unowned commission instead would
+// book a liability owed to nobody.
 const recordLedgerSale = async (saleData = {}) => {
   const gross = saleData.gross === undefined ? 100 : saleData.gross;
   const supplierCost =
     saleData.supplier_cost === undefined ? 70 : saleData.supplier_cost;
-  const commission =
-    saleData.commission === undefined ? 10 : saleData.commission;
   const currencyCode = saleData.currency || "USD";
   const maturesAt =
     saleData.matures_at === undefined
-      ? new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)
+      ? ledger.maturityFor()
       : saleData.matures_at;
 
-  return recordLedgerEntries(
-    [
-      {
-        account_type: "CONSUMER_PAYMENT",
-        amount: gross,
-        currency: currencyCode,
-      },
-      {
-        account_type: "SUPPLIER_COST",
-        amount: -supplierCost,
-        currency: currencyCode,
-      },
-      {
-        account_type: "AFFILIATE_COMMISSION",
-        owner_id: saleData.affiliate_id,
-        amount: -commission,
-        currency: currencyCode,
-        matures_at: maturesAt,
-      },
-      {
-        account_type: "PLATFORM_REVENUE",
-        amount: -(gross - supplierCost - commission),
-        currency: currencyCode,
-      },
-    ],
-    { source_type: "SALE", source_id: saleData.source_id },
-  );
+  const commission = saleData.affiliate_id
+    ? saleData.commission === undefined
+      ? 10
+      : saleData.commission
+    : 0;
+
+  const entries = [
+    {
+      account_type: "CONSUMER_PAYMENT",
+      amount: gross,
+      currency: currencyCode,
+    },
+    {
+      account_type: "SUPPLIER_COST",
+      amount: -supplierCost,
+      currency: currencyCode,
+    },
+    {
+      // Decimal, not JavaScript numbers: a fractional gross or commission
+      // would leave a float residue and fail the zero-sum check, which would
+      // read as a model bug rather than a helper bug.
+      account_type: "PLATFORM_REVENUE",
+      amount: new Prisma.Decimal(gross)
+        .minus(supplierCost)
+        .minus(commission)
+        .negated(),
+      currency: currencyCode,
+    },
+  ];
+
+  if (saleData.affiliate_id) {
+    entries.push({
+      account_type: "AFFILIATE_COMMISSION",
+      owner_id: saleData.affiliate_id,
+      amount: -commission,
+      currency: currencyCode,
+      matures_at: maturesAt,
+    });
+  }
+
+  return recordLedgerEntries(entries, {
+    source_type: "SALE",
+    source_id: saleData.source_id,
+  });
 };
 
 const orchestrator = {

--- a/tests/unit/models/ledger.test.ts
+++ b/tests/unit/models/ledger.test.ts
@@ -1,14 +1,14 @@
 import { Prisma } from "generated/prisma/client";
-import { sumByCurrency } from "models/ledger";
+import ledger from "models/ledger";
 
 describe("models/ledger.ts", () => {
   describe(".sumByCurrency()", () => {
     test("returns an empty map for no entries", () => {
-      expect(sumByCurrency([]).size).toBe(0);
+      expect(ledger.sumByCurrency([]).size).toBe(0);
     });
 
     test("nets a balanced set to zero", () => {
-      const totals = sumByCurrency([
+      const totals = ledger.sumByCurrency([
         { amount: new Prisma.Decimal("100.0000"), currency: "USD" },
         { amount: new Prisma.Decimal("-70.0000"), currency: "USD" },
         { amount: new Prisma.Decimal("-10.0000"), currency: "USD" },
@@ -19,7 +19,7 @@ describe("models/ledger.ts", () => {
     });
 
     test("reports the residual of an unbalanced set", () => {
-      const totals = sumByCurrency([
+      const totals = ledger.sumByCurrency([
         { amount: new Prisma.Decimal("100.0000"), currency: "USD" },
         { amount: new Prisma.Decimal("-70.0000"), currency: "USD" },
       ]);
@@ -30,7 +30,7 @@ describe("models/ledger.ts", () => {
     // The rule that keeps a BRL balance and a USD balance from being silently
     // added together. Each currency has to net to zero on its own.
     test("totals each currency independently", () => {
-      const totals = sumByCurrency([
+      const totals = ledger.sumByCurrency([
         { amount: new Prisma.Decimal("100.0000"), currency: "USD" },
         { amount: new Prisma.Decimal("-100.0000"), currency: "USD" },
         { amount: new Prisma.Decimal("550.0000"), currency: "BRL" },
@@ -45,7 +45,7 @@ describe("models/ledger.ts", () => {
     // A set that nets to zero across currencies is still unbalanced. Summing
     // them together would hide it, which is exactly the mistake this prevents.
     test("does not offset one currency against another", () => {
-      const totals = sumByCurrency([
+      const totals = ledger.sumByCurrency([
         { amount: new Prisma.Decimal("100.0000"), currency: "USD" },
         { amount: new Prisma.Decimal("-100.0000"), currency: "BRL" },
       ]);
@@ -55,7 +55,7 @@ describe("models/ledger.ts", () => {
     });
 
     test("is case-insensitive on the currency code", () => {
-      const totals = sumByCurrency([
+      const totals = ledger.sumByCurrency([
         { amount: new Prisma.Decimal("100.0000"), currency: "usd" },
         { amount: new Prisma.Decimal("-100.0000"), currency: "USD" },
       ]);
@@ -67,7 +67,7 @@ describe("models/ledger.ts", () => {
     // Decimal arithmetic, not floating point: 0.1 + 0.2 - 0.3 is exactly zero
     // here and famously is not in a JavaScript number.
     test("sums without floating point error", () => {
-      const totals = sumByCurrency([
+      const totals = ledger.sumByCurrency([
         { amount: new Prisma.Decimal("0.1000"), currency: "USD" },
         { amount: new Prisma.Decimal("0.2000"), currency: "USD" },
         { amount: new Prisma.Decimal("-0.3000"), currency: "USD" },
@@ -77,7 +77,7 @@ describe("models/ledger.ts", () => {
     });
 
     test("keeps the full 4-decimal scale", () => {
-      const totals = sumByCurrency([
+      const totals = ledger.sumByCurrency([
         { amount: new Prisma.Decimal("0.0001"), currency: "USD" },
         { amount: new Prisma.Decimal("-0.0002"), currency: "USD" },
       ]);

--- a/tests/unit/models/ledger.test.ts
+++ b/tests/unit/models/ledger.test.ts
@@ -1,0 +1,88 @@
+import { Prisma } from "generated/prisma/client";
+import { sumByCurrency } from "models/ledger";
+
+describe("models/ledger.ts", () => {
+  describe(".sumByCurrency()", () => {
+    test("returns an empty map for no entries", () => {
+      expect(sumByCurrency([]).size).toBe(0);
+    });
+
+    test("nets a balanced set to zero", () => {
+      const totals = sumByCurrency([
+        { amount: new Prisma.Decimal("100.0000"), currency: "USD" },
+        { amount: new Prisma.Decimal("-70.0000"), currency: "USD" },
+        { amount: new Prisma.Decimal("-10.0000"), currency: "USD" },
+        { amount: new Prisma.Decimal("-20.0000"), currency: "USD" },
+      ]);
+
+      expect(totals.get("USD")?.toFixed(4)).toBe("0.0000");
+    });
+
+    test("reports the residual of an unbalanced set", () => {
+      const totals = sumByCurrency([
+        { amount: new Prisma.Decimal("100.0000"), currency: "USD" },
+        { amount: new Prisma.Decimal("-70.0000"), currency: "USD" },
+      ]);
+
+      expect(totals.get("USD")?.toFixed(4)).toBe("30.0000");
+    });
+
+    // The rule that keeps a BRL balance and a USD balance from being silently
+    // added together. Each currency has to net to zero on its own.
+    test("totals each currency independently", () => {
+      const totals = sumByCurrency([
+        { amount: new Prisma.Decimal("100.0000"), currency: "USD" },
+        { amount: new Prisma.Decimal("-100.0000"), currency: "USD" },
+        { amount: new Prisma.Decimal("550.0000"), currency: "BRL" },
+        { amount: new Prisma.Decimal("-500.0000"), currency: "BRL" },
+      ]);
+
+      expect(totals.size).toBe(2);
+      expect(totals.get("USD")?.toFixed(4)).toBe("0.0000");
+      expect(totals.get("BRL")?.toFixed(4)).toBe("50.0000");
+    });
+
+    // A set that nets to zero across currencies is still unbalanced. Summing
+    // them together would hide it, which is exactly the mistake this prevents.
+    test("does not offset one currency against another", () => {
+      const totals = sumByCurrency([
+        { amount: new Prisma.Decimal("100.0000"), currency: "USD" },
+        { amount: new Prisma.Decimal("-100.0000"), currency: "BRL" },
+      ]);
+
+      expect(totals.get("USD")?.toFixed(4)).toBe("100.0000");
+      expect(totals.get("BRL")?.toFixed(4)).toBe("-100.0000");
+    });
+
+    test("is case-insensitive on the currency code", () => {
+      const totals = sumByCurrency([
+        { amount: new Prisma.Decimal("100.0000"), currency: "usd" },
+        { amount: new Prisma.Decimal("-100.0000"), currency: "USD" },
+      ]);
+
+      expect(totals.size).toBe(1);
+      expect(totals.get("USD")?.toFixed(4)).toBe("0.0000");
+    });
+
+    // Decimal arithmetic, not floating point: 0.1 + 0.2 - 0.3 is exactly zero
+    // here and famously is not in a JavaScript number.
+    test("sums without floating point error", () => {
+      const totals = sumByCurrency([
+        { amount: new Prisma.Decimal("0.1000"), currency: "USD" },
+        { amount: new Prisma.Decimal("0.2000"), currency: "USD" },
+        { amount: new Prisma.Decimal("-0.3000"), currency: "USD" },
+      ]);
+
+      expect(totals.get("USD")?.isZero()).toBe(true);
+    });
+
+    test("keeps the full 4-decimal scale", () => {
+      const totals = sumByCurrency([
+        { amount: new Prisma.Decimal("0.0001"), currency: "USD" },
+        { amount: new Prisma.Decimal("-0.0002"), currency: "USD" },
+      ]);
+
+      expect(totals.get("USD")?.toFixed(4)).toBe("-0.0001");
+    });
+  });
+});


### PR DESCRIPTION
Tasks 5 and 6 of the payments milestone: an append-only LedgerEntry table
and models/ledger.ts, the zero-sum accounting core commissions and payouts
will be built on.

record() rejects any set of entries that does not sum to zero within a
currency, so money is never created or destroyed by a write and a bug that
loses money fails at write time rather than surfacing in a payout weeks
later. reverse() writes a negated mirror of a set instead of updating it,
so history is never rewritten. Balances are a SUM over rows, computed per
currency and never stored.

Sign convention: positive is money the platform received or holds, negative
is money it owes or spent. A single signed column cannot make both "cash in
is positive" and "commission owed is positive" true under a zero-sum rule,
so a commission balance is negative while owed and payableBalancesFor() is
the single place that sign is flipped for user-facing reads.

Three decisions worth recording:

- A reversal copies the original's matures_at. With matured balance defined
  as "matures_at IS NULL OR matures_at <= now", a null on the reversal would
  leave the original matured with nothing offsetting it, so the clawback
  would silently claw nothing back.
- Amounts carrying more than 4 decimal places are refused, not rounded.
  Rounding at write time can turn a set that validated as balanced into one
  that lands unbalanced.
- The ledger accepts the base currency unregistered, matching models/pricing,
  so an unconfigured install can still record a sale. A registered but
  disabled currency is accepted too: turning a currency off stops us pricing
  in it, it does not un-happen sales already made in it.

source_type is a VarChar rather than an enum so the polymorphic reference
can reach an Order later without a migration; account_type is a real enum
because a new account is an accounting decision and the database is the only
place integrity can be enforced without foreign keys.

Task 5 originally covered three tables. Only LedgerEntry ships here:
PayoutAccount's field list is exactly what the unanswered tax posture
determines, so it moves to task 8 and Payout to task 10, where each is first
used. docs/payments-tasks.md is updated to say so.

No features registered and no filterOutput branch — this PR adds no
endpoints, per the plan's rule that features are registered by the PR that
needs them.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NL35am9GhcP7nLVBT5eq4c