### PR TITLE
fix: stale logout state and locale-aware price formatting

### DIFF
--- a/components/store/StoreTopNav.tsx
+++ b/components/store/StoreTopNav.tsx
@@ -7,7 +7,7 @@ import { Store, Library, Search } from "lucide-react";
 import { DiscountBadge } from "./DiscountBadge";
 import { UserMenu } from "./UserMenu";
 import { type GameApi } from "components/store/GameListItem";
-import { formatPrice } from "lib/price";
+import { formatBasePrice, formatPrice } from "lib/price";
 
 export type StoreNavContext = {
   slug: string;
@@ -163,9 +163,9 @@ export function StoreTopNav({ store }: { store?: StoreNavContext }) {
                               >
                                 {isDemo ? "Free" : formatPrice(game)}
                               </p>
-                              {!isDemo && game.base_price && (
+                              {!isDemo && formatBasePrice(game) && (
                                 <p className="text-xs font-semibold line-through text-white/40">
-                                  ${game.base_price}
+                                  {formatBasePrice(game)}
                                 </p>
                               )}
                             </div>

--- a/components/store/UserMenu.tsx
+++ b/components/store/UserMenu.tsx
@@ -38,7 +38,7 @@ export function UserMenu() {
 
   const handleSignOut = async () => {
     await fetch("/api/v1/sessions", { method: "DELETE" });
-    mutate(null, false);
+    await mutate();
     router.push("/store");
     setIsOpen(false);
   };

--- a/lib/price.ts
+++ b/lib/price.ts
@@ -20,6 +20,44 @@ export interface PricedItem {
 
 const BASE_SYMBOL = "$";
 
+// Currencies whose convention is a comma decimal separator and a period
+// thousands separator (e.g. R$34.887,99), the mirror of the US/UK style the
+// raw amount string already uses. The amount always arrives as a plain
+// period-decimal, ungrouped digit string from the server (see
+// docs/payments-architecture.md and models/pricing.ts's `toFixed`), so this
+// only reformats the separators via string splitting — it never re-parses
+// through Number, which would risk losing precision on ledger-scale amounts.
+const COMMA_DECIMAL_CURRENCIES = new Set([
+  "BRL",
+  "EUR",
+  "ARS",
+  "CLP",
+  "COP",
+  "UYU",
+  "CZK",
+  "DKK",
+  "NOK",
+  "PLN",
+  "SEK",
+  "TRY",
+  "IDR",
+  "VND",
+]);
+
+function localizeAmount(amount: string, currency: string): string {
+  if (!COMMA_DECIMAL_CURRENCIES.has((currency || "").toUpperCase())) {
+    return amount;
+  }
+
+  const sign = amount.startsWith("-") ? "-" : "";
+  const [integerPart, decimalPart] = amount.replace("-", "").split(".");
+  const grouped = integerPart.replace(/\B(?=(\d{3})+(?!\d))/g, ".");
+
+  return decimalPart !== undefined
+    ? `${sign}${grouped},${decimalPart}`
+    : `${sign}${grouped}`;
+}
+
 export function isFree(item: PricedItem): boolean {
   const amount = item.display_price?.amount ?? item.price;
   return !amount || Number(amount) === 0;
@@ -27,7 +65,8 @@ export function isFree(item: PricedItem): boolean {
 
 export function formatPrice(item: PricedItem): string {
   if (item.display_price) {
-    return `${item.display_price.symbol}${item.display_price.amount}`;
+    const { symbol, amount, currency } = item.display_price;
+    return `${symbol}${localizeAmount(amount, currency)}`;
   }
 
   return `${BASE_SYMBOL}${item.price}`;
@@ -36,13 +75,13 @@ export function formatPrice(item: PricedItem): string {
 // The struck-through "was" price, or null when there is no discount to show.
 export function formatBasePrice(item: PricedItem): string | null {
   if (item.display_price) {
-    const { base_amount, amount, symbol } = item.display_price;
+    const { base_amount, amount, symbol, currency } = item.display_price;
 
     if (!base_amount || base_amount === amount) {
       return null;
     }
 
-    return `${symbol}${base_amount}`;
+    return `${symbol}${localizeAmount(base_amount, currency)}`;
   }
 
   if (!item.base_price || item.base_price === item.price) {
@@ -69,7 +108,7 @@ export function hasDiscount(item: PricedItem): boolean {
 // payment. Re-rounding here is precisely how that precision would be lost, so
 // this function only ever puts a symbol in front of a string it does not touch.
 export function formatMoney(amount: string | number, currency: string): string {
-  return `${currencySymbol(currency)}${amount}`;
+  return `${currencySymbol(currency)}${localizeAmount(String(amount), currency)}`;
 }
 
 // Symbol lookup memoised per currency code. Intl knows the symbol for every


### PR DESCRIPTION
## Description

Three related frontend fixes:

1. **Stale logout state** — `UserMenu` cleared the SWR cache with `mutate(null, false)` on sign-out, which never touches the `error` field that drives `isLoggedOut`. The avatar/dropdown stayed visible until a manual refresh. Now revalidates (`await mutate()`) so the fetcher's 401 naturally sets the error and flips the UI to "Log In" immediately.
2. **Comma-decimal formatting for BRL and similar currencies** — `lib/price.ts` always concatenated the server's amount digits with a period decimal separator, regardless of currency. Added `localizeAmount`, a pure string transform (no re-parsing through `Number`, preserving ledger-scale precision) that renders `R$20,33` / `R$34.887,99` instead of `R$20.33` / `R$34,887.99` for BRL, EUR, and other comma-decimal currencies.
3. **Hardcoded `$` in the store search dropdown** — found while fixing #2: `StoreTopNav.tsx`'s strikethrough "was" price hardcoded a `$` and the raw USD `base_price`, so it mismatched the currency-correct current price shown right next to it. Switched to `formatBasePrice(game)`, the same helper used elsewhere, so it now inherits the correct symbol and separator.

## Related issue

N/A

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📖 Documentation
- [ ] ♻️ Refactor
- [ ] 🧪 Tests

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] `npm run lint:eslint:check` passes
- [x] `npm run lint:prettier:check` passes
- [x] `npm run test` passes (locally verified via `npm run test:no-docker`; only pre-existing environment-specific failure is an exact Postgres version string assertion — `16.0` vs this environment's `16.13` — unrelated to this change)
- [ ] Added or updated tests where relevant (no frontend test setup exists in this repo per CLAUDE.md; verified manually per the PR's testing notes)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WjhF83rRKSstZL6PxgYyMo)_