### PR TITLE
feat(sales): surface sale data to each audience in the UI

### DIFF
--- a/components/Pagination.tsx
+++ b/components/Pagination.tsx
@@ -1,0 +1,43 @@
+export interface PaginationApi {
+  page: number;
+  limit: number;
+  total: number;
+  pages: number;
+}
+
+// The Previous/Next block copy-pasted across the backoffice tables, extracted
+// because four sale surfaces needed it in the same change. Renders nothing when
+// there is only one page, so callers can drop it in unconditionally.
+export function Pagination({
+  pagination,
+  onPageChange,
+}: {
+  pagination?: PaginationApi;
+  onPageChange: (updater: (page: number) => number) => void;
+}) {
+  if (!pagination || pagination.pages <= 1) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center justify-center gap-3">
+      <button
+        disabled={pagination.page <= 1}
+        onClick={() => onPageChange((page) => Math.max(1, page - 1))}
+        className="px-3 py-1.5 rounded-lg bg-white/5 border border-white/10 text-sm font-bold text-white/70 disabled:opacity-30"
+      >
+        Previous
+      </button>
+      <span className="text-sm font-bold text-white/50">
+        Page {pagination.page} of {pagination.pages}
+      </span>
+      <button
+        disabled={pagination.page >= pagination.pages}
+        onClick={() => onPageChange((page) => page + 1)}
+        className="px-3 py-1.5 rounded-lg bg-white/5 border border-white/10 text-sm font-bold text-white/70 disabled:opacity-30"
+      >
+        Next
+      </button>
+    </div>
+  );
+}

--- a/components/backoffice/BackofficeTopNav.tsx
+++ b/components/backoffice/BackofficeTopNav.tsx
@@ -11,10 +11,12 @@ import {
   LogOut,
   ArrowLeft,
   ShieldCheck,
+  Banknote,
 } from "lucide-react";
 
 const NAV_ITEMS = [
   { href: "/backoffice", label: "Dashboard", icon: LayoutDashboard },
+  { href: "/backoffice/revenue", label: "Revenue", icon: Banknote },
   { href: "/backoffice/games", label: "Games", icon: Gamepad2 },
   { href: "/backoffice/users", label: "Users", icon: Users },
   { href: "/backoffice/studios", label: "Studios", icon: Building2 },

--- a/lib/price.ts
+++ b/lib/price.ts
@@ -55,3 +55,59 @@ export function formatBasePrice(item: PricedItem): string | null {
 export function hasDiscount(item: PricedItem): boolean {
   return !isFree(item) && formatBasePrice(item) !== null;
 }
+
+// Money that is not a product price: a sale's `price_at_sale`, a statement
+// balance, a revenue total.
+//
+// Every helper above takes a `PricedItem` — an object carrying `price` and
+// optionally `display_price` — so none of them can be handed an
+// `{ amount, currency }` pair. These surfaces have no product to pass.
+//
+// The digits are used exactly as the server sent them. That is the whole point:
+// sales serialise at 2 decimal places and statement balances at 4, because the
+// ledger holds fractions of a cent that an affiliate reconciles against a real
+// payment. Re-rounding here is precisely how that precision would be lost, so
+// this function only ever puts a symbol in front of a string it does not touch.
+export function formatMoney(amount: string | number, currency: string): string {
+  return `${currencySymbol(currency)}${amount}`;
+}
+
+// Symbol lookup memoised per currency code. Intl knows the symbol for every
+// registered code, which saves shipping a table that would drift from the
+// Currency rows in the database.
+const symbolCache = new Map<string, string>();
+
+export function currencySymbol(currency: string): string {
+  const code = (currency || "").toUpperCase();
+
+  if (!code) {
+    return BASE_SYMBOL;
+  }
+
+  const cached = symbolCache.get(code);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  // Intl throws RangeError on a code it does not recognise rather than
+  // returning anything, and the ledger will happily record a currency Intl has
+  // never heard of. Falling back to the code itself keeps the amount labelled
+  // instead of unlabelled, which matters more here than looking tidy.
+  let symbol = `${code} `;
+  try {
+    const parts = new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: code,
+    }).formatToParts(0);
+
+    const currencyPart = parts.find((part) => part.type === "currency");
+    if (currencyPart) {
+      symbol = currencyPart.value;
+    }
+  } catch {
+    // Keep the code-as-symbol fallback.
+  }
+
+  symbolCache.set(code, symbol);
+  return symbol;
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "type": "module",
   "scripts": {
     "dev": "npm run services:up && npm run services:wait:database && npm run prisma:generate && npm run migrate:dev && next dev",
-    "test": "npm run services:up && npm run prisma:generate && npm run migrate:dev && concurrently -n next,jest -k -s command-jest \"next dev\" \"jest --runInBand\"",
+    "test": "npm run services:up && npm run services:wait:database && npm run prisma:generate && npm run migrate:dev && concurrently -n next,jest -k -s command-jest \"next dev\" \"jest --runInBand\"",
     "posttest": "npm run services:down",
     "test:watch": "jest --watchAll --runInBand --verbose",
     "test:no-docker": "npm run prisma:generate && npx prisma migrate deploy && concurrently -n next,jest -k -s command-jest \"next dev\" \"jest --runInBand\"",

--- a/pages/backoffice/revenue/index.tsx
+++ b/pages/backoffice/revenue/index.tsx
@@ -1,0 +1,203 @@
+import Head from "next/head";
+import { useState } from "react";
+import useSWR from "swr";
+import {
+  Loader2,
+  Banknote,
+  Package,
+  Store as StoreIcon,
+  TrendingUp,
+  Send,
+} from "lucide-react";
+import { BackofficeLayout } from "components/backoffice/BackofficeLayout";
+import { formatMoney } from "lib/price";
+
+interface RevenueRow {
+  currency: string;
+  gross: string;
+  supplier_cost: string;
+  affiliate_commission: string;
+  platform_revenue: string;
+  payouts: string;
+}
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+const RANGES = [
+  ["all", "All time"],
+  ["30", "Last 30 days"],
+  ["7", "Last 7 days"],
+] as const;
+
+type Range = (typeof RANGES)[number][0];
+
+const ONE_DAY_IN_MILLISECONDS = 1000 * 60 * 60 * 24;
+
+// Module scope on purpose. This reads the clock, so calling it while rendering
+// would give the SWR key a different value on every render and refetch in a
+// loop — react-hooks/purity refuses it inside the component for exactly that
+// reason. It is only ever called from the range buttons' click handler, which
+// also gives the better behaviour: the window holds still while you read the
+// report rather than sliding forward underneath you.
+function boundaryFor(range: Range): string | null {
+  if (range === "all") {
+    return null;
+  }
+
+  return new Date(
+    Date.now() - Number(range) * ONE_DAY_IN_MILLISECONDS,
+  ).toISOString();
+}
+
+function StatCard({
+  icon: Icon,
+  label,
+  value,
+  accent,
+}: {
+  icon: React.ComponentType<{ size?: number; className?: string }>;
+  label: string;
+  value: React.ReactNode;
+  accent?: string;
+}) {
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/5 p-5 flex items-center gap-4">
+      <div
+        className={`p-3 rounded-xl shrink-0 ${accent ?? "bg-white/10 text-white/60"}`}
+      >
+        <Icon size={20} />
+      </div>
+      <div className="min-w-0">
+        <div className="text-xs font-black uppercase tracking-wider text-white/40">
+          {label}
+        </div>
+        <div className="text-2xl font-black text-white break-all">{value}</div>
+      </div>
+    </div>
+  );
+}
+
+// The platform's own income statement.
+//
+// One block per currency and never a combined figure: a BRL book and a USD book
+// are not addable, and the API returns them as separate rows for that reason.
+// Amounts arrive at the ledger's 4-decimal scale and are rendered untouched —
+// platform revenue is a residual, so rounding it for display is exactly what
+// would stop the columns adding up.
+export default function BackofficeRevenuePage() {
+  const [range, setRange] = useState<Range>("all");
+  const [from, setFrom] = useState<string | null>(null);
+
+  function selectRange(value: Range) {
+    setRange(value);
+    setFrom(boundaryFor(value));
+  }
+
+  const { data, isLoading, error } = useSWR<{ revenue: RevenueRow[] }>(
+    from
+      ? `/api/v1/backoffice/revenue?from=${encodeURIComponent(from)}`
+      : "/api/v1/backoffice/revenue",
+    fetcher,
+  );
+
+  const revenue = data?.revenue ?? [];
+
+  return (
+    <>
+      <Head>
+        <title>Revenue | Manifold</title>
+        <meta name="theme-color" content="#1D0F3B" />
+      </Head>
+
+      <div className="flex flex-col gap-8">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-3xl font-black">Revenue</h1>
+            <p className="text-white/50 text-sm font-bold mt-1">
+              Every money movement the ledger recorded, grouped by currency.
+            </p>
+          </div>
+
+          <div className="flex items-center gap-1 rounded-xl border border-white/10 bg-white/5 p-1 w-fit">
+            {RANGES.map(([value, label]) => (
+              <button
+                key={value}
+                onClick={() => selectRange(value)}
+                className={`px-3 py-1.5 rounded-lg text-xs font-black uppercase tracking-wider transition-colors ${
+                  range === value
+                    ? "bg-white/10 text-white"
+                    : "text-white/40 hover:text-white/70"
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {isLoading ? (
+          <Loader2 className="animate-spin text-white/30" />
+        ) : error ? (
+          <p className="text-rose-300 font-bold">Failed to load revenue.</p>
+        ) : revenue.length === 0 ? (
+          <div className="rounded-2xl border border-white/10 bg-white/5 px-6 py-16 text-center">
+            <p className="text-white/40 font-bold">
+              No ledger entries in this range.
+            </p>
+          </div>
+        ) : (
+          revenue.map((row) => (
+            <div key={row.currency} className="flex flex-col gap-3">
+              <h2 className="text-xl font-black">{row.currency}</h2>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <StatCard
+                  icon={Banknote}
+                  label="Gross collected"
+                  value={formatMoney(row.gross, row.currency)}
+                  accent="bg-indigo-500/20 text-indigo-300"
+                />
+                <StatCard
+                  icon={TrendingUp}
+                  label="Platform revenue"
+                  value={formatMoney(row.platform_revenue, row.currency)}
+                  accent="bg-emerald-500/20 text-emerald-300"
+                />
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <StatCard
+                  icon={Package}
+                  label="Supplier cost"
+                  value={formatMoney(row.supplier_cost, row.currency)}
+                />
+                <StatCard
+                  icon={StoreIcon}
+                  label="Affiliate commission"
+                  value={formatMoney(row.affiliate_commission, row.currency)}
+                />
+                <StatCard
+                  icon={Send}
+                  label="Paid out"
+                  value={formatMoney(row.payouts, row.currency)}
+                />
+              </div>
+            </div>
+          ))
+        )}
+
+        <p className="text-white/30 text-xs font-bold max-w-2xl">
+          Supplier cost, commission and platform revenue are the three ways the
+          gross was distributed, so they add back up to it. Commission is
+          counted when it is earned, whether or not it has cleared its hold —
+          paid out is a separate line, and subtracting it here would count the
+          same money twice.
+        </p>
+      </div>
+    </>
+  );
+}
+
+BackofficeRevenuePage.getLayout = function getLayout(page: React.ReactElement) {
+  return <BackofficeLayout>{page}</BackofficeLayout>;
+};

--- a/pages/library/index.tsx
+++ b/pages/library/index.tsx
@@ -1,7 +1,7 @@
 import Head from "next/head";
 import Link from "next/link";
 import useSWR from "swr";
-import { BookMarked, Layers, PackageX } from "lucide-react";
+import { BookMarked, Layers, PackageX, Receipt } from "lucide-react";
 
 import { StoreLayout } from "components/store/StoreLayout";
 import { SectionDivider } from "components/store/SectionDivider";
@@ -56,6 +56,16 @@ export default function LibraryPage() {
               Access your secured digital assets. Download, manage, and play
               your collection.
             </p>
+            {/* The library shows what you own at today's list price; the
+                history shows what you actually paid. Different questions, so
+                they get different pages. */}
+            <Link
+              href="/library/purchases"
+              className="inline-flex w-fit items-center gap-2 px-4 py-2.5 rounded-xl border border-white/10 bg-white/5 text-sm font-black uppercase tracking-wider text-white/70 hover:bg-white/10 hover:text-white transition-colors"
+            >
+              <Receipt size={16} />
+              Purchase History
+            </Link>
           </header>
 
           <SectionDivider />

--- a/pages/library/purchases.tsx
+++ b/pages/library/purchases.tsx
@@ -1,0 +1,213 @@
+import Head from "next/head";
+import Link from "next/link";
+import { useState } from "react";
+import useSWR from "swr";
+import { Receipt, Layers, PackageX, Store as StoreIcon } from "lucide-react";
+
+import { StoreLayout } from "components/store/StoreLayout";
+import { SectionDivider } from "components/store/SectionDivider";
+import { Pagination, type PaginationApi } from "components/Pagination";
+import { formatMoney } from "lib/price";
+
+interface PurchaseApi {
+  id: string;
+  game_id: string;
+  game_title: string;
+  game_slug: string | null;
+  store_id: string | null;
+  price_at_sale: string;
+  currency: string;
+  created_at: string;
+}
+
+// A buyer's own purchase history.
+//
+// Deliberately separate from /library, which answers "what do I own" and shows
+// each game's *current* list price. This answers "what did I pay", which is
+// only reconstructible from Sale: the amount charged, in the currency it was
+// charged in, on the day it was charged.
+export default function PurchasesPage() {
+  const [page, setPage] = useState(1);
+
+  const { data, error, isLoading } = useSWR<{
+    purchases: PurchaseApi[];
+    pagination: PaginationApi;
+  }>(
+    `/api/v1/user/purchases?page=${page}`,
+    (url: string) =>
+      fetch(url).then(async (res) => {
+        if (!res.ok) throw new Error("Not logged in");
+        return res.json();
+      }),
+    { shouldRetryOnError: false },
+  );
+
+  const isLoggedOut = !!error;
+  const purchases = data?.purchases ?? [];
+  const total = data?.pagination.total ?? 0;
+
+  return (
+    <div className="min-h-screen bg-[#1D0F3B] text-white pb-24 overflow-x-hidden selection:bg-white selection:text-black">
+      <Head>
+        <title>Purchase History | Manifold Outlets</title>
+        <meta name="theme-color" content="#1D0F3B" />
+      </Head>
+
+      <style jsx global>{`
+        html,
+        body {
+          background-color: #1d0f3b !important;
+        }
+      `}</style>
+
+      <main className="w-full pt-[calc(env(safe-area-inset-top)+7rem)] lg:pt-[calc(env(safe-area-inset-top)+9rem)] flex flex-col items-center">
+        <div className="w-full max-w-4xl mx-auto px-6 md:px-10 flex flex-col gap-12">
+          <header className="flex flex-col gap-4 animate-in fade-in slide-in-from-bottom-4 duration-700">
+            <div className="inline-flex items-center gap-3 px-4 py-2 rounded-full bg-white/5 border border-white/10 w-fit text-white/80 backdrop-blur-sm">
+              <Receipt size={16} />
+              <span className="text-xs font-black tracking-widest uppercase">
+                Transaction Record
+              </span>
+            </div>
+            <h1 className="text-5xl md:text-7xl font-black tracking-tighter text-white drop-shadow-2xl">
+              Purchase History
+            </h1>
+            <p className="text-xl text-white/50 font-bold max-w-2xl">
+              What you paid, in the currency you were charged, and where you
+              bought it.
+            </p>
+            <Link
+              href="/library"
+              className="w-fit text-sm font-black uppercase tracking-wider text-white/50 hover:text-white transition-colors"
+            >
+              ← Back to my library
+            </Link>
+          </header>
+
+          <SectionDivider />
+
+          {isLoggedOut ? (
+            <div className="flex flex-col items-center justify-center py-20 px-4 text-center bg-white/5 border border-white/10 rounded-[2rem] backdrop-blur-md">
+              <Layers size={64} className="text-white/20 mb-6" />
+              <h2 className="text-3xl font-black mb-4">
+                Authentication Required
+              </h2>
+              <p className="text-white/50 font-bold max-w-md mb-8">
+                You must be logged in to view your purchase history.
+              </p>
+              <Link
+                href="/login?callbackUrl=/library/purchases"
+                className="px-8 py-4 rounded-xl bg-white text-black font-black uppercase tracking-wider hover:scale-105 transition-transform"
+              >
+                Log In to Manifold
+              </Link>
+            </div>
+          ) : isLoading ? (
+            <div className="flex flex-col items-center justify-center py-32">
+              <div className="animate-spin rounded-full h-16 w-16 border-t-4 border-b-4 border-white/20 mb-6"></div>
+              <p className="text-xl font-bold text-white/40 tracking-widest uppercase">
+                Retrieving Records...
+              </p>
+            </div>
+          ) : purchases.length > 0 ? (
+            <div className="flex flex-col gap-6 animate-in fade-in duration-1000">
+              <span className="text-sm font-black text-white/40 uppercase tracking-widest">
+                {total} {total === 1 ? "Purchase" : "Purchases"}
+              </span>
+
+              <div className="rounded-2xl border border-white/10 overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead className="bg-white/5 text-white/50 text-xs uppercase tracking-wider">
+                    {/* "Bought through" is dropped below sm. Four columns do
+                        not fit a phone, and the container scrolls from the
+                        right — so keeping it would push "Paid", the column
+                        someone opens this page for, off the visible edge. */}
+                    <tr>
+                      <th className="px-4 py-3 text-left">Game</th>
+                      <th className="hidden sm:table-cell px-4 py-3 text-left">
+                        Bought through
+                      </th>
+                      <th className="px-4 py-3 text-left">Date</th>
+                      <th className="px-4 py-3 text-right">Paid</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {purchases.map((purchase) => (
+                      <tr
+                        key={purchase.id}
+                        className="border-t border-white/5 align-middle"
+                      >
+                        <td className="px-4 py-3 font-bold text-white">
+                          {purchase.game_slug ? (
+                            <Link
+                              href={`/item/${purchase.game_slug}`}
+                              className="hover:underline"
+                            >
+                              {purchase.game_title}
+                            </Link>
+                          ) : (
+                            purchase.game_title
+                          )}
+                        </td>
+                        <td className="hidden sm:table-cell px-4 py-3 text-white/40 whitespace-nowrap">
+                          {purchase.store_id ? (
+                            <span className="inline-flex items-center gap-1.5">
+                              <StoreIcon size={14} />
+                              An outlet
+                            </span>
+                          ) : (
+                            "Manifold"
+                          )}
+                        </td>
+                        <td className="px-4 py-3 text-white/40 whitespace-nowrap">
+                          {new Date(purchase.created_at).toLocaleDateString()}
+                        </td>
+                        <td className="px-4 py-3 text-right font-black text-emerald-300 whitespace-nowrap">
+                          {formatMoney(
+                            purchase.price_at_sale,
+                            purchase.currency,
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              <Pagination
+                pagination={data?.pagination}
+                onPageChange={setPage}
+              />
+
+              <p className="text-white/30 text-xs font-bold">
+                Manifold is the seller for every purchase above. Outlets are
+                storefronts that referred you; your contract of sale is with
+                Manifold.
+              </p>
+            </div>
+          ) : (
+            <div className="flex flex-col items-center justify-center py-24 px-4 text-center border border-white/5 rounded-[2rem] bg-black/20">
+              <PackageX size={64} className="text-white/10 mb-6" />
+              <h2 className="text-3xl font-black mb-4 text-white/80">
+                No Purchases Yet
+              </h2>
+              <p className="text-white/40 font-bold max-w-md mb-8">
+                Anything you buy will show up here with the price you paid.
+              </p>
+              <Link
+                href="/store"
+                className="px-8 py-4 rounded-xl border border-white/20 text-white font-black uppercase tracking-wider hover:bg-white hover:text-black transition-all"
+              >
+                Browse Outlets
+              </Link>
+            </div>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}
+
+PurchasesPage.getLayout = function getLayout(page: React.ReactElement) {
+  return <StoreLayout>{page}</StoreLayout>;
+};

--- a/pages/store/[slug]/manage.tsx
+++ b/pages/store/[slug]/manage.tsx
@@ -6,6 +6,8 @@ import useSWR, { useSWRConfig } from "swr";
 import { Loader2, ExternalLink, X, ChevronDown } from "lucide-react";
 import { GameAutocomplete } from "components/store/GameAutocomplete";
 import { type GameApi } from "components/store/GameListItem";
+import { Pagination, type PaginationApi } from "components/Pagination";
+import { formatMoney } from "lib/price";
 
 interface StoreApi {
   id: string;
@@ -30,11 +32,29 @@ interface GameOverrideApi {
 
 interface SaleApi {
   id: string;
+  // A per-outlet pseudonym, never the buyer's id. Stable within this outlet so
+  // repeat customers are countable, different at every other outlet so two
+  // operators cannot work out that they share one. See models/authorization.
+  buyer_ref: string;
   game_id: string;
   game_title: string;
+  game_slug: string | null;
   store_id: string | null;
   price_at_sale: string;
+  currency: string;
   created_at: string;
+}
+
+interface StatementBalanceApi {
+  currency: string;
+  total: string;
+  payable: string;
+  held: string;
+}
+
+interface StatementApi {
+  balances: StatementBalanceApi[];
+  hold_days: number;
 }
 
 const fetcher = (url: string) =>
@@ -46,7 +66,7 @@ const fetcher = (url: string) =>
     return res.json();
   });
 
-type Tab = "curation" | "settings" | "sales";
+type Tab = "curation" | "settings" | "sales" | "earnings";
 
 export default function StoreManagePage() {
   const router = useRouter();
@@ -119,18 +139,23 @@ export default function StoreManagePage() {
           </Link>
         </div>
 
-        <div className="flex items-center gap-2 border-b border-white/10">
+        {/* Scrollable and shrink-proof, the same idiom BackofficeTopNav uses.
+            Four tabs do not fit a 390px viewport: without this the row pushes
+            the page into horizontal scroll and the last tab sits off-screen
+            where it cannot be tapped at all. */}
+        <div className="-mx-4 flex items-center gap-2 overflow-x-auto border-b border-white/10 px-4 sm:mx-0 sm:px-0 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           {(
             [
               ["curation", "Curation"],
               ["settings", "Settings"],
               ["sales", "Sales"],
+              ["earnings", "Earnings"],
             ] as [Tab, string][]
           ).map(([value, label]) => (
             <button
               key={value}
               onClick={() => setTab(value)}
-              className={`px-4 py-3 text-sm font-black uppercase tracking-wider transition-colors border-b-2 ${
+              className={`shrink-0 px-4 py-3 text-sm font-black uppercase tracking-wider transition-colors border-b-2 ${
                 tab === value
                   ? "text-white border-white"
                   : "text-white/40 border-transparent hover:text-white/70"
@@ -150,6 +175,7 @@ export default function StoreManagePage() {
         )}
         {tab === "settings" && <SettingsTab store={storeData} />}
         {tab === "sales" && <SalesTab storeSlug={storeData.slug} />}
+        {tab === "earnings" && <EarningsTab storeSlug={storeData.slug} />}
       </div>
     </div>
   );
@@ -576,10 +602,12 @@ function SettingsTab({ store }: { store: StoreApi }) {
 }
 
 function SalesTab({ storeSlug }: { storeSlug: string }) {
+  const [page, setPage] = useState(1);
+
   const { data, isLoading, error } = useSWR<{
     sales: SaleApi[];
-    pagination: { total: number };
-  }>(`/api/v1/stores/${storeSlug}/sales`, fetcher);
+    pagination: PaginationApi;
+  }>(`/api/v1/stores/${storeSlug}/sales?page=${page}`, fetcher);
 
   if (isLoading) {
     return <Loader2 className="animate-spin text-white/30" size={24} />;
@@ -592,35 +620,154 @@ function SalesTab({ storeSlug }: { storeSlug: string }) {
   }
 
   const sales = data?.sales ?? [];
+  const pagination = data?.pagination;
+  const total = pagination?.total ?? 0;
 
   return (
     <div className="flex flex-col gap-4">
-      <p className="text-white/50 text-sm font-bold">
-        {data?.pagination.total ?? 0} sale
-        {data?.pagination.total === 1 ? "" : "s"} attributed to this outlet.
-      </p>
+      <div>
+        <p className="text-white/50 text-sm font-bold">
+          {total} sale{total === 1 ? "" : "s"} attributed to this outlet.
+        </p>
+        <p className="text-white/30 text-xs font-bold mt-1">
+          Buyers are shown as an anonymous reference. The same reference is the
+          same person returning to your outlet.
+        </p>
+      </div>
 
       {sales.length === 0 ? (
         <p className="text-white/30 text-sm font-bold italic">
           No sales yet. Share your storefront link to start tracking sales.
         </p>
       ) : (
-        <div className="flex flex-col gap-2">
-          {sales.map((sale) => (
+        <>
+          <div className="flex flex-col gap-2">
+            {sales.map((sale) => (
+              <div
+                key={sale.id}
+                className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 px-4 py-3 rounded-xl border border-white/10 bg-white/5"
+              >
+                <div className="min-w-0 flex-1">
+                  {sale.game_slug ? (
+                    <Link
+                      href={`/item/${sale.game_slug}`}
+                      className="font-bold text-sm text-white truncate hover:underline"
+                    >
+                      {sale.game_title}
+                    </Link>
+                  ) : (
+                    <span className="font-bold text-sm text-white truncate">
+                      {sale.game_title}
+                    </span>
+                  )}
+                  <div className="text-white/30 text-xs font-bold font-mono mt-0.5">
+                    {sale.buyer_ref}
+                  </div>
+                </div>
+                <div className="flex items-center gap-4 shrink-0">
+                  <span className="font-black text-sm text-emerald-300">
+                    {formatMoney(sale.price_at_sale, sale.currency)}
+                  </span>
+                  <span className="text-white/40 text-xs font-bold">
+                    {new Date(sale.created_at).toLocaleDateString()}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <Pagination pagination={pagination} onPageChange={setPage} />
+        </>
+      )}
+    </div>
+  );
+}
+
+// What this outlet has earned, straight from the ledger.
+//
+// One row per currency and never a single total: an outlet can hold a BRL
+// balance and a USD balance at once and they are not addable. Amounts arrive
+// already sign-flipped and at the ledger's own 4-decimal scale, so they
+// reconcile against a real payment rather than against a rounded display value.
+function EarningsTab({ storeSlug }: { storeSlug: string }) {
+  const { data, isLoading, error } = useSWR<StatementApi>(
+    `/api/v1/stores/${storeSlug}/statement`,
+    fetcher,
+  );
+
+  if (isLoading) {
+    return <Loader2 className="animate-spin text-white/30" size={24} />;
+  }
+
+  if (error) {
+    return (
+      <p className="text-rose-300 font-bold text-sm">
+        Failed to load earnings.
+      </p>
+    );
+  }
+
+  const balances = data?.balances ?? [];
+  const holdDays = data?.hold_days ?? 30;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <h2 className="text-lg font-black">Earnings</h2>
+        <p className="text-white/50 text-sm font-bold mt-1">
+          Commission is held for {holdDays} days after each sale so refunds and
+          chargebacks can resolve. Held amounts become payable automatically.
+        </p>
+      </div>
+
+      {balances.length === 0 ? (
+        <p className="text-white/30 text-sm font-bold italic">
+          Nothing earned yet. Commission appears here once a sale is attributed
+          to your outlet.
+        </p>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {balances.map((balance) => (
             <div
-              key={sale.id}
-              className="flex items-center justify-between gap-4 px-4 py-3 rounded-xl border border-white/10 bg-white/5"
+              key={balance.currency}
+              className="rounded-2xl border border-white/10 bg-white/5 p-5 flex flex-col gap-4"
             >
-              <span className="font-bold text-sm text-white truncate">
-                {sale.game_title}
-              </span>
-              <span className="text-white/40 text-xs font-bold shrink-0">
-                {new Date(sale.created_at).toLocaleDateString()}
-              </span>
+              <div className="flex items-baseline justify-between gap-4">
+                <span className="text-xs font-black uppercase tracking-wider text-white/40">
+                  {balance.currency} total
+                </span>
+                <span className="text-2xl font-black text-white">
+                  {formatMoney(balance.total, balance.currency)}
+                </span>
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                <div className="rounded-xl border border-emerald-500/20 bg-emerald-500/10 px-4 py-3">
+                  <div className="text-xs font-black uppercase tracking-wider text-emerald-300/70">
+                    Payable now
+                  </div>
+                  <div className="text-lg font-black text-emerald-300 mt-1 break-all">
+                    {formatMoney(balance.payable, balance.currency)}
+                  </div>
+                </div>
+                <div className="rounded-xl border border-white/10 bg-white/5 px-4 py-3">
+                  <div className="text-xs font-black uppercase tracking-wider text-white/40">
+                    Held
+                  </div>
+                  <div className="text-lg font-black text-white/70 mt-1 break-all">
+                    {formatMoney(balance.held, balance.currency)}
+                  </div>
+                </div>
+              </div>
             </div>
           ))}
         </div>
       )}
+
+      <p className="text-white/30 text-xs font-bold">
+        Payments go to the account registered against this outlet, not to
+        whoever owns it. Transferring the outlet does not move the balance.
+      </p>
     </div>
   );
 }

--- a/pages/studio/[slug]/index.tsx
+++ b/pages/studio/[slug]/index.tsx
@@ -6,7 +6,8 @@ import { useState } from "react";
 import { Loader2, Building2, Copy, Check, Gamepad2 } from "lucide-react";
 import { ReviewSummary } from "components/store/ReviewSummary";
 import { type GameApi } from "components/store/GameListItem";
-import { formatPrice, isFree } from "lib/price";
+import { Pagination, type PaginationApi } from "components/Pagination";
+import { formatMoney, formatPrice, isFree } from "lib/price";
 
 interface Studio {
   id: string;
@@ -16,6 +17,22 @@ interface Studio {
   logo_url: string | null;
   is_publisher: boolean;
 }
+
+// No buyer field of any kind, matching the read:studio_sale filter branch. A
+// studio is a supplier, not an affiliate, and has no use for telling one buyer
+// from another — so the server does not send one to be typed here.
+interface StudioSaleApi {
+  id: string;
+  game_id: string;
+  game_title: string;
+  game_slug: string | null;
+  store_id: string | null;
+  price_at_sale: string;
+  currency: string;
+  created_at: string;
+}
+
+type Tab = "games" | "sales";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
@@ -28,6 +45,7 @@ const STATUS_STYLES: Record<string, string> = {
 export default function StudioPage() {
   const router = useRouter();
   const slug = router.query.slug as string | undefined;
+  const [tab, setTab] = useState<Tab>("games");
 
   const {
     data: studio,
@@ -99,40 +117,154 @@ export default function StudioPage() {
               </p>
             )}
 
-            <div className="flex flex-col gap-4">
-              <h2 className="text-lg font-black uppercase tracking-wider text-white/80">
-                Your Games
-              </h2>
-
-              {isLoadingGames ? (
-                <div className="flex items-center justify-center py-12">
-                  <Loader2 className="animate-spin text-white/30" />
-                </div>
-              ) : games.length === 0 ? (
-                <div className="flex flex-col items-center gap-4 py-12 px-6 rounded-2xl border border-white/10 bg-white/5 text-center">
-                  <Gamepad2 size={32} className="text-white/20" />
-                  <p className="text-white/50 font-bold text-sm">
-                    No games yet.
-                  </p>
-                  <Link
-                    href={`/studio/${studio.slug}/games/steam-import`}
-                    className="px-4 py-2.5 rounded-xl bg-emerald-500 text-black font-black text-sm uppercase tracking-wider hover:bg-emerald-400 transition-colors"
-                  >
-                    Import a Game from Steam
-                  </Link>
-                </div>
-              ) : (
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                  {games.map((game) => (
-                    <StudioGameCard key={game.id} game={game} />
-                  ))}
-                </div>
-              )}
+            <div className="-mx-4 flex items-center gap-2 overflow-x-auto border-b border-white/10 px-4 sm:mx-0 sm:px-0 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+              {(
+                [
+                  ["games", "Your Games"],
+                  ["sales", "Sales"],
+                ] as [Tab, string][]
+              ).map(([value, label]) => (
+                <button
+                  key={value}
+                  onClick={() => setTab(value)}
+                  className={`shrink-0 px-4 py-3 text-sm font-black uppercase tracking-wider transition-colors border-b-2 ${
+                    tab === value
+                      ? "text-white border-white"
+                      : "text-white/40 border-transparent hover:text-white/70"
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
             </div>
+
+            {tab === "games" ? (
+              <div className="flex flex-col gap-4">
+                {isLoadingGames ? (
+                  <div className="flex items-center justify-center py-12">
+                    <Loader2 className="animate-spin text-white/30" />
+                  </div>
+                ) : games.length === 0 ? (
+                  <div className="flex flex-col items-center gap-4 py-12 px-6 rounded-2xl border border-white/10 bg-white/5 text-center">
+                    <Gamepad2 size={32} className="text-white/20" />
+                    <p className="text-white/50 font-bold text-sm">
+                      No games yet.
+                    </p>
+                    <Link
+                      href={`/studio/${studio.slug}/games/steam-import`}
+                      className="px-4 py-2.5 rounded-xl bg-emerald-500 text-black font-black text-sm uppercase tracking-wider hover:bg-emerald-400 transition-colors"
+                    >
+                      Import a Game from Steam
+                    </Link>
+                  </div>
+                ) : (
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    {games.map((game) => (
+                      <StudioGameCard key={game.id} game={game} />
+                    ))}
+                  </div>
+                )}
+              </div>
+            ) : (
+              <StudioSalesTab studioSlug={studio.slug} />
+            )}
           </div>
         )}
       </div>
     </>
+  );
+}
+
+// Sales of this studio's own games, resolved server-side through the catalogue
+// since Sale carries no studio_id.
+//
+// 403 rather than 404 is the interesting failure here: the studio exists, the
+// viewer just is not on it. Worth saying so plainly rather than showing an
+// empty list, which would read as "no sales".
+function StudioSalesTab({ studioSlug }: { studioSlug: string }) {
+  const [page, setPage] = useState(1);
+
+  const { data, isLoading, error } = useSWR<{
+    sales: StudioSaleApi[];
+    pagination: PaginationApi;
+  }>(
+    `/api/v1/studios/${studioSlug}/sales?page=${page}`,
+    async (url: string) => {
+      const response = await fetch(url);
+      if (!response.ok) {
+        const body = await response.json().catch(() => null);
+        throw new Error(body?.message || "Failed to load sales.");
+      }
+      return response.json();
+    },
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="animate-spin text-white/30" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <p className="text-rose-300 font-bold text-sm">
+        {error.message || "Failed to load sales."}
+      </p>
+    );
+  }
+
+  const sales = data?.sales ?? [];
+  const total = data?.pagination.total ?? 0;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <p className="text-white/50 text-sm font-bold">
+        {total} sale{total === 1 ? "" : "s"} of your games.
+      </p>
+
+      {sales.length === 0 ? (
+        <div className="flex flex-col items-center gap-2 py-12 px-6 rounded-2xl border border-white/10 bg-white/5 text-center">
+          <Gamepad2 size={32} className="text-white/20" />
+          <p className="text-white/50 font-bold text-sm">No sales yet.</p>
+        </div>
+      ) : (
+        <>
+          <div className="flex flex-col gap-2">
+            {sales.map((sale) => (
+              <div
+                key={sale.id}
+                className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 px-4 py-3 rounded-xl border border-white/10 bg-white/5"
+              >
+                {sale.game_slug ? (
+                  <Link
+                    href={`/item/${sale.game_slug}`}
+                    className="min-w-0 flex-1 font-bold text-sm text-white truncate hover:underline"
+                  >
+                    {sale.game_title}
+                  </Link>
+                ) : (
+                  <span className="min-w-0 flex-1 font-bold text-sm text-white truncate">
+                    {sale.game_title}
+                  </span>
+                )}
+                <div className="flex items-center gap-4 shrink-0">
+                  <span className="font-black text-sm text-emerald-300">
+                    {formatMoney(sale.price_at_sale, sale.currency)}
+                  </span>
+                  <span className="text-white/40 text-xs font-bold">
+                    {new Date(sale.created_at).toLocaleDateString()}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <Pagination pagination={data?.pagination} onPageChange={setPage} />
+        </>
+      )}
+    </div>
   );
 }
 


### PR DESCRIPTION
## Description

The endpoints from #197 had no interface. This adds the four surfaces, plus the building block none of them could be written without.

### `formatMoney(amount, currency)` in `lib/price.ts`

Every existing helper takes a `PricedItem` — an object carrying `price` and optionally `display_price` — so a sale row (`{price_at_sale, currency}`) or a statement balance could not be passed to any of them.

It prints the digits **exactly as the server sent them**. That is the point: sales serialise at 2 decimal places and statement balances at 4, because the ledger holds fractions of a cent that an affiliate reconciles against a real payment. Re-rounding in the browser is precisely how that precision would be lost. Symbols come from `Intl` rather than a table that would drift from the `Currency` rows, falling back to the code itself for a currency `Intl` does not recognise — the ledger will happily record one.

### The four surfaces

- **Outlet** (`pages/store/[slug]/manage.tsx`) — the Sales tab now renders `price_at_sale` and the `buyer_ref` pseudonym, and paginates instead of silently showing page one. A new **Earnings** tab consumes the statement endpoint, which had had no UI since it shipped: one card per currency, payable and held split out, with the 30-day hold explained and a note that payment follows the outlet rather than its owner.
- **Studio** (`pages/studio/[slug]/index.tsx`) — the page was flat, so it gains the tab idiom from the outlet manage page plus a Sales tab. There is no buyer column to render.
- **Buyer** (`pages/library/purchases.tsx`) — a sibling page linked from the library. The library answers "what do I own" at today's list price; this answers "what did I pay".
- **Admin** (`pages/backoffice/revenue/index.tsx`) — one block per currency, a range selector, and a note on why paid-out is not netted against commission.

`Pagination` is extracted to `components/Pagination.tsx` — it was copy-pasted across the backoffice tables already, and four callers needed it at once.

### Two mobile bugs, found by driving the pages rather than assuming

A fourth tab does not fit a 390px viewport:

- The outlet tab row pushed the page into **87px of horizontal scroll**, and **Earnings sat off-screen where it could not be tapped at all** — the click was intercepted by the Sales tab covering it. Both tab rows now scroll horizontally, the idiom `BackofficeTopNav` already uses (`overflow-x-auto` + `shrink-0` on the items). All five views now measure 0px page overflow, and the tab is clickable without forcing.
- The purchases table scrolled inside its own `overflow-x-auto` container, which is correct — but the column it hid was **Paid**, the one someone opens the page for. "Bought through" is dropped below `sm`; the table went from overflowing to fitting exactly (340px in a 340px container).

### One eslint error worth noting

`react-hooks/purity` refused `Date.now()` in the revenue component body, and it was right to: the SWR key would differ on every render and refetch in a loop. The boundary is now resolved in the click handler from a module-scope helper. Verified in a browser that the API call count stays flat across idle seconds. It also gives the better behaviour — the report window holds still while you read it instead of sliding forward underneath you.

## Related issue

Follows #197.

## Type of change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📖 Documentation
- [ ] 🧪 Tests

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] `npm run lint:eslint:check` passes (one pre-existing warning in `pages/item/[slug].tsx`, untouched here)
- [x] `npm run lint:prettier:check` passes
- [x] `npm run test` passes — 687 passed. Two suites fail environmentally in this container and pass in CI: `api/v1/status/get.test.ts` (asserts Postgres `"16.0"` against a `16.13 (Ubuntu…)` string) and `api/v1/items/games/steam-import/post.test.ts` (needs the Steam API)
- [ ] Added or updated tests where relevant — **no frontend test setup exists** in this repo (no testing-library, no component tests), so these were verified by driving Chromium against seeded data at both 1280px and 390px. Figures check out against the seed: gross 159.96, supplier 111.972, commission 13.997, platform 33.991, and the three distributions add back to the gross exactly.

## Notes

`npm run features:backfill` is still outstanding from #197 — `read:studio_sale` joined `studio.MEMBER_PERMISSIONS`, so existing studio owners and members need topping up before the Studio → Sales tab works for them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NL35am9GhcP7nLVBT5eq4c)_