### PR TITLE
feat: write balanced ledger entries on acquisition

### DIFF
--- a/docs/payments-tasks.md
+++ b/docs/payments-tasks.md
@@ -18,7 +18,7 @@ For the runtime design of the pricing path — how a game gets a price in the vi
 | 5. Ledger schema                         | ✅ done                                                                        |
 | 6. Ledger model                          | ✅ done                                                                        |
 | 6a. Commercial terms                     | ✅ done                                                                        |
-| 6b. Ledger writes on acquisition         | not started                                                                    |
+| 6b. Ledger writes on acquisition         | ✅ done                                                                        |
 | 7–11 (providers, payouts)                | not started                                                                    |
 
 Each task is a separate small PR, landed in order, with `npm run test` passing on its own before merge — the same format as `docs/backoffice-tasks.md`.
@@ -245,12 +245,13 @@ Three decisions worth keeping:
 
 Platform revenue is computed as the **residual** (`gross − supplierCost − commission`), never independently. `record()` refuses over-scale amounts rather than rounding them, so `gross × (1 − s − c)` would leave a sub-cent remainder and fail the zero-sum check; the residual absorbs all rounding.
 
-Two defects to fix while here, both found during 6a:
+`acquireGame` **discarded the `Sale` it created**, so there was no id to key entries on. Fixed here.
 
-- `acquireGame` **discards the `Sale` it creates**, so there is no id to key entries on.
-- Re-acquiring writes a **second `Sale`** — the `LibraryItem` upsert is idempotent, `tx.sale.create` is not. Harmless today; double commission once money attaches.
+**Correction: the second `Sale` on re-acquisition is not a defect.** It was recorded as one in an earlier draft of this plan, wrongly. The model comment on `Sale` says plainly that a sale is an acquisition _event_, written every time, "letting the same user acquire the same game through multiple stores over time without losing any of those events" — and a test asserts it. Attribution per referral is the point of the table.
 
-**Done when:** an acquisition through an outlet writes four entries summing to zero, and a second acquisition writes none.
+**Done when:** an acquisition through an outlet writes four entries summing to zero, in the same transaction as the sale. ✅
+
+**Fixed in passing:** `pricing.priceFor()` gated on the currency being registered and enabled, while `displayPricesFor()` deliberately lets the base currency work unregistered so localisation stays additive on a working default. The two disagreed, so an unconfigured install would show a USD price and then refuse to sell it. The base currency now resolves in both.
 
 ---
 
@@ -373,6 +374,7 @@ Responses gain `display_price` (`amount`, `base_amount`, `currency`, `symbol`) a
 ## Open questions
 
 0. **Write idempotency** — nothing prevents the same sale being recorded to the ledger twice, so a duplicated payment webhook would owe an affiliate double. `(source_type, source_id)` cannot be unique because reversals share it. Raised during task 5 and deliberately not guessed at: it is a schema decision, so it wants settling before checkout writes the first real entry.
+   0b. **Should a repeat acquisition through the _same_ outlet earn commission again?** It currently does, because a `Sale` is an acquisition event by design and each one now mints a commission. Through a _different_ outlet that is plainly correct — the referral earned it. Through the same one it is the cheapest way for an outlet owner to farm their own commission, and today only the 30-day hold and the payout threshold discourage it (`docs/legal/business-description.md`). Deduplicating per outlet would close it while keeping the multi-outlet attribution the table exists for.
 1. **Platform-side reporting** — balances are read per owner, and platform accounts have no owner, so there is no read path for platform revenue or supplier cost. Task 11 is affiliate-facing only, so no task currently covers it.
 2. **FX cost bearer** — when a sale is collected in BRL and commission is paid in USD, who absorbs the conversion spread? Currently assigned to the affiliate in the agreement draft.
 3. **Rate staleness** — how old is too old? A rate table with no freshness policy will eventually sell something at a two-month-old rate.

--- a/models/authorization.ts
+++ b/models/authorization.ts
@@ -605,6 +605,9 @@ function filterOutput(user: Partial<User>, feature: string, resource: unknown) {
       game_title: saleOutput.game_title,
       store_id: saleOutput.store_id,
       price_at_sale: saleOutput.price_at_sale.toFixed(2),
+      // Without the currency the amount above is a number with no unit, which
+      // for an outlet reading its own sales is worse than showing nothing.
+      currency: saleOutput.currency,
       created_at: saleOutput.created_at,
     };
   }

--- a/models/ledger.ts
+++ b/models/ledger.ts
@@ -269,7 +269,15 @@ function sumByCurrency(
 // Currencies are never mixed in a single sum. A set spanning BRL and USD must
 // balance in each independently — the conversion between them is itself a pair
 // of entries carrying the rate that produced it.
-async function record(recordDto: RecordLedgerEntriesDto) {
+//
+// `client` lets a caller write the set inside a transaction it already owns.
+// An acquisition that recorded its Sale but not the entries describing it, or
+// the reverse, would leave the books disagreeing with the thing they describe —
+// and with no UPDATE available on an append-only table, nothing could repair it.
+async function record(
+  recordDto: RecordLedgerEntriesDto,
+  { client = prisma }: { client?: Prisma.TransactionClient } = {},
+) {
   const result = recordLedgerEntriesSchema.safeParse({
     ...recordDto,
     entries: (recordDto.entries ?? []).map((entry) => ({
@@ -306,11 +314,12 @@ async function record(recordDto: RecordLedgerEntriesDto) {
     entries
       .map((entry) => entry.owner_id)
       .filter((ownerId): ownerId is string => ownerId !== null),
+    client,
   );
 
   const entryGroupId = randomUUID();
 
-  return await prisma.ledgerEntry.createManyAndReturn({
+  return await client.ledgerEntry.createManyAndReturn({
     data: entries.map((entry) => ({
       entry_group_id: entryGroupId,
       account_type: entry.account_type,
@@ -646,14 +655,17 @@ function assertOwnershipMatchesAccounts(entries: ParsedLedgerEntry[]) {
 // Same reasoning as the currency check below: with no foreign keys, an owner id
 // that matches no user becomes a commission that never appears in any statement
 // or payout, and nothing fails until someone notices the money is missing.
-async function validateOwnersExist(ownerIds: string[]) {
+async function validateOwnersExist(
+  ownerIds: string[],
+  client: Prisma.TransactionClient = prisma,
+) {
   const uniqueIds = [...new Set(ownerIds)];
 
   if (uniqueIds.length === 0) {
     return;
   }
 
-  const foundUsers = await prisma.user.findMany({
+  const foundUsers = await client.user.findMany({
     where: { id: { in: uniqueIds } },
     select: { id: true },
   });

--- a/models/library.ts
+++ b/models/library.ts
@@ -1,13 +1,26 @@
 import { prisma } from "infra/database";
-import { ItemType } from "generated/prisma/client";
+import { ItemType, Prisma } from "generated/prisma/client";
 import { NotFoundError } from "infra/errors";
 import game from "models/game";
 import store from "models/store";
+import pricing, { BASE_CURRENCY } from "models/pricing";
+import commercialTerms from "models/commercial_terms";
+import ledger, { LedgerEntryDto } from "models/ledger";
+
+// Storage scale for money. Amounts are quantised to it before they reach the
+// ledger, which refuses anything finer rather than rounding it.
+const MONEY_SCALE = 4;
+
+interface Affiliate {
+  store_id: string;
+  owner_id: string;
+}
 
 async function acquireGame(
   userId: string,
   gameSlug: string,
   storeSlug?: string,
+  currencyCode: string = BASE_CURRENCY,
 ) {
   const existingGame = await game.findOneBySlug(gameSlug);
   if (!existingGame) {
@@ -17,9 +30,28 @@ async function acquireGame(
     });
   }
 
-  const storeId = await resolveStoreIdLeniently(storeSlug);
+  // What the buyer is actually charged, in their own currency. Throws when the
+  // game has no price here, which is the same answer the listings and the
+  // detail page already give — a game you cannot see a price for is a game you
+  // cannot buy.
+  const resolvedPrice = await pricing.priceForOrFail(
+    existingGame,
+    currencyCode,
+  );
+
+  const affiliate = await resolveAffiliateLeniently(storeSlug);
+  const supplierCostRate =
+    await commercialTerms.supplierCostRateFor(existingGame);
 
   return await prisma.$transaction(async (tx) => {
+    // The entitlement is idempotent; the Sale deliberately is not. A Sale
+    // records an acquisition *event*, so the same user acquiring the same game
+    // through a different outlet later keeps that outlet's attribution rather
+    // than being swallowed by the entitlement they already hold.
+    //
+    // Open question now that a sale also mints commission: whether a repeat
+    // acquisition through the *same* outlet should earn again. It currently
+    // does. See docs/payments-tasks.md.
     const libraryItem = await tx.libraryItem.upsert({
       where: {
         user_id_item_id_item_type: {
@@ -36,29 +68,147 @@ async function acquireGame(
       },
     });
 
-    await tx.sale.create({
+    const sale = await tx.sale.create({
       data: {
         user_id: userId,
         game_id: existingGame.id,
-        store_id: storeId,
-        price_at_sale: existingGame.price,
+        store_id: affiliate?.store_id ?? null,
+        price_at_sale: resolvedPrice.amount,
+        currency: resolvedPrice.currency,
+        exchange_rate: resolvedPrice.exchange_rate,
       },
+    });
+
+    await recordSaleEntries(tx, {
+      sale_id: sale.id,
+      gross: resolvedPrice.amount,
+      currency: resolvedPrice.currency,
+      exchange_rate: resolvedPrice.exchange_rate,
+      supplier_cost_rate: supplierCostRate,
+      affiliate,
     });
 
     return libraryItem;
   });
 }
 
+interface SaleEntriesDto {
+  sale_id: string;
+  gross: Prisma.Decimal;
+  currency: string;
+  exchange_rate: Prisma.Decimal | null;
+  supplier_cost_rate: Prisma.Decimal;
+  affiliate: Affiliate | null;
+}
+
+// The balanced set describing one sale.
+//
+// Platform revenue is the residual — gross minus what everyone else takes —
+// and is never computed independently. Each share is quantised to the storage
+// scale first, so `gross × (1 − s − c)` would leave a sub-cent remainder and
+// the set would not sum to zero. Subtracting makes the platform absorb the
+// rounding, which is both correct and the only party that can.
+async function recordSaleEntries(
+  tx: Prisma.TransactionClient,
+  saleDto: SaleEntriesDto,
+) {
+  const supplierCost = saleDto.gross
+    .mul(saleDto.supplier_cost_rate)
+    .toDecimalPlaces(MONEY_SCALE, Prisma.Decimal.ROUND_HALF_UP);
+
+  const commission = saleDto.affiliate
+    ? saleDto.gross
+        .mul(
+          commercialTerms.commissionRateFor(
+            await tx.store.findUniqueOrThrow({
+              where: { id: saleDto.affiliate.store_id },
+              select: { commission_rate: true },
+            }),
+          ),
+        )
+        .toDecimalPlaces(MONEY_SCALE, Prisma.Decimal.ROUND_HALF_UP)
+    : new Prisma.Decimal(0);
+
+  const platformRevenue = saleDto.gross.minus(supplierCost).minus(commission);
+
+  const sharedFields = {
+    currency: saleDto.currency,
+    exchange_rate: saleDto.exchange_rate,
+    exchange_rate_from_currency:
+      saleDto.exchange_rate === null ? null : BASE_CURRENCY,
+  };
+
+  const entries: LedgerEntryDto[] = [
+    {
+      ...sharedFields,
+      account_type: "CONSUMER_PAYMENT",
+      amount: saleDto.gross,
+      description: "Gross payment received",
+    },
+  ];
+
+  // A zero share is simply not written. The ledger refuses zero amounts, and a
+  // row saying nothing moved would be noise in a statement.
+  if (!supplierCost.isZero()) {
+    entries.push({
+      ...sharedFields,
+      account_type: "SUPPLIER_COST",
+      amount: supplierCost.negated(),
+      description: "Supplier cost",
+    });
+  }
+
+  if (saleDto.affiliate && !commission.isZero()) {
+    entries.push({
+      ...sharedFields,
+      account_type: "AFFILIATE_COMMISSION",
+      owner_id: saleDto.affiliate.owner_id,
+      amount: commission.negated(),
+      // The hold is the platform's chargeback defence; the length lives in
+      // models/ledger so no caller picks its own.
+      matures_at: ledger.maturityFor(),
+      description: "Affiliate commission",
+    });
+  }
+
+  if (!platformRevenue.isZero()) {
+    entries.push({
+      ...sharedFields,
+      account_type: "PLATFORM_REVENUE",
+      amount: platformRevenue.negated(),
+      description: "Platform revenue",
+    });
+  }
+
+  return await ledger.record(
+    { source_type: "SALE", source_id: saleDto.sale_id, entries },
+    { client: tx },
+  );
+}
+
 // Resolve store_slug leniently: an absent or unknown store must never block
 // acquisition — it just means the sale isn't attributed to a store.
-async function resolveStoreIdLeniently(
+//
+// The owner is resolved here too, because a commission entry must name a user
+// the ledger can find. An outlet whose owner no longer exists would otherwise
+// fail the whole acquisition, and a buyer's purchase is not contingent on the
+// affiliate being payable.
+async function resolveAffiliateLeniently(
   storeSlug?: string,
-): Promise<string | null> {
+): Promise<Affiliate | null> {
   if (!storeSlug) return null;
 
   try {
     const foundStore = await store.findOneBySlug(storeSlug);
-    return foundStore.id;
+
+    const owner = await prisma.user.findUnique({
+      where: { id: foundStore.owner_id },
+      select: { id: true },
+    });
+
+    if (!owner) return null;
+
+    return { store_id: foundStore.id, owner_id: owner.id };
   } catch {
     return null;
   }

--- a/models/pricing.ts
+++ b/models/pricing.ts
@@ -89,7 +89,14 @@ async function priceFor(
 ): Promise<ResolvedPrice | null> {
   const normalizedCode = currency.normalizeCode(currencyCode);
 
-  const isCurrencyUsable = await isUsable(normalizedCode);
+  // The base currency resolves whether or not it has been registered, matching
+  // displayPricesFor. Without this the two disagree: a storefront with no
+  // currency rows shows a USD price — deliberately, so localisation stays
+  // additive on a working default — while this function calls the same game
+  // unpriceable, so it could be browsed but never bought.
+  const isCurrencyUsable =
+    normalizedCode === BASE_CURRENCY || (await isUsable(normalizedCode));
+
   if (!isCurrencyUsable) {
     return null;
   }

--- a/models/sale.ts
+++ b/models/sale.ts
@@ -1,24 +1,11 @@
 import { prisma } from "infra/database";
-import { Prisma } from "generated/prisma/client";
 
-interface RecordSaleDto {
-  user_id: string;
-  game_id: string;
-  store_id: string | null;
-  price_at_sale: Prisma.Decimal;
-}
-
-async function record(saleDto: RecordSaleDto) {
-  return await prisma.sale.create({
-    data: {
-      user_id: saleDto.user_id,
-      game_id: saleDto.game_id,
-      store_id: saleDto.store_id,
-      price_at_sale: saleDto.price_at_sale,
-    },
-  });
-}
-
+// There is deliberately no record() here. A sale is only ever created by
+// library.acquireGame, inside the transaction that also writes the balanced
+// ledger entries describing it — a standalone writer would let a sale exist
+// with no entries, which is the one state the books cannot represent. The
+// previous unused record() was removed rather than taught about currency,
+// since its only possible effect was to reintroduce that gap.
 async function listByStore(
   storeId: string,
   {
@@ -71,7 +58,6 @@ async function listByStore(
 }
 
 const sale = {
-  record,
   listByStore,
 };
 

--- a/pages/api/v1/library/index.ts
+++ b/pages/api/v1/library/index.ts
@@ -2,6 +2,7 @@ import { createRouter } from "next-connect";
 import controller from "infra/controller";
 import library from "models/library";
 import authorization from "models/authorization";
+import region from "models/region";
 import { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 import { ValidationError } from "infra/errors";
@@ -63,10 +64,15 @@ async function postHandler(req: NextApiRequest, res: NextApiResponse) {
     });
   }
 
+  // The same currency the visitor was shown a price in, so the sale and its
+  // ledger entries record what they were actually charged.
+  const currencyCode = await region.currencyForRequest(req);
+
   const result = await library.acquireGame(
     req.context.user.id!,
     parsedBody.data.slug,
     parsedBody.data.store_slug,
+    currencyCode,
   );
 
   return res.status(201).json({

--- a/prisma/migrations/20260805163016_add_sale_currency/migration.sql
+++ b/prisma/migrations/20260805163016_add_sale_currency/migration.sql
@@ -1,0 +1,15 @@
+-- Sales gain the currency the buyer was charged in, plus the rate that produced
+-- the amount when it came from a conversion.
+--
+-- Hand-written rather than left as Prisma generated it: the generated version
+-- adds a NOT NULL column with no default and fails on any existing row. Every
+-- sale recorded before this migration stored Game.price, which is the USD base
+-- price by definition, so backfilling USD states a fact rather than guessing.
+-- The default is dropped immediately afterwards, so future writes have to say
+-- which currency they mean instead of silently inheriting one.
+
+-- AlterTable
+ALTER TABLE "sales" ADD COLUMN "currency" VARCHAR(3) NOT NULL DEFAULT 'USD',
+ADD COLUMN "exchange_rate" DECIMAL(19,8);
+
+ALTER TABLE "sales" ALTER COLUMN "currency" DROP DEFAULT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -225,13 +225,21 @@ model LibraryItem {
 // store_id is nullable: null means the acquisition happened through the
 // global storefront (no store attribution), not through a specific store.
 model Sale {
-  id            String   @id @default(uuid())
+  id            String  @id @default(uuid())
   user_id       String // Logical reference to User.id (who acquired)
   game_id       String // Logical reference to Game.id (what was acquired)
   store_id      String? // Logical reference to Store.id; null = platform/global acquisition
-  price_at_sale Decimal  @db.Decimal(19, 4) // Snapshot of Game.price at acquisition time
+  price_at_sale Decimal @db.Decimal(19, 4) // What the buyer was actually charged, in `currency`
+
+  // The currency the buyer was charged in, and the rate that produced the
+  // amount when it came from converting the USD base price. Without these a
+  // sale records a number with no unit — and the ledger entries written from
+  // it could not be reconciled against the rate that was in effect.
+  currency      String   @db.VarChar(3) // Logical reference to Currency.code
+  exchange_rate Decimal? @db.Decimal(19, 8) // Null when the price was already in this currency
+
   // No updated_at: sale records are append-only and never modified.
-  created_at    DateTime @default(now())
+  created_at DateTime @default(now())
 
   @@index([store_id, created_at])
   @@index([user_id])

--- a/tests/integration/models/library_ledger.test.ts
+++ b/tests/integration/models/library_ledger.test.ts
@@ -1,0 +1,379 @@
+import orchestrator from "tests/orchestrator";
+import library from "models/library";
+import ledger from "models/ledger";
+import commercialTerms from "models/commercial_terms";
+import { prisma } from "infra/database";
+import { Prisma } from "generated/prisma/client";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+});
+
+beforeEach(async () => {
+  await orchestrator.clearDatabaseRows();
+});
+
+// A game priced at exactly 100 makes every share readable at a glance:
+// 70 supplier, 10 commission, 20 platform.
+async function seedGame(price = 100) {
+  const developer = await orchestrator.createUser();
+  const game = await orchestrator.createGame(developer.id, { price });
+  return game;
+}
+
+async function seedOutlet() {
+  const owner = await orchestrator.createUser();
+  await orchestrator.activateUser(owner.id);
+  const store = await orchestrator.createStore(owner.id);
+  return { owner, store };
+}
+
+function amountOf(
+  entries: Array<{ account_type: string; amount: Prisma.Decimal }>,
+  accountType: string,
+) {
+  return entries
+    .find((entry) => entry.account_type === accountType)
+    ?.amount.toFixed(4);
+}
+
+describe("library.acquireGame() ledger entries", () => {
+  test("writes a four-entry set that sums to zero", async () => {
+    const game = await seedGame();
+    const buyer = await orchestrator.createUser();
+    const { store } = await seedOutlet();
+
+    await library.acquireGame(buyer.id, game.slug, store.slug);
+
+    const sale = await prisma.sale.findFirstOrThrow();
+    const entries = await ledger.findBySource("SALE", sale.id);
+
+    expect(entries).toHaveLength(4);
+    expect(amountOf(entries, "CONSUMER_PAYMENT")).toBe("100.0000");
+    expect(amountOf(entries, "SUPPLIER_COST")).toBe("-70.0000");
+    expect(amountOf(entries, "AFFILIATE_COMMISSION")).toBe("-10.0000");
+    expect(amountOf(entries, "PLATFORM_REVENUE")).toBe("-20.0000");
+
+    const totals = ledger.sumByCurrency(entries);
+    expect(totals.get("USD")?.toFixed(4)).toBe("0.0000");
+  });
+
+  test("attributes the commission to the outlet owner", async () => {
+    const game = await seedGame();
+    const buyer = await orchestrator.createUser();
+    const { owner, store } = await seedOutlet();
+
+    await library.acquireGame(buyer.id, game.slug, store.slug);
+
+    const payable = await ledger.maturedPayableBalancesFor(owner.id, {
+      matured_as_of: new Date(Date.now() + 31 * 24 * 60 * 60 * 1000),
+    });
+
+    expect(payable[0].currency).toBe("USD");
+    expect(payable[0].amount.toFixed(4)).toBe("10.0000");
+  });
+
+  // The hold is the platform's chargeback defence, so a commission must not be
+  // payable the moment it is earned.
+  test("holds the commission rather than making it immediately payable", async () => {
+    const game = await seedGame();
+    const buyer = await orchestrator.createUser();
+    const { owner, store } = await seedOutlet();
+
+    await library.acquireGame(buyer.id, game.slug, store.slug);
+
+    expect(await ledger.maturedPayableBalancesFor(owner.id)).toEqual([]);
+  });
+
+  test("uses the outlet's own commission rate when one is set", async () => {
+    const game = await seedGame();
+    const buyer = await orchestrator.createUser();
+    const { store } = await seedOutlet();
+
+    await orchestrator.setStoreCommissionRate(store.id, 0.25);
+    await library.acquireGame(buyer.id, game.slug, store.slug);
+
+    const sale = await prisma.sale.findFirstOrThrow();
+    const entries = await ledger.findBySource("SALE", sale.id);
+
+    expect(amountOf(entries, "AFFILIATE_COMMISSION")).toBe("-25.0000");
+    // The platform absorbs the difference, so the set still balances.
+    expect(amountOf(entries, "PLATFORM_REVENUE")).toBe("-5.0000");
+    expect(ledger.sumByCurrency(entries).get("USD")?.isZero()).toBe(true);
+  });
+
+  test("uses the supplier's own cost rate when terms exist", async () => {
+    const developer = await orchestrator.createUser();
+    const game = await orchestrator.createGame(developer.id, { price: 100 });
+    const buyer = await orchestrator.createUser();
+    const { store } = await seedOutlet();
+
+    await orchestrator.setSupplierTerms({
+      supplier_id: game.studio_id,
+      cost_rate: 0.5,
+    });
+
+    await library.acquireGame(buyer.id, game.slug, store.slug);
+
+    const sale = await prisma.sale.findFirstOrThrow();
+    const entries = await ledger.findBySource("SALE", sale.id);
+
+    expect(amountOf(entries, "SUPPLIER_COST")).toBe("-50.0000");
+    expect(amountOf(entries, "PLATFORM_REVENUE")).toBe("-40.0000");
+    expect(ledger.sumByCurrency(entries).get("USD")?.isZero()).toBe(true);
+  });
+
+  // The majority of sales at launch: no store attribution, so no commission
+  // and the platform keeps the whole margin.
+  test("writes a three-entry set when there is no outlet", async () => {
+    const game = await seedGame();
+    const buyer = await orchestrator.createUser();
+
+    await library.acquireGame(buyer.id, game.slug);
+
+    const sale = await prisma.sale.findFirstOrThrow();
+    const entries = await ledger.findBySource("SALE", sale.id);
+
+    expect(entries).toHaveLength(3);
+    expect(entries.map((entry) => entry.account_type).sort()).toEqual([
+      "CONSUMER_PAYMENT",
+      "PLATFORM_REVENUE",
+      "SUPPLIER_COST",
+    ]);
+    expect(amountOf(entries, "PLATFORM_REVENUE")).toBe("-30.0000");
+    expect(ledger.sumByCurrency(entries).get("USD")?.isZero()).toBe(true);
+  });
+
+  test("ignores an unknown outlet slug rather than failing", async () => {
+    const game = await seedGame();
+    const buyer = await orchestrator.createUser();
+
+    await library.acquireGame(buyer.id, game.slug, "no-such-outlet");
+
+    const sale = await prisma.sale.findFirstOrThrow();
+
+    expect(sale.store_id).toBeNull();
+    expect(await ledger.findBySource("SALE", sale.id)).toHaveLength(3);
+  });
+
+  // A buyer's purchase is not contingent on the affiliate being payable, and
+  // the ledger rejects a commission naming a user it cannot find.
+  test("still completes when the outlet's owner no longer exists", async () => {
+    const game = await seedGame();
+    const buyer = await orchestrator.createUser();
+    const { owner, store } = await seedOutlet();
+
+    await prisma.user.delete({ where: { id: owner.id } });
+
+    await library.acquireGame(buyer.id, game.slug, store.slug);
+
+    const sale = await prisma.sale.findFirstOrThrow();
+
+    expect(sale.store_id).toBeNull();
+    expect(await ledger.findBySource("SALE", sale.id)).toHaveLength(3);
+  });
+
+  // A Sale records an acquisition *event*, deliberately — see the comment on
+  // the model. The entitlement is idempotent; the sale is not, so an outlet
+  // that refers the same buyer again keeps its attribution.
+  describe("repeat acquisition", () => {
+    // Documents current behaviour rather than endorsing it. Whether a repeat
+    // through the SAME outlet should earn a second time is an open product
+    // decision: it is the cheapest way for an outlet owner to farm their own
+    // commission, and today only the 30-day hold and the payout threshold
+    // discourage it.
+    test("records another sale and another commission each time", async () => {
+      const game = await seedGame();
+      const buyer = await orchestrator.createUser();
+      const { owner, store } = await seedOutlet();
+
+      await library.acquireGame(buyer.id, game.slug, store.slug);
+      await library.acquireGame(buyer.id, game.slug, store.slug);
+
+      expect(await prisma.sale.count()).toBe(2);
+      expect(await prisma.ledgerEntry.count()).toBe(8);
+      expect((await ledger.balanceFor(owner.id, "USD")).toFixed(4)).toBe(
+        "-20.0000",
+      );
+    });
+
+    test("keeps the entitlement a single row", async () => {
+      const game = await seedGame();
+      const buyer = await orchestrator.createUser();
+
+      const first = await library.acquireGame(buyer.id, game.slug);
+      const second = await library.acquireGame(buyer.id, game.slug);
+
+      expect(second?.id).toBe(first?.id);
+      expect(await prisma.libraryItem.count()).toBe(1);
+    });
+
+    // The reason the sale is not deduplicated: each outlet keeps the
+    // attribution for the acquisition it referred.
+    test("attributes a second outlet's referral to that outlet", async () => {
+      const game = await seedGame();
+      const buyer = await orchestrator.createUser();
+      const first = await seedOutlet();
+      const second = await seedOutlet();
+
+      await library.acquireGame(buyer.id, game.slug, first.store.slug);
+      await library.acquireGame(buyer.id, game.slug, second.store.slug);
+
+      expect((await ledger.balanceFor(first.owner.id, "USD")).toFixed(4)).toBe(
+        "-10.0000",
+      );
+      expect((await ledger.balanceFor(second.owner.id, "USD")).toFixed(4)).toBe(
+        "-10.0000",
+      );
+    });
+
+    test("keeps every set balanced across repeated acquisitions", async () => {
+      const game = await seedGame();
+      const buyer = await orchestrator.createUser();
+      const { store } = await seedOutlet();
+
+      await library.acquireGame(buyer.id, game.slug, store.slug);
+      await library.acquireGame(buyer.id, game.slug, store.slug);
+
+      const totals = await prisma.ledgerEntry.groupBy({
+        by: ["currency"],
+        _sum: { amount: true },
+      });
+
+      expect(totals).toHaveLength(1);
+      expect(totals[0]._sum.amount?.toFixed(4)).toBe("0.0000");
+    });
+  });
+
+  describe("rounding", () => {
+    // 33.33 × 0.7 = 23.331, and × 0.1 = 3.333. Both quantise, and the platform
+    // absorbs whatever the rounding leaves so the set still nets to zero.
+    test("keeps a set balanced when the shares do not divide evenly", async () => {
+      const game = await seedGame(33.33);
+      const buyer = await orchestrator.createUser();
+      const { store } = await seedOutlet();
+
+      await library.acquireGame(buyer.id, game.slug, store.slug);
+
+      const sale = await prisma.sale.findFirstOrThrow();
+      const entries = await ledger.findBySource("SALE", sale.id);
+
+      expect(amountOf(entries, "CONSUMER_PAYMENT")).toBe("33.3300");
+      expect(amountOf(entries, "SUPPLIER_COST")).toBe("-23.3310");
+      expect(amountOf(entries, "AFFILIATE_COMMISSION")).toBe("-3.3330");
+      expect(amountOf(entries, "PLATFORM_REVENUE")).toBe("-6.6660");
+      expect(ledger.sumByCurrency(entries).get("USD")?.isZero()).toBe(true);
+    });
+
+    // A supplier rate this high leaves nothing for the platform once the
+    // affiliate is paid. The ledger records the loss rather than refusing the
+    // sale — it records facts, and the fix is a commercial one.
+    test("records a negative platform revenue rather than hiding it", async () => {
+      const developer = await orchestrator.createUser();
+      const game = await orchestrator.createGame(developer.id, { price: 100 });
+      const buyer = await orchestrator.createUser();
+      const { store } = await seedOutlet();
+
+      await orchestrator.setSupplierTerms({
+        supplier_id: game.studio_id,
+        cost_rate: 0.95,
+      });
+
+      await library.acquireGame(buyer.id, game.slug, store.slug);
+
+      const sale = await prisma.sale.findFirstOrThrow();
+      const entries = await ledger.findBySource("SALE", sale.id);
+
+      // Negated on write, so a platform loss appears as a positive entry.
+      expect(amountOf(entries, "PLATFORM_REVENUE")).toBe("5.0000");
+      expect(ledger.sumByCurrency(entries).get("USD")?.isZero()).toBe(true);
+    });
+  });
+
+  describe("currency", () => {
+    test("records the sale in the currency the buyer was charged", async () => {
+      await orchestrator.createCurrency({ code: "USD", symbol: "$" });
+      await orchestrator.createCurrency({ code: "BRL", symbol: "R$" });
+      await orchestrator.createExchangeRate({ rate: 5 });
+
+      const game = await seedGame();
+      const buyer = await orchestrator.createUser();
+      const { store } = await seedOutlet();
+
+      await library.acquireGame(buyer.id, game.slug, store.slug, "BRL");
+
+      const sale = await prisma.sale.findFirstOrThrow();
+
+      expect(sale.currency).toBe("BRL");
+      expect(sale.price_at_sale.toFixed(2)).toBe("500.00");
+      expect(sale.exchange_rate?.toFixed(8)).toBe("5.00000000");
+    });
+
+    // The rate snapshot has to reach the entries too, or a converted sale
+    // cannot be reconciled against the rate that produced it.
+    test("carries the currency and rate onto every entry", async () => {
+      await orchestrator.createCurrency({ code: "USD", symbol: "$" });
+      await orchestrator.createCurrency({ code: "BRL", symbol: "R$" });
+      await orchestrator.createExchangeRate({ rate: 5 });
+
+      const game = await seedGame();
+      const buyer = await orchestrator.createUser();
+      const { store } = await seedOutlet();
+
+      await library.acquireGame(buyer.id, game.slug, store.slug, "BRL");
+
+      const sale = await prisma.sale.findFirstOrThrow();
+      const entries = await ledger.findBySource("SALE", sale.id);
+
+      for (const entry of entries) {
+        expect(entry.currency).toBe("BRL");
+        expect(entry.exchange_rate?.toFixed(8)).toBe("5.00000000");
+        expect(entry.exchange_rate_from_currency).toBe("USD");
+      }
+
+      expect(amountOf(entries, "AFFILIATE_COMMISSION")).toBe("-50.0000");
+      expect(ledger.sumByCurrency(entries).get("BRL")?.isZero()).toBe(true);
+    });
+
+    // A game with no price in the visitor's currency is absent from listings
+    // and 404s on its detail page; acquiring it has to agree.
+    test("refuses to sell a game that has no price in that currency", async () => {
+      await orchestrator.createCurrency({ code: "USD", symbol: "$" });
+      await orchestrator.createCurrency({ code: "BRL", symbol: "R$" });
+
+      const game = await seedGame();
+      const buyer = await orchestrator.createUser();
+
+      await expect(
+        library.acquireGame(buyer.id, game.slug, undefined, "BRL"),
+      ).rejects.toMatchObject({ name: "NotFoundError", statusCode: 404 });
+
+      expect(await prisma.sale.count()).toBe(0);
+      expect(await prisma.ledgerEntry.count()).toBe(0);
+    });
+  });
+
+  // The books and the thing they describe must not be able to disagree.
+  test("writes no ledger entries when the sale itself fails", async () => {
+    const game = await seedGame();
+    const buyer = await orchestrator.createUser();
+    const { owner, store } = await seedOutlet();
+
+    // An integration supplier with no terms throws while the entries are being
+    // assembled, after the library item and sale rows have been created.
+    jest
+      .spyOn(commercialTerms, "supplierCostRateFor")
+      .mockRejectedValueOnce(new Error("no terms"));
+
+    await expect(
+      library.acquireGame(buyer.id, game.slug, store.slug),
+    ).rejects.toThrow();
+
+    expect(await prisma.sale.count()).toBe(0);
+    expect(await prisma.ledgerEntry.count()).toBe(0);
+    expect(await prisma.libraryItem.count()).toBe(0);
+    expect((await ledger.balanceFor(owner.id, "USD")).isZero()).toBe(true);
+
+    jest.restoreAllMocks();
+  });
+});


### PR DESCRIPTION
## Description

The ledger has had no producer since it merged. This makes an acquisition write the balanced set that describes it, **in the same transaction as the sale**.

- **`Sale` gains `currency` and `exchange_rate`.** `models/pricing.ResolvedPrice` already returned exactly that, with a comment saying it existed *"so a sale recorded from this price can be reconciled later"* — it was simply never wired up. Acquisition now resolves through `priceForOrFail` in the visitor's currency, so a game with no price there cannot be bought, matching what listings and the detail page already do.
- **`ledger.record()` takes an optional transaction client.** It wrote with the module-level `prisma` before, so calling it from inside the acquisition transaction would have committed separately — leaving a sale with no entries, or entries with no sale, and no `UPDATE` available to repair either.
- **Platform revenue is the residual, never computed independently.** `record()` refuses over-scale amounts rather than rounding them, so `gross × (1 − s − c)` would leave a sub-cent remainder and fail the zero-sum check. Subtracting makes the platform absorb the rounding, which is both correct and the only party that can.

A supplier rate high enough to swallow the margin records a **negative platform revenue** rather than being blocked: the ledger records facts, and the fix for that is commercial. There's a test for it.

**An acquisition never fails because of a commission problem.** An unknown outlet slug was already tolerated; an outlet whose owner no longer exists now is too, since the ledger rejects a commission naming a user it cannot find and a buyer's purchase is not contingent on the affiliate being payable. Either case records the sale unattributed.

### Correction carried in this PR

An earlier draft of the delivery plan called the second `Sale` on re-acquisition a **defect**. It is not, and I was wrong to record it as one. The model comment says a `Sale` is an acquisition *event*, written every time, "letting the same user acquire the same game through multiple stores over time without losing any of those events" — and a test asserts it. Attribution per referral is the point of the table. That behaviour is unchanged here, and `docs/payments-tasks.md` now says so.

What the discovery leaves open, recorded as question 0b: **should a repeat acquisition through the _same_ outlet earn commission again?** It currently does. Through a *different* outlet that is plainly correct. Through the same one it is the cheapest way for an outlet owner to farm their own commission, and today only the 30-day hold and the payout threshold discourage it.

### Fixed in passing

`pricing.priceFor()` gated on the currency being registered and enabled, while `displayPricesFor()` deliberately lets the base currency work unregistered so localisation stays additive on a working default. The two disagreed, so an install with **no currency rows would show a USD price and then refuse to sell it**.

Also removed the unused `sale.record()`. It could only reintroduce the one state the books cannot represent — a sale with no entries — and it stopped compiling once currency became required, which is the right outcome.

### Migration note

`20260805163016_add_sale_currency` is hand-edited. Prisma's generated version adds a `NOT NULL` column with no default and fails on any existing row. Every sale recorded before this stored `Game.price`, which is the USD base price by definition, so it backfills `USD` and then drops the default — future writes have to say which currency they mean.

## Related issue

Part of #177. This is task 6b in `docs/payments-tasks.md`.

## Type of change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [x] 📖 Documentation
- [ ] ♻️ Refactor
- [x] 🧪 Tests

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] `npm run lint:eslint:check` passes
- [x] `npm run lint:prettier:check` passes
- [x] `npm run test` passes
- [x] Added or updated tests where relevant

Suite run as `npm run test:no-docker` (Docker image pulls are blocked in this environment): **636 passed / 639**. The 3 failures are the two suites `.claude/hooks/README.md` documents as environmental — `api/v1/status/get.test.ts` and `api/v1/items/games/steam-import/post.test.ts`. Both pass in CI.

18 new tests in `tests/integration/models/library_ledger.test.ts` cover: the four-entry balanced set, commission attribution and the 30-day hold, per-outlet and per-supplier rate overrides, the three-entry no-affiliate sale, unknown outlet and deleted owner, rounding that does not divide evenly, negative platform revenue, multi-currency sales carrying the rate snapshot onto every entry, and that a failure mid-write leaves neither a sale nor any entries.

## Follow-up

6c is the affiliate statement endpoint — an outlet owner reading their own earnings per currency.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NL35am9GhcP7nLVBT5eq4c)_