### PR TITLE
fix: remove custom rotation on pull-to-refresh icon

### DIFF
--- a/components/PullToRefreshIndicator.tsx
+++ b/components/PullToRefreshIndicator.tsx
@@ -32,11 +32,6 @@ export function PullToRefreshIndicator({
       <Loader2
         size={28}
         className={`text-[var(--color-purple-dark)] ${isRefreshing ? "animate-spin" : ""}`}
-        style={
-          !isRefreshing
-            ? { transform: `rotate(${progress * 360}deg)` }
-            : undefined
-        }
       />
     </div>
   );


### PR DESCRIPTION
## Description

Follow-up to #200 (already merged). The pull-to-refresh icon (`components/PullToRefreshIndicator.tsx`) was manually rotated proportional to pull distance while dragging, on top of Tailwind's `animate-spin` kicking in once the refresh actually fires. Removed the manual `rotate(${progress * 360}deg)` transform so the icon stays static during the pull gesture and only spins via `animate-spin` once `isRefreshing` is true.

## Related issue

N/A

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📖 Documentation
- [ ] ♻️ Refactor
- [ ] 🧪 Tests

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] `npm run lint:eslint:check` passes
- [x] `npm run lint:prettier:check` passes
- [ ] `npm run test` passes (no automated coverage of this UI-only visual change; not re-run for this single-line follow-up, see `#200`'s prior full suite run for baseline)
- [ ] Added or updated tests where relevant (no frontend test setup exists in this repo per CLAUDE.md)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WjhF83rRKSstZL6PxgYyMo)_