### PR TITLE
feat: add commission and supplier cost terms

### DIFF
--- a/docs/payments-tasks.md
+++ b/docs/payments-tasks.md
@@ -17,6 +17,8 @@ For the runtime design of the pricing path — how a game gets a price in the vi
 | 4d. Currency selection by region header  | ✅ done ([#188](https://github.com/pedromello/manifoldpowered.com/issues/188)) |
 | 5. Ledger schema                         | ✅ done                                                                        |
 | 6. Ledger model                          | ✅ done                                                                        |
+| 6a. Commercial terms                     | ✅ done                                                                        |
+| 6b. Ledger writes on acquisition         | not started                                                                    |
 | 7–11 (providers, payouts)                | not started                                                                    |
 
 Each task is a separate small PR, landed in order, with `npm run test` passing on its own before merge — the same format as `docs/backoffice-tasks.md`.
@@ -212,6 +214,43 @@ The runtime design — the sign convention, why a reversal copies `matures_at`, 
 **Also decided here, and provisionally.** Commission is booked as a liability at the moment of sale, which means `PLATFORM_REVENUE` holds the residual margin rather than gross revenue. `docs/legal/business-description.md` describes commission as "an ordinary marketing expense" paid out of Manifold's own revenue, and phase-0 item 3 asks counsel to settle accrued-liability versus unearned treatment. Accruing at sale is the only option that lets the set balance at write time, but the account name and the disclosure wording should be reconciled once that answer lands.
 
 **Still open, and it belongs to task 10 rather than here.** The 30-day hold is a per-sale rolling maturation (`matures_at`), while Steam — the model this is patterned on — pays a fixed date after a calendar month closes: month M's sales are paid on M+1's 30th, so the hold varies from 30 to 60 days per sale and 30 days is the floor. Run a monthly payout against a rolling 30-day maturation and the two produce nearly identical payment dates, so nothing here needs to change. What differs is which statement a sale lands on: a calendar-month period keyed on sale date is far easier for an affiliate to reconcile than "everything that happened to mature since the last run". `matures_at` records _when a commission is safe to pay_ and stays independent of whichever rule computes it, so task 10 can choose the period without touching the ledger.
+
+---
+
+### 6a. Commercial terms — commission and supplier cost
+
+**TLDR:** The two rates a balanced sale needs, neither of which existed anywhere.
+
+Tasks 5 and 6 shipped a ledger that nothing could write to, because a sale's entry set needs three numbers and only one of them (the price) existed. This adds the other two.
+
+**Commission** is `Store.commission_rate`, nullable — null means the platform default applies, which is honest about the fact that most outlets never get a bespoke rate where a copied default would look like a decision someone made. **Admin-set only**, and unreachable from the owner-facing `PATCH /api/v1/stores/[slug]` because `storeSchema` does not carry the field. An outlet influencing its own commission is the same category of problem as one setting its own prices.
+
+**Supplier cost** is `SupplierTerms`, pointing at a supplier polymorphically (`supplier_type` + `supplier_id`) exactly as `LedgerEntry` points at its source. A studio supplies the games in the catalogue today; a gift-card distributor will supply codes later. `supplier_type` is a string column rather than an enum because onboarding a new kind of supplier is a commercial event, not a schema change.
+
+Three decisions worth keeping:
+
+- **Commission is a fraction of the gross**, not of the margin left after supplier cost. It makes an affiliate's earnings depend only on the price a buyer saw, which is the number they can actually verify. **This diverges from `docs/legal/storefront-owner-agreement-termsheet.md`**, which still describes commission as a percentage of net — the term sheet needs updating with counsel, and until it does the agreement and the code disagree. The default is 10%.
+- **`SupplierTerms` is mutable, not append-only like `ExchangeRate`.** Rates are append-only there so a conversion made months ago stays reproducible. That reasoning does not carry: the ledger already snapshots the actual amounts at sale time, so a rate table with `effective_at` would add a second historical record that could only ever disagree with the first. `AdminActionLog` keeps the audit trail.
+- **An integration supplier has no default rate.** A studio-supplied game has a house rate that has always applied (70%), but an integration's cost comes from a negotiated contract, so assuming one would book a margin nobody agreed to. An unconfigured integration fails loudly.
+
+**Done when:** an admin can set an outlet's commission and a supplier's cost rate, and neither is reachable by the party it pays. ✅
+
+---
+
+### 6b. Ledger writes on acquisition
+
+**TLDR:** Make a sale actually produce the balanced entry set.
+
+`Sale` gains a currency and rate snapshot — `models/pricing.ResolvedPrice` already returns exactly `{ amount, currency, exchange_rate }` "so a sale recorded from this price can be reconciled later", and is simply not wired up. `ledger.record()` gains a transaction client, because it currently writes with the module-level `prisma` and would commit outside `acquireGame`'s transaction.
+
+Platform revenue is computed as the **residual** (`gross − supplierCost − commission`), never independently. `record()` refuses over-scale amounts rather than rounding them, so `gross × (1 − s − c)` would leave a sub-cent remainder and fail the zero-sum check; the residual absorbs all rounding.
+
+Two defects to fix while here, both found during 6a:
+
+- `acquireGame` **discards the `Sale` it creates**, so there is no id to key entries on.
+- Re-acquiring writes a **second `Sale`** — the `LibraryItem` upsert is idempotent, `tx.sale.create` is not. Harmless today; double commission once money attaches.
+
+**Done when:** an acquisition through an outlet writes four entries summing to zero, and a second acquisition writes none.
 
 ---
 

--- a/models/authorization.ts
+++ b/models/authorization.ts
@@ -13,6 +13,7 @@ import {
   StudioMember,
   Currency,
   ExchangeRate,
+  SupplierTerms,
 } from "generated/prisma/client";
 import { InternalServerError } from "infra/errors";
 
@@ -109,6 +110,13 @@ const AVAILABLE_FEATURES = [
   "update:currency:any",
   "read:exchange_rate:any",
   "create:exchange_rate:any",
+
+  // Commercial terms (admin). Admin-only by design: an outlet influencing its
+  // own commission is the same category of problem as one setting its own
+  // prices (docs/legal/phase-0-checklist.md).
+  "update:store_commission:any",
+  "read:supplier_terms:any",
+  "update:supplier_terms:any",
 ];
 
 // The feature set granted to every user once they activate their account
@@ -158,6 +166,9 @@ const ADMIN_ONLY_FEATURES = [
   "update:currency:any",
   "read:exchange_rate:any",
   "create:exchange_rate:any",
+  "update:store_commission:any",
+  "read:supplier_terms:any",
+  "update:supplier_terms:any",
 ];
 
 const ADMIN_FEATURES = [...ACTIVATED_USER_FEATURES, ...ADMIN_ONLY_FEATURES];
@@ -481,8 +492,7 @@ function filterOutput(user: Partial<User>, feature: string, resource: unknown) {
   if (
     feature === "create:store" ||
     feature === "read:public_store" ||
-    feature === "update:store" ||
-    feature === "read:store:any"
+    feature === "update:store"
   ) {
     const storeOutput = resource as Store;
     return {
@@ -494,6 +504,46 @@ function filterOutput(user: Partial<User>, feature: string, resource: unknown) {
       owner_id: storeOutput.owner_id,
       created_at: storeOutput.created_at,
       updated_at: storeOutput.updated_at,
+    };
+  }
+
+  // The admin view of a store, kept separate from the branch above because that
+  // one also serves read:public_store — commission_rate must not be visible to
+  // anyone browsing, and the owner-facing paths deliberately do not show it
+  // either while the rate is admin-set.
+  if (
+    feature === "read:store:any" ||
+    feature === "update:store_commission:any"
+  ) {
+    const storeOutput = resource as Store;
+    return {
+      id: storeOutput.id,
+      slug: storeOutput.slug,
+      name: storeOutput.name,
+      description: storeOutput.description,
+      logo_url: storeOutput.logo_url,
+      owner_id: storeOutput.owner_id,
+      // Null means no bespoke rate, so the platform default applies. Serialised
+      // at full scale for the same reason exchange rates are: the wire format
+      // should not depend on how the driver stringifies a Decimal.
+      commission_rate: storeOutput.commission_rate?.toFixed(8) ?? null,
+      created_at: storeOutput.created_at,
+      updated_at: storeOutput.updated_at,
+    };
+  }
+
+  if (
+    feature === "read:supplier_terms:any" ||
+    feature === "update:supplier_terms:any"
+  ) {
+    const termsOutput = resource as SupplierTerms;
+    return {
+      id: termsOutput.id,
+      supplier_type: termsOutput.supplier_type,
+      supplier_id: termsOutput.supplier_id,
+      cost_rate: termsOutput.cost_rate.toFixed(8),
+      created_at: termsOutput.created_at,
+      updated_at: termsOutput.updated_at,
     };
   }
 

--- a/models/commercial_terms.ts
+++ b/models/commercial_terms.ts
@@ -1,0 +1,278 @@
+import { prisma } from "infra/database";
+import { z } from "zod";
+import { Game, Prisma, Store } from "generated/prisma/client";
+import { NotFoundError, ValidationError } from "infra/errors";
+
+// Rates are fractions of the gross sale amount, stored at the same scale as an
+// exchange rate. Four decimals would round 0.0725 fine but not 0.06125, and a
+// commission silently rounded is a commission argued about later.
+const RATE_SCALE = 8;
+
+// What an outlet earns on a sale it referred, when no bespoke rate is set.
+//
+// Deliberately a fraction of the GROSS sale, not of the margin left after
+// supplier cost. That is a commercial decision, not an arithmetic one: it makes
+// an affiliate's earnings depend only on the price a buyer saw, which is the
+// number they can actually verify.
+//
+// Note this diverges from docs/legal/storefront-owner-agreement-termsheet.md,
+// which still describes commission as a percentage of net. The term sheet needs
+// updating to match; until it does, the agreement and the code disagree.
+export const DEFAULT_COMMISSION_RATE = new Prisma.Decimal("0.10");
+
+// The kinds of supplier the platform can owe money to. A Studio supplies the
+// games in the catalogue; an integration (a gift-card distributor) will supply
+// codes. Extending this list is a commercial event and costs no migration,
+// which is why SupplierTerms.supplier_type is a string column rather than an
+// enum.
+export const SUPPLIER_TYPES = ["STUDIO", "INTEGRATION"] as const;
+
+export type SupplierType = (typeof SUPPLIER_TYPES)[number];
+
+// Defaults by supplier kind, applied when a supplier has no terms of its own.
+//
+// INTEGRATION deliberately has none. A studio-supplied game has a house rate
+// that has always applied, but an integration's cost comes from a negotiated
+// contract — assuming one would mean booking a margin nobody agreed to, so an
+// unconfigured integration fails loudly instead.
+export const DEFAULT_SUPPLIER_COST_RATES: Partial<
+  Record<SupplierType, Prisma.Decimal>
+> = {
+  STUDIO: new Prisma.Decimal("0.70"),
+};
+
+function isDecimalLike(value: number | string) {
+  try {
+    new Prisma.Decimal(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// A share of a sale, so it cannot be negative and cannot exceed the whole.
+// Validated on the raw input with the transform last, so the schema's input
+// type stays number | string — see the same note in models/ledger.
+const rateSchema = z
+  .union([z.number(), z.string()])
+  .superRefine((value, ctx) => {
+    if (!isDecimalLike(value)) {
+      ctx.addIssue({ code: "custom", message: "rate must be a number" });
+      return;
+    }
+
+    const rate = new Prisma.Decimal(value);
+
+    if (!rate.isFinite()) {
+      ctx.addIssue({ code: "custom", message: "rate must be finite" });
+      return;
+    }
+
+    if (rate.lessThan(0) || rate.greaterThan(1)) {
+      ctx.addIssue({
+        code: "custom",
+        message: "rate must be between 0 and 1",
+      });
+    }
+
+    // Refused rather than rounded, matching how the ledger treats an over-scale
+    // amount: a rate quietly trimmed on the way in no longer reproduces the
+    // commission it was used to calculate.
+    if (rate.decimalPlaces() > RATE_SCALE) {
+      ctx.addIssue({
+        code: "custom",
+        message: `rate must have at most ${RATE_SCALE} decimal places`,
+      });
+    }
+  })
+  .transform((value) => new Prisma.Decimal(value));
+
+export const commissionRateSchema = z.object({
+  // Null clears the bespoke rate and returns the outlet to the platform
+  // default, which is a different intent from setting it to zero.
+  commission_rate: rateSchema.nullable(),
+});
+
+export const supplierTermsSchema = z.object({
+  supplier_type: z.enum(SUPPLIER_TYPES),
+  supplier_id: z.uuid(),
+  cost_rate: rateSchema,
+});
+
+// Spelled out rather than inferred from the schema. This project compiles with
+// strictNullChecks off, and Zod decides a piped schema's key is optional by
+// asking whether `undefined` extends its output — which is true of everything
+// under that setting, so `cost_rate` would come back optional despite the
+// schema requiring it. Same reason models/ledger declares ParsedLedgerEntry.
+export interface SupplierTermsDto {
+  supplier_type: SupplierType;
+  supplier_id: string;
+  cost_rate: Prisma.Decimal;
+}
+
+export const supplierTermsQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  supplier_type: z.enum(SUPPLIER_TYPES).optional(),
+});
+
+// What the outlet that referred a sale earns, as a fraction of the gross.
+function commissionRateFor(
+  storeRow: Pick<Store, "commission_rate">,
+): Prisma.Decimal {
+  return storeRow.commission_rate ?? DEFAULT_COMMISSION_RATE;
+}
+
+// What the supplier of this game keeps, as a fraction of the gross.
+//
+// A game's supplier is its studio. When gift cards arrive their supplier will
+// be an integration, resolved through the same two-column reference, and this
+// function grows a branch rather than the table growing a column.
+async function supplierCostRateFor(
+  gameRow: Pick<Game, "studio_id">,
+): Promise<Prisma.Decimal> {
+  return await costRateFor("STUDIO", gameRow.studio_id);
+}
+
+async function costRateFor(
+  supplierType: SupplierType,
+  supplierId: string,
+): Promise<Prisma.Decimal> {
+  const terms = await findSupplierTerms(supplierType, supplierId);
+
+  if (terms) {
+    return terms.cost_rate;
+  }
+
+  const defaultRate = DEFAULT_SUPPLIER_COST_RATES[supplierType];
+
+  if (!defaultRate) {
+    throw new ValidationError({
+      message: `No cost rate is configured for the ${supplierType} supplier "${supplierId}".`,
+      action: "Set supplier terms for this supplier and try again.",
+    });
+  }
+
+  return defaultRate;
+}
+
+async function findSupplierTerms(
+  supplierType: SupplierType,
+  supplierId: string,
+) {
+  return await prisma.supplierTerms.findUnique({
+    where: {
+      supplier_type_supplier_id: {
+        supplier_type: supplierType,
+        supplier_id: supplierId,
+      },
+    },
+  });
+}
+
+// Upsert rather than create: a supplier has one set of terms at a time, and
+// re-agreeing a rate is the ordinary case rather than an error.
+async function setSupplierTerms(termsDto: SupplierTermsDto) {
+  await validateSupplierExists(termsDto.supplier_type, termsDto.supplier_id);
+
+  return await prisma.supplierTerms.upsert({
+    where: {
+      supplier_type_supplier_id: {
+        supplier_type: termsDto.supplier_type,
+        supplier_id: termsDto.supplier_id,
+      },
+    },
+    create: termsDto,
+    update: { cost_rate: termsDto.cost_rate },
+  });
+}
+
+async function findAllSupplierTermsPaginated({
+  page = 1,
+  limit = 20,
+  supplier_type,
+}: {
+  page?: number;
+  limit?: number;
+  supplier_type?: SupplierType;
+} = {}) {
+  const where: Prisma.SupplierTermsWhereInput = {};
+
+  if (supplier_type) {
+    where.supplier_type = supplier_type;
+  }
+
+  const [terms, total] = await Promise.all([
+    prisma.supplierTerms.findMany({
+      where,
+      orderBy: [{ supplier_type: "asc" }, { created_at: "desc" }],
+      skip: (page - 1) * limit,
+      take: limit,
+    }),
+    prisma.supplierTerms.count({ where }),
+  ]);
+
+  return {
+    terms,
+    pagination: {
+      page,
+      limit,
+      total,
+      pages: Math.ceil(total / limit),
+    },
+  };
+}
+
+// Kept out of store.update on purpose. That function re-parses the store
+// through storeSchema and regenerates the slug from the name, which is a lot of
+// unrelated machinery to run in order to change one number — and it is the
+// owner-facing path, which must never be able to reach this column.
+async function setCommissionRate(
+  storeId: string,
+  commissionRate: Prisma.Decimal | null,
+) {
+  return await prisma.store.update({
+    where: { id: storeId },
+    data: { commission_rate: commissionRate },
+  });
+}
+
+// No foreign keys, so a supplier id that matches nothing would become terms
+// that silently never apply to anything.
+async function validateSupplierExists(
+  supplierType: SupplierType,
+  supplierId: string,
+) {
+  if (supplierType !== "STUDIO") {
+    // Integrations have no table to check against yet. When one exists this
+    // grows a branch; until then the type itself is the only validation.
+    return;
+  }
+
+  const foundStudio = await prisma.studio.findUnique({
+    where: { id: supplierId },
+    select: { id: true },
+  });
+
+  if (!foundStudio) {
+    throw new NotFoundError({
+      message: `No studio was found for the supplier id "${supplierId}".`,
+      action: "Check the supplier id and try again.",
+    });
+  }
+}
+
+const commercialTerms = {
+  DEFAULT_COMMISSION_RATE,
+  DEFAULT_SUPPLIER_COST_RATES,
+  SUPPLIER_TYPES,
+  commissionRateFor,
+  supplierCostRateFor,
+  costRateFor,
+  findSupplierTerms,
+  setSupplierTerms,
+  findAllSupplierTermsPaginated,
+  setCommissionRate,
+};
+
+export default commercialTerms;

--- a/pages/api/v1/backoffice/stores/[slug]/index.ts
+++ b/pages/api/v1/backoffice/stores/[slug]/index.ts
@@ -3,10 +3,17 @@ import { createRouter } from "next-connect";
 import controller from "infra/controller";
 import store from "models/store";
 import authorization from "models/authorization";
+import auditLog from "models/audit_log";
+import commercialTerms, { commissionRateSchema } from "models/commercial_terms";
+import { ValidationError } from "infra/errors";
 
 export default createRouter<NextApiRequest, NextApiResponse>()
   .use(controller.injectAnonymousOrUser)
   .get(controller.canRequest("read:store:any"), getHandler)
+  .patch(
+    controller.canRequest("update:store_commission:any"),
+    patchCommissionHandler,
+  )
   .handler(controller.errorHandlers);
 
 async function getHandler(req: NextApiRequest, res: NextApiResponse) {
@@ -18,6 +25,61 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
     req.context.user,
     "read:store:any",
     foundStore,
+  );
+
+  return res.status(200).json(secureOutputValues);
+}
+
+// Commission is the only thing an admin may change about someone else's outlet,
+// so this deliberately does not reuse the owner-facing update path — that one
+// re-slugifies on a name change and has no business being reachable from here.
+async function patchCommissionHandler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const result = commissionRateSchema.safeParse(req.body);
+
+  if (!result.success) {
+    throw new ValidationError({
+      message: "One or more fields are invalid",
+      action: "Check the fields and try again",
+      context: result.error.issues,
+    });
+  }
+
+  const { slug } = req.query;
+
+  // findOneBySlug throws NotFoundError, so an unknown outlet never reaches the
+  // update or the audit log.
+  const existingStore = await store.findOneBySlug(slug as string);
+
+  const updatedStore = await commercialTerms.setCommissionRate(
+    existingStore.id,
+    result.data.commission_rate,
+  );
+
+  await auditLog.record({
+    admin_user_id: req.context.user.id as string,
+    action: "store:update_commission",
+    target_type: "store",
+    target_id: existingStore.id,
+    // What someone earns is worth being able to reconstruct, so the previous
+    // rate is snapshotted the same way user:disable snapshots features.
+    metadata: {
+      slug: existingStore.slug,
+      previous: {
+        commission_rate: existingStore.commission_rate?.toFixed(8) ?? null,
+      },
+      applied: {
+        commission_rate: result.data.commission_rate?.toFixed(8) ?? null,
+      },
+    },
+  });
+
+  const secureOutputValues = authorization.filterOutput(
+    req.context.user,
+    "update:store_commission:any",
+    updatedStore,
   );
 
   return res.status(200).json(secureOutputValues);

--- a/pages/api/v1/backoffice/supplier-terms/index.ts
+++ b/pages/api/v1/backoffice/supplier-terms/index.ts
@@ -1,0 +1,96 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { createRouter } from "next-connect";
+import controller from "infra/controller";
+import authorization from "models/authorization";
+import auditLog from "models/audit_log";
+import commercialTerms, {
+  supplierTermsSchema,
+  supplierTermsQuerySchema,
+  SupplierTermsDto,
+} from "models/commercial_terms";
+import { ValidationError } from "infra/errors";
+
+export default createRouter<NextApiRequest, NextApiResponse>()
+  .use(controller.injectAnonymousOrUser)
+  .get(controller.canRequest("read:supplier_terms:any"), getHandler)
+  .put(controller.canRequest("update:supplier_terms:any"), putHandler)
+  .handler(controller.errorHandlers);
+
+async function getHandler(req: NextApiRequest, res: NextApiResponse) {
+  const result = supplierTermsQuerySchema.safeParse(req.query);
+
+  if (!result.success) {
+    throw new ValidationError({
+      message: "Invalid query parameters",
+      action: "Check the fields and try again",
+      context: result.error.issues,
+    });
+  }
+
+  const { terms, pagination } =
+    await commercialTerms.findAllSupplierTermsPaginated(result.data);
+
+  const secureOutputValues = terms.map((termsItem) =>
+    authorization.filterOutput(
+      req.context.user,
+      "read:supplier_terms:any",
+      termsItem,
+    ),
+  );
+
+  return res.status(200).json({
+    supplier_terms: secureOutputValues,
+    pagination,
+  });
+}
+
+// PUT rather than POST: a supplier has one set of terms at a time, so the
+// request states what the terms now are rather than adding another row.
+// Re-agreeing a rate is ordinary, not a conflict.
+async function putHandler(req: NextApiRequest, res: NextApiResponse) {
+  const result = supplierTermsSchema.safeParse(req.body);
+
+  if (!result.success) {
+    throw new ValidationError({
+      message: "One or more fields are invalid",
+      action: "Check the fields and try again",
+      context: result.error.issues,
+    });
+  }
+
+  const termsDto = result.data as SupplierTermsDto;
+
+  const existingTerms = await commercialTerms.findSupplierTerms(
+    termsDto.supplier_type,
+    termsDto.supplier_id,
+  );
+
+  const savedTerms = await commercialTerms.setSupplierTerms(termsDto);
+
+  await auditLog.record({
+    admin_user_id: req.context.user.id as string,
+    action: "supplier_terms:update",
+    target_type: "supplier_terms",
+    target_id: savedTerms.id,
+    // The cost rate is the platform's entire gross margin, so what it was
+    // before is worth keeping.
+    metadata: {
+      supplier_type: savedTerms.supplier_type,
+      supplier_id: savedTerms.supplier_id,
+      previous: {
+        cost_rate: existingTerms?.cost_rate.toFixed(8) ?? null,
+      },
+      applied: {
+        cost_rate: savedTerms.cost_rate.toFixed(8),
+      },
+    },
+  });
+
+  const secureOutputValues = authorization.filterOutput(
+    req.context.user,
+    "update:supplier_terms:any",
+    savedTerms,
+  );
+
+  return res.status(existingTerms ? 200 : 201).json(secureOutputValues);
+}

--- a/prisma/migrations/20260805031340_add_commercial_terms/migration.sql
+++ b/prisma/migrations/20260805031340_add_commercial_terms/migration.sql
@@ -1,0 +1,17 @@
+-- AlterTable
+ALTER TABLE "stores" ADD COLUMN     "commission_rate" DECIMAL(19,8);
+
+-- CreateTable
+CREATE TABLE "supplier_terms" (
+    "id" TEXT NOT NULL,
+    "supplier_type" VARCHAR(50) NOT NULL,
+    "supplier_id" TEXT NOT NULL,
+    "cost_rate" DECIMAL(19,8) NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "supplier_terms_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "supplier_terms_supplier_type_supplier_id_key" ON "supplier_terms"("supplier_type", "supplier_id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -246,8 +246,20 @@ model Store {
   description String?  @db.Text
   logo_url    String?  @db.VarChar(2048)
   owner_id    String // Logical reference to User.id (creator/owner)
-  created_at  DateTime @default(now())
-  updated_at  DateTime @updatedAt
+
+  // What this outlet earns on a sale it referred, as a fraction of the gross.
+  // Null means the platform default applies — most outlets never get a bespoke
+  // rate, and a null is honest about that where a copied default would look
+  // like a decision someone made.
+  //
+  // Admin-set only. Storefront owners must never influence their own commission
+  // for the same reason they cannot set prices (docs/legal/phase-0-checklist.md),
+  // which is why this is absent from storeSchema and unreachable through the
+  // owner-facing PATCH.
+  commission_rate Decimal? @db.Decimal(19, 8)
+
+  created_at DateTime @default(now())
+  updated_at DateTime @updatedAt
 
   @@index([owner_id])
   @@index([slug])
@@ -485,6 +497,36 @@ model LedgerEntry {
   @@index([owner_id, account_type, currency, matures_at])
   @@index([source_type, source_id])
   @@map("ledger_entries")
+}
+
+// What a supplier keeps from a sale, as a fraction of the gross.
+//
+// Suppliers come in kinds: a Studio supplies the games in the catalogue today,
+// and a gift-card distributor will supply codes later. They share nothing but
+// the fact that they take a cut, so this points at one polymorphically
+// (supplier_type + supplier_id) exactly as LedgerEntry points at its source.
+//
+// supplier_type is deliberately not an enum. Onboarding a new kind of supplier
+// is a commercial event, not a schema change, and it must not cost a migration.
+// The allowed values live in models/commercial_terms, which is where
+// referential integrity lives in a schema with no foreign keys.
+//
+// Unlike ExchangeRate this is mutable rather than append-only. Rates are
+// append-only there so a conversion made months ago stays reproducible; that
+// reasoning does not carry here, because the ledger already snapshots the
+// actual amounts at sale time. A second historical record could only ever
+// disagree with the first. AdminActionLog keeps the audit trail.
+model SupplierTerms {
+  id            String  @id @default(uuid())
+  supplier_type String  @db.VarChar(50) // STUDIO, INTEGRATION — see models/commercial_terms
+  supplier_id   String // Logical reference to Studio.id, or to a future integration
+  cost_rate     Decimal @db.Decimal(19, 8)
+
+  created_at DateTime @default(now())
+  updated_at DateTime @updatedAt
+
+  @@unique([supplier_type, supplier_id])
+  @@map("supplier_terms")
 }
 
 // A price set explicitly by a developer/admin for one currency. Its presence

--- a/tests/integration/api/v1/backoffice/stores/[slug]/patch.test.ts
+++ b/tests/integration/api/v1/backoffice/stores/[slug]/patch.test.ts
@@ -1,0 +1,187 @@
+import orchestrator from "tests/orchestrator";
+
+const BASE_URL = "http://localhost:3000/api/v1/backoffice/stores";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+});
+
+beforeEach(async () => {
+  await orchestrator.clearDatabaseRows();
+});
+
+async function createStoreWithOwner() {
+  const owner = await orchestrator.createUser();
+  await orchestrator.activateUser(owner.id);
+  return await orchestrator.createStore(owner.id);
+}
+
+async function patchAs(slug: string, sessionToken: string, body: unknown) {
+  return await fetch(`${BASE_URL}/${slug}`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+      Cookie: `session_id=${sessionToken}`,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("PATCH /api/v1/backoffice/stores/[slug]", () => {
+  describe("Anonymous user", () => {
+    test("should return 403 Forbidden", async () => {
+      const store = await createStoreWithOwner();
+
+      const response = await fetch(`${BASE_URL}/${store.slug}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ commission_rate: 0.2 }),
+      });
+
+      expect(response.status).toBe(403);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        message: "You do not have permission to perform this action",
+        action:
+          "Verify your user has the following features: update:store_commission:any",
+        name: "ForbiddenError",
+        status_code: 403,
+      });
+    });
+  });
+
+  // The rate is what keeps an outlet an affiliate rather than a negotiating
+  // party, so its own owner must not be able to move it.
+  describe("Outlet owner", () => {
+    test("should return 403 Forbidden on their own outlet", async () => {
+      const owner = await orchestrator.createUser();
+      await orchestrator.activateUser(owner.id);
+      const store = await orchestrator.createStore(owner.id);
+      const session = await orchestrator.createSession(owner.id);
+
+      const response = await patchAs(store.slug, session.token, {
+        commission_rate: 0.9,
+      });
+
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe("Admin user", () => {
+    test("should set the commission rate and return 200", async () => {
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+      const store = await createStoreWithOwner();
+
+      const response = await patchAs(store.slug, session.token, {
+        commission_rate: 0.2,
+      });
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+      expect(responseBody.id).toBe(store.id);
+      expect(responseBody.slug).toBe(store.slug);
+      expect(responseBody.commission_rate).toBe("0.20000000");
+    });
+
+    // Null returns the outlet to the platform default, which is a different
+    // intent from a rate of zero.
+    test("should clear the rate when given null", async () => {
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+      const store = await createStoreWithOwner();
+
+      await patchAs(store.slug, session.token, { commission_rate: 0.2 });
+      const response = await patchAs(store.slug, session.token, {
+        commission_rate: null,
+      });
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+      expect(responseBody.commission_rate).toBeNull();
+    });
+
+    test("should write an audit log entry with the previous rate", async () => {
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+      const store = await createStoreWithOwner();
+
+      await patchAs(store.slug, session.token, { commission_rate: 0.2 });
+      await patchAs(store.slug, session.token, { commission_rate: 0.3 });
+
+      const auditLog = (await import("models/audit_log")).default;
+      const { logs } = await auditLog.findAllPaginated({
+        action: "store:update_commission",
+        target_id: store.id,
+      });
+
+      expect(logs).toHaveLength(2);
+      expect(logs[0].metadata).toMatchObject({
+        slug: store.slug,
+        previous: { commission_rate: "0.20000000" },
+        applied: { commission_rate: "0.30000000" },
+      });
+    });
+
+    test("should return 400 for a rate above 1", async () => {
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+      const store = await createStoreWithOwner();
+
+      const response = await patchAs(store.slug, session.token, {
+        commission_rate: 1.5,
+      });
+
+      expect(response.status).toBe(400);
+
+      const responseBody = await response.json();
+      expect(responseBody.name).toBe("ValidationError");
+      expect(responseBody.message).toBe("One or more fields are invalid");
+      expect(responseBody.action).toBe("Check the fields and try again");
+      expect(responseBody.status_code).toBe(400);
+    });
+
+    test("should return 400 for a negative rate", async () => {
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+      const store = await createStoreWithOwner();
+
+      const response = await patchAs(store.slug, session.token, {
+        commission_rate: -0.1,
+      });
+
+      expect(response.status).toBe(400);
+    });
+
+    test("should return 404 for an unknown outlet", async () => {
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+
+      const response = await patchAs("no-such-outlet", session.token, {
+        commission_rate: 0.2,
+      });
+
+      expect(response.status).toBe(404);
+    });
+
+    // The rate must never appear on a surface a shopper can reach.
+    test("should not expose the rate through the public store endpoint", async () => {
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+      const store = await createStoreWithOwner();
+
+      await patchAs(store.slug, session.token, { commission_rate: 0.2 });
+
+      const publicResponse = await fetch(
+        `http://localhost:3000/api/v1/stores/${store.slug}`,
+      );
+      const publicBody = await publicResponse.json();
+
+      expect(publicResponse.status).toBe(200);
+      expect(publicBody).not.toHaveProperty("commission_rate");
+    });
+  });
+});

--- a/tests/integration/api/v1/backoffice/supplier-terms/get.test.ts
+++ b/tests/integration/api/v1/backoffice/supplier-terms/get.test.ts
@@ -1,0 +1,135 @@
+import orchestrator from "tests/orchestrator";
+
+const BASE_URL = "http://localhost:3000/api/v1/backoffice/supplier-terms";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+});
+
+beforeEach(async () => {
+  await orchestrator.clearDatabaseRows();
+});
+
+async function getAs(sessionToken: string, query = "") {
+  return await fetch(`${BASE_URL}${query}`, {
+    headers: { Cookie: `session_id=${sessionToken}` },
+  });
+}
+
+async function createStudio() {
+  const owner = await orchestrator.createUser();
+  await orchestrator.activateUser(owner.id);
+  return await orchestrator.createStudio(owner.id);
+}
+
+describe("GET /api/v1/backoffice/supplier-terms", () => {
+  describe("Anonymous user", () => {
+    test("should return 403 Forbidden", async () => {
+      const response = await fetch(BASE_URL);
+
+      expect(response.status).toBe(403);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        message: "You do not have permission to perform this action",
+        action:
+          "Verify your user has the following features: read:supplier_terms:any",
+        name: "ForbiddenError",
+        status_code: 403,
+      });
+    });
+  });
+
+  describe("Activated user without the feature", () => {
+    test("should return 403 Forbidden", async () => {
+      const user = await orchestrator.createUser();
+      await orchestrator.activateUser(user.id);
+      const session = await orchestrator.createSession(user.id);
+
+      const response = await getAs(session.token);
+
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe("Admin user", () => {
+    test("should return an empty list with pagination", async () => {
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+
+      const response = await getAs(session.token);
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+      expect(responseBody.supplier_terms).toEqual([]);
+      expect(responseBody.pagination).toEqual({
+        page: 1,
+        limit: 20,
+        total: 0,
+        pages: 0,
+      });
+    });
+
+    test("should return recorded terms at full scale", async () => {
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+      const studio = await createStudio();
+
+      await orchestrator.setSupplierTerms({
+        supplier_id: studio.id,
+        cost_rate: 0.7,
+      });
+
+      const response = await getAs(session.token);
+      const responseBody = await response.json();
+
+      expect(responseBody.supplier_terms).toHaveLength(1);
+      expect(responseBody.supplier_terms[0]).toEqual({
+        id: expect.any(String),
+        supplier_type: "STUDIO",
+        supplier_id: studio.id,
+        cost_rate: "0.70000000",
+        created_at: expect.any(String),
+        updated_at: expect.any(String),
+      });
+    });
+
+    test("should filter by supplier type", async () => {
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+      const studio = await createStudio();
+
+      await orchestrator.setSupplierTerms({
+        supplier_id: studio.id,
+        cost_rate: 0.7,
+      });
+      await orchestrator.setSupplierTerms({
+        supplier_type: "INTEGRATION",
+        supplier_id: "33333333-3333-3333-3333-333333333333",
+        cost_rate: 0.92,
+      });
+
+      const response = await getAs(session.token, "?supplier_type=INTEGRATION");
+      const responseBody = await response.json();
+
+      expect(responseBody.pagination.total).toBe(1);
+      expect(responseBody.supplier_terms[0].cost_rate).toBe("0.92000000");
+    });
+
+    test("should return 400 for an unknown supplier type filter", async () => {
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+
+      const response = await getAs(session.token, "?supplier_type=WHOLESALER");
+
+      expect(response.status).toBe(400);
+
+      const responseBody = await response.json();
+      expect(responseBody.name).toBe("ValidationError");
+      expect(responseBody.message).toBe("Invalid query parameters");
+      expect(responseBody.action).toBe("Check the fields and try again");
+      expect(responseBody.status_code).toBe(400);
+    });
+  });
+});

--- a/tests/integration/api/v1/backoffice/supplier-terms/put.test.ts
+++ b/tests/integration/api/v1/backoffice/supplier-terms/put.test.ts
@@ -1,0 +1,227 @@
+import { randomUUID } from "node:crypto";
+import orchestrator from "tests/orchestrator";
+
+const BASE_URL = "http://localhost:3000/api/v1/backoffice/supplier-terms";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+});
+
+beforeEach(async () => {
+  await orchestrator.clearDatabaseRows();
+});
+
+async function putAs(sessionToken: string, body: unknown) {
+  return await fetch(BASE_URL, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      Cookie: `session_id=${sessionToken}`,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+async function createStudio() {
+  const owner = await orchestrator.createUser();
+  await orchestrator.activateUser(owner.id);
+  return await orchestrator.createStudio(owner.id);
+}
+
+describe("PUT /api/v1/backoffice/supplier-terms", () => {
+  describe("Anonymous user", () => {
+    test("should return 403 Forbidden", async () => {
+      const response = await fetch(BASE_URL, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          supplier_type: "STUDIO",
+          supplier_id: randomUUID(),
+          cost_rate: 0.7,
+        }),
+      });
+
+      expect(response.status).toBe(403);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        message: "You do not have permission to perform this action",
+        action:
+          "Verify your user has the following features: update:supplier_terms:any",
+        name: "ForbiddenError",
+        status_code: 403,
+      });
+    });
+  });
+
+  describe("Activated user without the feature", () => {
+    test("should return 403 Forbidden", async () => {
+      const user = await orchestrator.createUser();
+      await orchestrator.activateUser(user.id);
+      const session = await orchestrator.createSession(user.id);
+      const studio = await createStudio();
+
+      const response = await putAs(session.token, {
+        supplier_type: "STUDIO",
+        supplier_id: studio.id,
+        cost_rate: 0.7,
+      });
+
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe("Admin user", () => {
+    test("should create terms and return 201", async () => {
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+      const studio = await createStudio();
+
+      const response = await putAs(session.token, {
+        supplier_type: "STUDIO",
+        supplier_id: studio.id,
+        cost_rate: 0.7,
+      });
+
+      expect(response.status).toBe(201);
+
+      const responseBody = await response.json();
+      expect(responseBody.supplier_type).toBe("STUDIO");
+      expect(responseBody.supplier_id).toBe(studio.id);
+      expect(responseBody.cost_rate).toBe("0.70000000");
+    });
+
+    // Re-agreeing a rate replaces the terms rather than adding a second row,
+    // so the second write is a 200 rather than another 201.
+    test("should replace existing terms and return 200", async () => {
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+      const studio = await createStudio();
+
+      await putAs(session.token, {
+        supplier_type: "STUDIO",
+        supplier_id: studio.id,
+        cost_rate: 0.7,
+      });
+
+      const response = await putAs(session.token, {
+        supplier_type: "STUDIO",
+        supplier_id: studio.id,
+        cost_rate: 0.65,
+      });
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+      expect(responseBody.cost_rate).toBe("0.65000000");
+
+      const listResponse = await fetch(BASE_URL, {
+        headers: { Cookie: `session_id=${session.token}` },
+      });
+      const listBody = await listResponse.json();
+      expect(listBody.pagination.total).toBe(1);
+    });
+
+    test("should write an audit log entry with the previous rate", async () => {
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+      const studio = await createStudio();
+
+      await putAs(session.token, {
+        supplier_type: "STUDIO",
+        supplier_id: studio.id,
+        cost_rate: 0.7,
+      });
+      await putAs(session.token, {
+        supplier_type: "STUDIO",
+        supplier_id: studio.id,
+        cost_rate: 0.6,
+      });
+
+      const auditLog = (await import("models/audit_log")).default;
+      const { logs } = await auditLog.findAllPaginated({
+        action: "supplier_terms:update",
+      });
+
+      expect(logs).toHaveLength(2);
+      expect(logs[0].metadata).toMatchObject({
+        supplier_type: "STUDIO",
+        supplier_id: studio.id,
+        previous: { cost_rate: "0.70000000" },
+        applied: { cost_rate: "0.60000000" },
+      });
+    });
+
+    test("should return 404 when the studio does not exist", async () => {
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+      const missingId = randomUUID();
+
+      const response = await putAs(session.token, {
+        supplier_type: "STUDIO",
+        supplier_id: missingId,
+        cost_rate: 0.7,
+      });
+
+      expect(response.status).toBe(404);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        message: `No studio was found for the supplier id "${missingId}".`,
+        action: "Check the supplier id and try again.",
+        name: "NotFoundError",
+        status_code: 404,
+      });
+    });
+
+    test("should return 400 for an unknown supplier type", async () => {
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+      const studio = await createStudio();
+
+      const response = await putAs(session.token, {
+        supplier_type: "WHOLESALER",
+        supplier_id: studio.id,
+        cost_rate: 0.7,
+      });
+
+      expect(response.status).toBe(400);
+
+      const responseBody = await response.json();
+      expect(responseBody.name).toBe("ValidationError");
+      expect(responseBody.message).toBe("One or more fields are invalid");
+      expect(responseBody.action).toBe("Check the fields and try again");
+      expect(responseBody.status_code).toBe(400);
+    });
+
+    test("should return 400 for a rate above 1", async () => {
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+      const studio = await createStudio();
+
+      const response = await putAs(session.token, {
+        supplier_type: "STUDIO",
+        supplier_id: studio.id,
+        cost_rate: 1.2,
+      });
+
+      expect(response.status).toBe(400);
+    });
+
+    // Storage is 8 decimals; a rate quietly trimmed no longer reproduces the
+    // cost it was used to calculate, so it is refused rather than rounded.
+    test("should return 400 for a rate with more than 8 decimal places", async () => {
+      const admin = await orchestrator.createAdminUser();
+      const session = await orchestrator.createSession(admin.id);
+      const studio = await createStudio();
+
+      const response = await putAs(session.token, {
+        supplier_type: "STUDIO",
+        supplier_id: studio.id,
+        cost_rate: "0.123456789",
+      });
+
+      expect(response.status).toBe(400);
+    });
+  });
+});

--- a/tests/integration/models/commercial_terms.test.ts
+++ b/tests/integration/models/commercial_terms.test.ts
@@ -1,0 +1,214 @@
+import orchestrator from "tests/orchestrator";
+import commercialTerms from "models/commercial_terms";
+import { Prisma } from "generated/prisma/client";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+beforeEach(async () => {
+  await orchestrator.clearDatabaseRows();
+});
+
+describe("models/commercial_terms.ts", () => {
+  describe(".commissionRateFor()", () => {
+    test("falls back to the platform default when the outlet has none", () => {
+      const rate = commercialTerms.commissionRateFor({ commission_rate: null });
+
+      expect(rate.toFixed(8)).toBe("0.10000000");
+    });
+
+    test("prefers the outlet's own rate", () => {
+      const rate = commercialTerms.commissionRateFor({
+        commission_rate: new Prisma.Decimal("0.25"),
+      });
+
+      expect(rate.toFixed(8)).toBe("0.25000000");
+    });
+
+    // Zero is a real commercial arrangement — an outlet that earns nothing —
+    // and must not be mistaken for "unset".
+    test("treats a zero rate as a decision, not as unset", () => {
+      const rate = commercialTerms.commissionRateFor({
+        commission_rate: new Prisma.Decimal("0"),
+      });
+
+      expect(rate.toFixed(8)).toBe("0.00000000");
+    });
+  });
+
+  describe(".supplierCostRateFor()", () => {
+    test("falls back to the studio default when the supplier has no terms", async () => {
+      const owner = await orchestrator.createUser();
+      const studio = await orchestrator.createStudio(owner.id);
+
+      const rate = await commercialTerms.supplierCostRateFor({
+        studio_id: studio.id,
+      });
+
+      expect(rate.toFixed(8)).toBe("0.70000000");
+    });
+
+    test("prefers terms recorded for that supplier", async () => {
+      const owner = await orchestrator.createUser();
+      const studio = await orchestrator.createStudio(owner.id);
+
+      await orchestrator.setSupplierTerms({
+        supplier_id: studio.id,
+        cost_rate: 0.6,
+      });
+
+      const rate = await commercialTerms.supplierCostRateFor({
+        studio_id: studio.id,
+      });
+
+      expect(rate.toFixed(8)).toBe("0.60000000");
+    });
+
+    test("keeps one supplier's terms away from another's", async () => {
+      const owner = await orchestrator.createUser();
+      const studio = await orchestrator.createStudio(owner.id);
+      const otherStudio = await orchestrator.createStudio(owner.id);
+
+      await orchestrator.setSupplierTerms({
+        supplier_id: studio.id,
+        cost_rate: 0.5,
+      });
+
+      const rate = await commercialTerms.supplierCostRateFor({
+        studio_id: otherStudio.id,
+      });
+
+      expect(rate.toFixed(8)).toBe("0.70000000");
+    });
+  });
+
+  describe(".costRateFor()", () => {
+    // A studio-supplied game has a house rate that has always applied. An
+    // integration's cost comes from a negotiated contract, so assuming one
+    // would book a margin nobody agreed to.
+    test("refuses an integration with no configured terms", async () => {
+      const supplierId = "11111111-1111-1111-1111-111111111111";
+
+      await expect(
+        commercialTerms.costRateFor("INTEGRATION", supplierId),
+      ).rejects.toMatchObject({
+        name: "ValidationError",
+        message: `No cost rate is configured for the INTEGRATION supplier "${supplierId}".`,
+        action: "Set supplier terms for this supplier and try again.",
+        statusCode: 400,
+      });
+    });
+
+    test("uses configured terms for an integration", async () => {
+      const supplierId = "11111111-1111-1111-1111-111111111111";
+
+      await commercialTerms.setSupplierTerms({
+        supplier_type: "INTEGRATION",
+        supplier_id: supplierId,
+        cost_rate: new Prisma.Decimal("0.92"),
+      });
+
+      const rate = await commercialTerms.costRateFor("INTEGRATION", supplierId);
+
+      expect(rate.toFixed(8)).toBe("0.92000000");
+    });
+  });
+
+  describe(".setSupplierTerms()", () => {
+    test("records terms for a studio", async () => {
+      const owner = await orchestrator.createUser();
+      const studio = await orchestrator.createStudio(owner.id);
+
+      const terms = await commercialTerms.setSupplierTerms({
+        supplier_type: "STUDIO",
+        supplier_id: studio.id,
+        cost_rate: new Prisma.Decimal("0.65"),
+      });
+
+      expect(terms.supplier_type).toBe("STUDIO");
+      expect(terms.supplier_id).toBe(studio.id);
+      expect(terms.cost_rate.toFixed(8)).toBe("0.65000000");
+    });
+
+    // A supplier has one set of terms at a time; re-agreeing a rate is the
+    // ordinary case, not a conflict.
+    test("replaces terms rather than accumulating rows", async () => {
+      const owner = await orchestrator.createUser();
+      const studio = await orchestrator.createStudio(owner.id);
+
+      await orchestrator.setSupplierTerms({
+        supplier_id: studio.id,
+        cost_rate: 0.7,
+      });
+      await orchestrator.setSupplierTerms({
+        supplier_id: studio.id,
+        cost_rate: 0.55,
+      });
+
+      const { terms, pagination } =
+        await commercialTerms.findAllSupplierTermsPaginated();
+
+      expect(pagination.total).toBe(1);
+      expect(terms[0].cost_rate.toFixed(8)).toBe("0.55000000");
+    });
+
+    // No foreign keys, so an id matching no studio would become terms that
+    // silently never apply to anything.
+    test("rejects a supplier id that matches no studio", async () => {
+      const missingId = "22222222-2222-2222-2222-222222222222";
+
+      await expect(
+        commercialTerms.setSupplierTerms({
+          supplier_type: "STUDIO",
+          supplier_id: missingId,
+          cost_rate: new Prisma.Decimal("0.7"),
+        }),
+      ).rejects.toMatchObject({
+        name: "NotFoundError",
+        message: `No studio was found for the supplier id "${missingId}".`,
+        action: "Check the supplier id and try again.",
+        statusCode: 404,
+      });
+    });
+  });
+
+  describe(".setCommissionRate()", () => {
+    test("sets and then clears an outlet's rate", async () => {
+      const owner = await orchestrator.createUser();
+      const store = await orchestrator.createStore(owner.id);
+
+      const withRate = await commercialTerms.setCommissionRate(
+        store.id,
+        new Prisma.Decimal("0.15"),
+      );
+      expect(withRate.commission_rate?.toFixed(8)).toBe("0.15000000");
+
+      // Null returns the outlet to the platform default, which is a different
+      // intent from setting the rate to zero.
+      const cleared = await commercialTerms.setCommissionRate(store.id, null);
+      expect(cleared.commission_rate).toBeNull();
+      expect(commercialTerms.commissionRateFor(cleared).toFixed(8)).toBe(
+        "0.10000000",
+      );
+    });
+
+    // The rate must not be reachable from the path an outlet owner controls.
+    test("is not settable through the owner-facing store update", async () => {
+      const owner = await orchestrator.createUser();
+      const store = await orchestrator.createStore(owner.id);
+      const storeModel = (await import("models/store")).default;
+
+      await storeModel.update(store.id, {
+        name: "Renamed Outlet",
+        // @ts-expect-error deliberately outside the owner-facing schema
+        commission_rate: new Prisma.Decimal("0.99"),
+      });
+
+      const reloaded = await storeModel.findOneBySlug("renamed-outlet");
+
+      expect(reloaded.commission_rate).toBeNull();
+    });
+  });
+});

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -17,6 +17,7 @@ import currency from "models/currency";
 import exchangeRate from "models/exchange_rate";
 import pricing from "models/pricing";
 import ledger from "models/ledger";
+import commercialTerms from "models/commercial_terms";
 import { Prisma } from "generated/prisma/client";
 
 const EMAIL_HTTP_URL = `http://${process.env.EMAIL_HTTP_HOST}:${process.env.EMAIL_HTTP_PORT}`;
@@ -265,6 +266,24 @@ const createExchangeRate = async (rateData = {}) => {
   });
 };
 
+// Commercial terms
+const setStoreCommissionRate = async (storeId, rate) => {
+  return commercialTerms.setCommissionRate(
+    storeId,
+    rate === null ? null : new Prisma.Decimal(String(rate)),
+  );
+};
+
+const setSupplierTerms = async (termsData = {}) => {
+  return commercialTerms.setSupplierTerms({
+    supplier_type: termsData.supplier_type || "STUDIO",
+    supplier_id: termsData.supplier_id,
+    cost_rate: new Prisma.Decimal(
+      String(termsData.cost_rate === undefined ? 0.7 : termsData.cost_rate),
+    ),
+  });
+};
+
 // Ledger
 const recordLedgerEntries = async (entries, sourceData = {}) => {
   return ledger.record({
@@ -371,6 +390,8 @@ const orchestrator = {
   setGamePriceOverride,
   recordLedgerEntries,
   recordLedgerSale,
+  setStoreCommissionRate,
+  setSupplierTerms,
 };
 
 export default orchestrator;


### PR DESCRIPTION
## Description

Tasks 5 and 6 shipped a ledger nothing could write to. A sale's balanced entry set needs three numbers and only the price existed; this adds the other two.

**Commission** is `Store.commission_rate`, nullable — null means the platform default (10%) applies, which is honest about the fact that most outlets never get a bespoke rate, where a copied default would look like a decision someone made. Admin-set only, and unreachable from the owner-facing `PATCH /api/v1/stores/[slug]` because `storeSchema` does not carry the field: an outlet influencing its own commission is the same category of problem as one setting its own prices (`docs/legal/phase-0-checklist.md`).

**Supplier cost** is `SupplierTerms`, pointing at a supplier polymorphically (`supplier_type` + `supplier_id`) exactly as `LedgerEntry` points at its source. A studio supplies the catalogue today at 70%; a gift-card distributor will supply codes later. `supplier_type` is a string column rather than an enum because onboarding a new kind of supplier is a commercial event, not a schema change, and must cost no migration.

New endpoints, both audit-logged with a `previous` snapshot:

- `PATCH /api/v1/backoffice/stores/[slug]` — the first admin mutation on stores
- `GET` / `PUT /api/v1/backoffice/supplier-terms`

### Decisions worth recording

- **Commission is a fraction of the gross**, not of the margin left after supplier cost, so an affiliate's earnings depend only on the price a buyer saw — the number they can actually verify. **This diverges from `docs/legal/storefront-owner-agreement-termsheet.md:25`, which still says net.** That draft needs updating with counsel; until it does, the agreement and the code disagree. Flagged in `docs/payments-tasks.md` rather than edited here, since it is a legal document.
- **`SupplierTerms` is mutable rather than append-only like `ExchangeRate`.** Rates are append-only there so a conversion made months ago stays reproducible. That reasoning does not carry: the ledger already snapshots the actual amounts at sale time, so a second historical record could only ever disagree with the first. `AdminActionLog` keeps the audit trail.
- **An integration supplier has no default rate.** A studio-supplied game has a house rate that has always applied, but an integration's cost comes from a negotiated contract, so assuming one would book a margin nobody agreed to. An unconfigured integration fails loudly instead.
- The admin view of a store is **split into its own `filterOutput` branch**, because the existing one also serves `read:public_store` — the rate must never reach anyone browsing. There is a test asserting it is absent from the public endpoint.
- Rates are **refused rather than rounded** past 8 decimal places, matching how the ledger treats an over-scale amount and for the same reason.

Three admin-only features added (`update:store_commission:any`, `read:supplier_terms:any`, `update:supplier_terms:any`), so no `ACTIVATED_USER_FEATURES` churn and none of the four whole-array test fixtures need touching. `npm run features:backfill` run.

## Related issue

Part of #177. Adds tasks 6a and 6b to `docs/payments-tasks.md`; this PR is 6a.

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] 📖 Documentation
- [ ] ♻️ Refactor
- [x] 🧪 Tests

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] `npm run lint:eslint:check` passes
- [x] `npm run lint:prettier:check` passes
- [x] `npm run test` passes
- [x] Added or updated tests where relevant

Suite run as `npm run test:no-docker` (Docker image pulls are blocked in this environment): **618 passed / 621**. The 3 failures are the two suites `.claude/hooks/README.md` documents as environmental — `api/v1/status/get.test.ts` (asserts Postgres `16.0`, native package reports `16.13`) and `api/v1/items/games/steam-import/post.test.ts` (needs the unreachable Steam API). Both pass in CI.

## Follow-up

Next is 6b: `Sale` gains a currency, `ledger.record()` gains a transaction client, and `acquireGame` writes the balanced set. Two defects found during this work are fixed there — `acquireGame` currently discards the `Sale` it creates, and re-acquiring writes a second one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NL35am9GhcP7nLVBT5eq4c)_