### PR TITLE
feat(payments): add payout provider interface and adapters

### DIFF
--- a/docs/payments-tasks.md
+++ b/docs/payments-tasks.md
@@ -21,7 +21,8 @@ For the runtime design of the pricing path — how a game gets a price in the vi
 | 6b. Ledger writes on acquisition         | ✅ done                                                                        |
 | 6c. Outlet statement                     | ✅ done                                                                        |
 | 8. Payout account model + endpoints      | ✅ done                                                                        |
-| 7, 9–11 (providers, payouts)             | not started                                                                    |
+| 7. Provider interface + Stripe adapter   | ✅ done                                                                        |
+| 9–11 (payouts)                           | not started                                                                    |
 
 Each task is a separate small PR, landed in order, with `npm run test` passing on its own before merge — the same format as `docs/backoffice-tasks.md`.
 
@@ -289,9 +290,17 @@ Four methods — `createAccount`, `getAccountStatus`, `sendPayout`, `getPayoutSt
 
 Providers declare which currencies they can pay in, so the payout run can route a BRL balance to a rail that reaches Pix and a USD balance to Stripe.
 
-**Done when:** the fake and Stripe adapters satisfy the same interface and the call sites never import a provider directly.
+**Done when:** the fake and Stripe adapters satisfy the same interface and the call sites never import a provider directly. ✅
 
-**Landed out of order — task 8 went first.** The `provider` column this registry keys on now exists on `PayoutAccount`, with its allowed values in a `PAYOUT_PROVIDERS` constant that this task replaces with the registry's own keys. `getAccountStatus` also has a seam to call: `payoutAccount.setProviderState`, which the admin backoffice already writes through, so wiring a provider in means replacing who calls it rather than adding the concept.
+**Landed out of order — task 8 went first.** The `provider` column this registry keys on already existed on `PayoutAccount`, with its allowed values in a `PAYOUT_PROVIDERS` constant. That constant is now `payoutProviders.providerKeys()`: one place declares a rail, so there is no second list to disagree with the registry — no provider string that validates but resolves to no adapter, and no adapter nothing can select.
+
+**Swappability is proven by the fake, not by Stripe.** `infra/payout_providers/stripe.ts` is registered and declares the currencies it would pay in, but its four methods throw `ServiceError` until Connect is configured. That is deliberate: this repo mocks nothing — the suite runs against a real postgres, SMTP catcher and S3, and `jest.mock` appears nowhere in `tests/` — so a real Stripe implementation would ship as code no test ever runs. `infra/payout_providers/fake.ts` is the adapter that actually works, holding accounts and payouts in a `Map`, and it is what makes the payout path in tasks 9–10 exercisable without network. Two adapters satisfying one interface is what the "done when" was asking for; a rail that throws is a smaller lie than a rail that is untested.
+
+**The rail and the currency are validated as a pair.** Because a provider declares `supportedCurrencies`, `payoutAccount` can refuse a combination it could never pay — including a provider change that strands an existing currency, which is the case a per-field check misses. Previously such a row was written, passed verification, and failed at the one moment it mattered.
+
+Two things left as seams rather than wired now: `getAccountStatus` returns exactly the shape `payoutAccount.setProviderState` takes, so a verification sync is a pass-through rather than a translation — a translation is where a rail's "restricted" quietly becomes our "enabled". And `sendPayout` takes an `idempotency_key` that the fake honours by returning the first payout, so task 10's re-runnability is a property that can fail a test here rather than in production.
+
+**Deliberately not registered in production: the fake.** A test seam that can be selected in production is a way to mark an outlet payable without a provider ever seeing it — the same reasoning that makes `storage.clearAllBuckets()` refuse to run there.
 
 ---
 

--- a/infra/payout_providers/fake.ts
+++ b/infra/payout_providers/fake.ts
@@ -1,0 +1,202 @@
+import { randomUUID } from "node:crypto";
+import { NotFoundError, ValidationError } from "infra/errors";
+import type {
+  CreateAccountInput,
+  PayoutProviderAdapter,
+  ProviderAccount,
+  ProviderAccountStatus,
+  ProviderPayout,
+  SendPayoutInput,
+} from "./index";
+
+// A payout rail that keeps its state in a Map.
+//
+// This repo mocks nothing — the suite runs against a real postgres, a real
+// SMTP catcher and a real S3 (infra/compose.yaml), and `jest.mock` appears
+// nowhere in tests/. So the way to exercise a payout end to end is a real
+// adapter with a fake backend, not a stubbed Stripe. It is also what proves the
+// interface is swappable: two adapters satisfy it, and the call sites can tell
+// them apart only by the key.
+//
+// Registered outside production only — see the comment in ./index.
+
+interface FakeAccount {
+  provider_account_id: string;
+  store_id: string;
+  payout_currency: string;
+  payouts_enabled: boolean;
+}
+
+interface FakePayout {
+  provider_payout_id: string;
+  provider_account_id: string;
+  amount: string;
+  currency: string;
+  idempotency_key: string;
+  status: "PAID";
+}
+
+const accounts = new Map<string, FakeAccount>();
+const payouts = new Map<string, FakePayout>();
+// Keyed by idempotency key, so a retried payout returns the first one rather
+// than paying twice. The real rails behave this way and a fake that did not
+// would let task 10's re-runnability pass here and fail in production.
+const payoutsByIdempotencyKey = new Map<string, string>();
+
+const KEY = "FAKE";
+
+// Two currencies, not one, so multi-currency routing has something to route:
+// a rail declaring only USD (as the Stripe skeleton does) and a rail declaring
+// both is the smallest arrangement in which "pick a rail that can pay this
+// balance" is a real decision.
+const SUPPORTED_CURRENCIES = ["USD", "BRL"] as const;
+
+function assertSupportedCurrency(code: string) {
+  const normalizedCode = code.trim().toUpperCase();
+
+  if (!SUPPORTED_CURRENCIES.includes(normalizedCode as "USD" | "BRL")) {
+    throw new ValidationError({
+      message: `The fake payout provider cannot pay in "${normalizedCode}".`,
+      action: `Use one of: ${SUPPORTED_CURRENCIES.join(", ")}.`,
+    });
+  }
+
+  return normalizedCode;
+}
+
+function findAccountOrThrow(providerAccountId: string): FakeAccount {
+  const account = accounts.get(providerAccountId);
+
+  if (!account) {
+    throw new NotFoundError({
+      message: `The fake payout provider has no account "${providerAccountId}".`,
+      action: "Create the account before reading or paying it.",
+    });
+  }
+
+  return account;
+}
+
+async function createAccount(
+  input: CreateAccountInput,
+): Promise<ProviderAccount> {
+  const payoutCurrency = assertSupportedCurrency(input.payout_currency);
+  const providerAccountId = `fake_acct_${randomUUID()}`;
+
+  // Disabled on creation, like every real rail: registering a destination is
+  // not the same as having been verified to receive money at it.
+  accounts.set(providerAccountId, {
+    provider_account_id: providerAccountId,
+    store_id: input.store_id,
+    payout_currency: payoutCurrency,
+    payouts_enabled: false,
+  });
+
+  return { provider_account_id: providerAccountId, payouts_enabled: false };
+}
+
+async function getAccountStatus(
+  providerAccountId: string,
+): Promise<ProviderAccountStatus> {
+  const account = findAccountOrThrow(providerAccountId);
+
+  return {
+    provider_account_id: account.provider_account_id,
+    payouts_enabled: account.payouts_enabled,
+  };
+}
+
+async function sendPayout(input: SendPayoutInput): Promise<ProviderPayout> {
+  const account = findAccountOrThrow(input.provider_account_id);
+  const currencyCode = assertSupportedCurrency(input.currency);
+
+  const existingPayoutId = payoutsByIdempotencyKey.get(input.idempotency_key);
+  if (existingPayoutId) {
+    const existingPayout = payouts.get(existingPayoutId);
+    if (existingPayout) {
+      return {
+        provider_payout_id: existingPayout.provider_payout_id,
+        status: existingPayout.status,
+      };
+    }
+  }
+
+  if (!account.payouts_enabled) {
+    throw new ValidationError({
+      message: `The fake payout account "${input.provider_account_id}" is not verified.`,
+      action: "Enable payouts on the account before sending one.",
+    });
+  }
+
+  if (input.amount.lessThanOrEqualTo(0)) {
+    throw new ValidationError({
+      message: "A payout amount must be greater than zero.",
+      action: "Send a positive amount.",
+    });
+  }
+
+  const providerPayoutId = `fake_po_${randomUUID()}`;
+
+  payouts.set(providerPayoutId, {
+    provider_payout_id: providerPayoutId,
+    provider_account_id: input.provider_account_id,
+    // Stored at the ledger's scale, not via toString(): toString() normalises
+    // trailing zeros, so a 199.9000 payout would be recorded as "199.9" in the
+    // one place someone reconciles it against a bank line (see CLAUDE.md).
+    amount: input.amount.toFixed(4),
+    currency: currencyCode,
+    idempotency_key: input.idempotency_key,
+    status: "PAID",
+  });
+  payoutsByIdempotencyKey.set(input.idempotency_key, providerPayoutId);
+
+  return { provider_payout_id: providerPayoutId, status: "PAID" };
+}
+
+async function getPayoutStatus(
+  providerPayoutId: string,
+): Promise<ProviderPayout> {
+  const payout = payouts.get(providerPayoutId);
+
+  if (!payout) {
+    throw new NotFoundError({
+      message: `The fake payout provider has no payout "${providerPayoutId}".`,
+      action: "Send the payout before reading its status.",
+    });
+  }
+
+  return {
+    provider_payout_id: payout.provider_payout_id,
+    status: payout.status,
+  };
+}
+
+// Test seams. Verification on a real rail is an out-of-band event — a webhook,
+// a review — so a fake needs a way to say it happened; without one, nothing
+// downstream of `payouts_enabled` is reachable in a test.
+export function markVerified(providerAccountId: string): void {
+  const account = findAccountOrThrow(providerAccountId);
+  account.payouts_enabled = true;
+}
+
+export function reset(): void {
+  accounts.clear();
+  payouts.clear();
+  payoutsByIdempotencyKey.clear();
+}
+
+const fakeProvider: PayoutProviderAdapter & {
+  markVerified: typeof markVerified;
+  reset: typeof reset;
+} = {
+  key: KEY,
+  supportedCurrencies: SUPPORTED_CURRENCIES,
+  createAccount,
+  getAccountStatus,
+  sendPayout,
+  getPayoutStatus,
+  markVerified,
+  reset,
+};
+
+export default fakeProvider;

--- a/infra/payout_providers/index.ts
+++ b/infra/payout_providers/index.ts
@@ -1,0 +1,148 @@
+import { Prisma } from "generated/prisma/client";
+import { ValidationError } from "infra/errors";
+import fakeProvider from "./fake";
+import stripeProvider from "./stripe";
+
+// The payout rail, behind one interface, so the payout run never learns which
+// one it is talking to.
+//
+// The alternative — a `if (provider === "STRIPE")` at each call site — puts the
+// knowledge of every rail in every caller, and makes the second rail a change
+// to code that already moves money. Four methods is the whole surface a payout
+// needs: register a destination, ask whether it may be paid, pay it, ask what
+// happened.
+
+// How far a payout can get. A tuple plus a derived union rather than a Prisma
+// enum, matching LEDGER_SOURCE_TYPES: no column holds this yet — the Payout
+// table arrives in task 10 — and a provider that reports a state we have no
+// name for should fail loudly at its own adapter rather than at a migration.
+export const PAYOUT_STATUSES = ["PENDING", "PAID", "FAILED"] as const;
+
+export type PayoutStatus = (typeof PAYOUT_STATUSES)[number];
+
+export interface CreateAccountInput {
+  // The outlet being paid. Passed rather than looked up because infra/ does not
+  // read the database — the model layer owns that, and an adapter that queried
+  // for a store would be untestable without one.
+  store_id: string;
+  payout_currency: string;
+  email?: string;
+  label?: string;
+}
+
+export interface ProviderAccount {
+  provider_account_id: string;
+  payouts_enabled: boolean;
+}
+
+// Deliberately the exact shape payoutAccount.setProviderState takes, so a
+// status sync is a pass-through rather than a translation. A translation is
+// where a rail's "restricted" quietly becomes our "enabled".
+export interface ProviderAccountStatus {
+  provider_account_id: string;
+  payouts_enabled: boolean;
+}
+
+export interface SendPayoutInput {
+  provider_account_id: string;
+  // A Decimal, never a number: this is money, and the ledger holds four
+  // decimal places (see CLAUDE.md). An adapter converts to whatever unit its
+  // API wants at the boundary, and that conversion is the adapter's problem.
+  amount: Prisma.Decimal;
+  currency: string;
+  // Ours, not the provider's. The payout run passes the same key when it
+  // retries, which is what makes a re-run safe against a provider that already
+  // accepted the first attempt.
+  idempotency_key: string;
+}
+
+export interface ProviderPayout {
+  provider_payout_id: string;
+  status: PayoutStatus;
+}
+
+export interface PayoutProviderAdapter {
+  // Matches PayoutAccount.provider. The column stores this string, which is
+  // why it is on the adapter rather than only in the registry's keys: an
+  // adapter that disagreed with its own key would route to itself under a name
+  // nothing else uses.
+  readonly key: string;
+
+  // Which currencies this rail can actually pay in, normalized and uppercase.
+  // Declared so a payout run can route a BRL balance to a rail that reaches
+  // Pix and a USD balance to Stripe, instead of discovering the mismatch when
+  // the transfer is rejected.
+  readonly supportedCurrencies: readonly string[];
+
+  createAccount(input: CreateAccountInput): Promise<ProviderAccount>;
+  getAccountStatus(providerAccountId: string): Promise<ProviderAccountStatus>;
+  sendPayout(input: SendPayoutInput): Promise<ProviderPayout>;
+  getPayoutStatus(providerPayoutId: string): Promise<ProviderPayout>;
+}
+
+// Which rails exist. The fake is registered outside production for the same
+// reason storage.clearAllBuckets refuses to run there: it is a test seam, and a
+// test seam that can be selected in production is a way to mark an outlet
+// payable without a provider ever seeing it.
+//
+// Registration happens here rather than in each adapter so that the set of
+// rails is readable in one place, and so an adapter never has an import that
+// runs for its own side effect.
+const adapters: PayoutProviderAdapter[] = [
+  stripeProvider,
+  ...(process.env.NODE_ENV === "production" ? [] : [fakeProvider]),
+];
+
+const registry = new Map<string, PayoutProviderAdapter>(
+  adapters.map((adapter) => [adapter.key, adapter]),
+);
+
+export function providerKeys(): string[] {
+  return [...registry.keys()];
+}
+
+export function isRegistered(key: string): boolean {
+  return registry.has(normalizeKey(key));
+}
+
+// A ValidationError rather than an InternalServerError because the key reaching
+// here is caller-supplied: it comes off the payout-account endpoints, where an
+// outlet names its own rail. An unknown rail is a bad request, not a bug.
+export function getProvider(key: string): PayoutProviderAdapter {
+  const adapter = registry.get(normalizeKey(key));
+
+  if (!adapter) {
+    throw new ValidationError({
+      message: `"${key}" is not a supported payout provider.`,
+      action: `Use one of: ${providerKeys().join(", ")}.`,
+    });
+  }
+
+  return adapter;
+}
+
+// Keys are compared uppercase for the same reason currency codes are: the
+// column is free text with no foreign key, so a casing difference would not
+// fail — it would simply match nothing, and an outlet would sit unpayable with
+// a row that looks correct.
+export function normalizeKey(key: string): string {
+  return key.trim().toUpperCase();
+}
+
+export function supportsCurrency(
+  adapter: PayoutProviderAdapter,
+  code: string,
+): boolean {
+  return adapter.supportedCurrencies.includes(code.trim().toUpperCase());
+}
+
+const payoutProviders = {
+  PAYOUT_STATUSES,
+  providerKeys,
+  isRegistered,
+  getProvider,
+  normalizeKey,
+  supportsCurrency,
+};
+
+export default payoutProviders;

--- a/infra/payout_providers/stripe.ts
+++ b/infra/payout_providers/stripe.ts
@@ -1,0 +1,90 @@
+import { ServiceError } from "infra/errors";
+import type {
+  CreateAccountInput,
+  PayoutProviderAdapter,
+  ProviderAccount,
+  ProviderAccountStatus,
+  ProviderPayout,
+  SendPayoutInput,
+} from "./index";
+
+// Stripe, declared but not yet wired.
+//
+// The rail is registered so the column value "STRIPE" resolves, so the
+// interface has a second implementation holding it honest, and so the currency
+// it can pay in is a fact the payout run can already route on. What it cannot
+// do yet is move money, and it says so rather than pretending.
+//
+// This is deliberate rather than unfinished. The implementation is Connect
+// accounts (createAccount / getAccountStatus) plus Transfers (sendPayout /
+// getPayoutStatus), and none of it is verifiable here: the suite has no
+// network mocking of any kind, so a real implementation would ship as code no
+// test ever runs, against an account whose Connect configuration is not
+// settled. A rail that throws is a smaller lie than a rail that is untested.
+//
+// When it lands: add `stripe` with `npm install -E`, and construct the client
+// lazily inside each method. infra/storage.ts and infra/email.ts build their
+// clients at module scope, which is fine for services the dev environment
+// always runs — doing it here would make an unset STRIPE_SECRET_KEY break
+// importing this module at all, including in every test that only wanted the
+// fake.
+
+const KEY = "STRIPE";
+
+// A deliberately conservative subset of what Stripe Connect can pay out in.
+// The real ceiling depends on the connected account's country and the
+// platform's own configuration, which cannot be known before an account
+// exists, so this lists the currencies the platform actually prices and sells
+// in today. Understating is the safe direction: a rail that declines to route
+// a balance leaves it unpaid and visible, where overstating routes money at a
+// destination that rejects it after the ledger has already recorded the send.
+//
+// Widen this from the connected account's capabilities once createAccount is
+// real, rather than by editing the list by hand.
+const SUPPORTED_CURRENCIES = ["USD", "EUR", "GBP", "BRL"] as const;
+
+function notConfigured(operation: string): never {
+  throw new ServiceError({
+    message: `Stripe payouts are not configured, so "${operation}" is unavailable.`,
+    action:
+      "Configure the Stripe payout provider, or use a different payout provider.",
+    context: { provider: KEY, operation },
+  });
+}
+
+async function createAccount(
+  input: CreateAccountInput,
+): Promise<ProviderAccount> {
+  void input;
+  notConfigured("createAccount");
+}
+
+async function getAccountStatus(
+  providerAccountId: string,
+): Promise<ProviderAccountStatus> {
+  void providerAccountId;
+  notConfigured("getAccountStatus");
+}
+
+async function sendPayout(input: SendPayoutInput): Promise<ProviderPayout> {
+  void input;
+  notConfigured("sendPayout");
+}
+
+async function getPayoutStatus(
+  providerPayoutId: string,
+): Promise<ProviderPayout> {
+  void providerPayoutId;
+  notConfigured("getPayoutStatus");
+}
+
+const stripeProvider: PayoutProviderAdapter = {
+  key: KEY,
+  supportedCurrencies: SUPPORTED_CURRENCIES,
+  createAccount,
+  getAccountStatus,
+  sendPayout,
+  getPayoutStatus,
+};
+
+export default stripeProvider;

--- a/models/payout_account.ts
+++ b/models/payout_account.ts
@@ -4,17 +4,19 @@ import { Prisma } from "generated/prisma/client";
 import { NotFoundError, ValidationError } from "infra/errors";
 import currency, { currencyCodeSchema } from "models/currency";
 import pricing from "models/pricing";
+import payoutProviders from "infra/payout_providers";
 
 // The rails we can pay an outlet through.
 //
-// A plain list rather than an enum column for the same reason
-// SupplierTerms.supplier_type is a string: onboarding a payout provider is a
-// commercial event, not a schema change. This becomes the provider registry's
-// key set once the provider interface lands, and this constant goes away in
-// favour of the registry's own keys.
-export const PAYOUT_PROVIDERS = ["STRIPE"] as const;
+// No longer a list of its own: the registry in infra/payout_providers is the
+// one place a rail is declared, and a second list here could disagree with it —
+// a provider string that validates but resolves to no adapter, or an adapter
+// nothing can select. Kept as an export because it reads as the answer to
+// "which rails exist" at the model layer, where the rest of this schema's
+// referential integrity lives.
+export const PAYOUT_PROVIDERS = payoutProviders.providerKeys();
 
-export type PayoutProvider = (typeof PAYOUT_PROVIDERS)[number];
+export type PayoutProvider = string;
 
 // What an outlet may say about its own payout account.
 //
@@ -22,8 +24,19 @@ export type PayoutProvider = (typeof PAYOUT_PROVIDERS)[number];
 // omission: the party being paid must not be able to declare itself payable,
 // and the external account id is the provider's to issue. Both are written
 // only through setProviderState below.
+//
+// provider is a refined string rather than z.enum because the allowed values
+// come from the registry at runtime, and z.enum needs a literal tuple. The
+// refinement normalizes first, so casing can never produce a row that matches
+// no adapter.
 export const payoutAccountSchema = z.object({
-  provider: z.enum(PAYOUT_PROVIDERS),
+  provider: z
+    .string()
+    .trim()
+    .toUpperCase()
+    .refine((value) => payoutProviders.isRegistered(value), {
+      message: `provider must be one of: ${payoutProviders.providerKeys().join(", ")}`,
+    }),
   payout_currency: currencyCodeSchema,
   label: z.string().trim().max(255).optional(),
 });
@@ -66,14 +79,37 @@ async function validatePayoutCurrency(code: string) {
   }
 }
 
+// A rail and a currency are only valid as a pair. Registering a BRL account on
+// a USD-only provider is a row that looks complete, passes verification, and
+// fails at the one moment it matters — when a payout run tries to send it. The
+// provider declares what it can pay in, so the mismatch is knowable at write
+// time; refusing here is the difference between a 400 to whoever chose the
+// combination and a failed transfer nobody is watching.
+function validateProviderPaysCurrency(providerKey: string, code: string) {
+  const provider = payoutProviders.getProvider(providerKey);
+  const normalizedCode = currency.normalizeCode(code);
+
+  if (!payoutProviders.supportsCurrency(provider, normalizedCode)) {
+    throw new ValidationError({
+      message: `The payout provider "${provider.key}" cannot pay in "${normalizedCode}".`,
+      action: `Choose a currency the provider supports (${provider.supportedCurrencies.join(", ")}), or a provider that pays in "${normalizedCode}".`,
+    });
+  }
+}
+
 async function create(storeId: string, accountDto: PayoutAccountDto) {
   await validatePayoutCurrency(accountDto.payout_currency);
+  validateProviderPaysCurrency(accountDto.provider, accountDto.payout_currency);
 
   try {
     return await prisma.payoutAccount.create({
       data: {
         store_id: storeId,
-        provider: accountDto.provider,
+        // Normalized on write as well as in the schema, for the same reason
+        // payout_currency is: a model called directly — by a script, a batch
+        // job, a test — bypasses the Zod layer, and a lowercase rail here would
+        // resolve to no adapter while looking perfectly correct in the row.
+        provider: payoutProviders.normalizeKey(accountDto.provider),
         payout_currency: currency.normalizeCode(accountDto.payout_currency),
         label: accountDto.label,
       },
@@ -119,20 +155,37 @@ async function update(storeId: string, updateDto: PayoutAccountUpdateDto) {
     ? currency.normalizeCode(updateDto.payout_currency)
     : undefined;
 
+  // Normalized before it is compared, not just before it is stored: railChanged
+  // below is a value comparison, so an unnormalized "stripe" against a stored
+  // "STRIPE" would read as a rail change and silently reset a verified outlet
+  // to unpayable.
+  const normalizedProvider = updateDto.provider
+    ? payoutProviders.normalizeKey(updateDto.provider)
+    : undefined;
+
+  // Checked against the pair the row will hold after the write, not against
+  // the field that happened to be sent. Changing only the provider on a BRL
+  // account is exactly the case a per-field check misses, and it is the one
+  // that leaves an outlet unpayable on a rail that cannot reach its currency.
+  validateProviderPaysCurrency(
+    normalizedProvider ?? existingAccount.provider,
+    normalizedCurrency ?? existingAccount.payout_currency,
+  );
+
   // Changing the rail invalidates the verification that was done against it.
   // Whoever was verified was verified to receive money at a particular provider
   // in a particular currency; leaving the flag set would let an outlet be
   // checked for one destination and paid at another. A label edit is cosmetic
   // and resets nothing.
   const railChanged =
-    (updateDto.provider && updateDto.provider !== existingAccount.provider) ||
+    (normalizedProvider && normalizedProvider !== existingAccount.provider) ||
     (normalizedCurrency &&
       normalizedCurrency !== existingAccount.payout_currency);
 
   return await prisma.payoutAccount.update({
     where: { store_id: storeId },
     data: {
-      provider: updateDto.provider,
+      provider: normalizedProvider,
       payout_currency: normalizedCurrency,
       label: updateDto.label,
       ...(railChanged

--- a/tests/integration/models/payout_account.test.ts
+++ b/tests/integration/models/payout_account.test.ts
@@ -73,6 +73,21 @@ describe("payoutAccount.update", () => {
       payoutAccount.update(store.id, { label: "Renamed rail" }),
     ).rejects.toThrow("This store has no payout account.");
   });
+
+  // The endpoints normalize through Zod, but a script or a batch job calling
+  // the model directly does not. Comparing an unnormalized rail against the
+  // stored one would read as a change and reset a verified outlet.
+  test("should keep verification when the rail is resent in another casing", async () => {
+    const { store } = await seedVerifiedAccount();
+
+    const updated = await payoutAccount.update(store.id, {
+      provider: "stripe",
+    });
+
+    expect(updated.provider).toBe("STRIPE");
+    expect(updated.payouts_enabled).toBe(true);
+    expect(updated.provider_account_id).toBe("acct_verified_123");
+  });
 });
 
 describe("payoutAccount.setProviderState", () => {
@@ -119,5 +134,48 @@ describe("payoutAccount.create", () => {
     expect(created.payout_currency).toBe("USD");
     expect(created.payouts_enabled).toBe(false);
     expect(created.provider_account_id).toBeNull();
+  });
+
+  // A rail and a currency are only valid as a pair. Without this the row is
+  // written, passes verification, and fails at the one moment it matters — when
+  // a payout run tries to send it.
+  test("should refuse a currency the chosen rail cannot pay in", async () => {
+    const owner = await orchestrator.createUser();
+    await orchestrator.activateUser(owner.id);
+    const store = await orchestrator.createStore(owner.id);
+    await orchestrator.createCurrency({ code: "JPY", symbol: "¥" });
+
+    await expect(
+      payoutAccount.create(store.id, {
+        provider: "STRIPE",
+        payout_currency: "JPY",
+      }),
+    ).rejects.toThrow('The payout provider "STRIPE" cannot pay in "JPY".');
+  });
+});
+
+describe("payoutAccount rail and currency compatibility", () => {
+  // The case a per-field check misses: the currency is untouched and still
+  // valid on its own, but the rail moving underneath it can no longer reach it.
+  test("should refuse a provider change that strands the existing currency", async () => {
+    const owner = await orchestrator.createUser();
+    await orchestrator.activateUser(owner.id);
+    const store = await orchestrator.createStore(owner.id);
+    await orchestrator.createCurrency({ code: "BRL", symbol: "R$" });
+
+    await payoutAccount.create(store.id, {
+      provider: "STRIPE",
+      payout_currency: "BRL",
+    });
+
+    // FAKE pays in BRL, so this one is allowed through and the guard is shown
+    // to be a real check rather than a blanket refusal of provider changes.
+    const moved = await payoutAccount.update(store.id, { provider: "FAKE" });
+    expect(moved.provider).toBe("FAKE");
+
+    await orchestrator.createCurrency({ code: "JPY", symbol: "¥" });
+    await expect(
+      payoutAccount.update(store.id, { payout_currency: "JPY" }),
+    ).rejects.toThrow('The payout provider "FAKE" cannot pay in "JPY".');
   });
 });

--- a/tests/unit/infra/payout_providers/fake.test.ts
+++ b/tests/unit/infra/payout_providers/fake.test.ts
@@ -1,0 +1,181 @@
+import { Prisma } from "generated/prisma/client";
+import fakeProvider from "infra/payout_providers/fake";
+
+// No orchestrator: the fake rail holds its state in memory and touches no
+// service, so this is a unit test by the rule in CLAUDE.md.
+beforeEach(() => {
+  fakeProvider.reset();
+});
+
+async function createVerifiedAccount() {
+  const account = await fakeProvider.createAccount({
+    store_id: "00000000-0000-0000-0000-000000000001",
+    payout_currency: "USD",
+  });
+
+  fakeProvider.markVerified(account.provider_account_id);
+
+  return account;
+}
+
+describe("infra/payout_providers/fake.ts", () => {
+  describe(".createAccount()", () => {
+    test("mints an account that is not yet payable", async () => {
+      const account = await fakeProvider.createAccount({
+        store_id: "00000000-0000-0000-0000-000000000001",
+        payout_currency: "USD",
+      });
+
+      expect(account.provider_account_id).toEqual(expect.any(String));
+      expect(account.payouts_enabled).toBe(false);
+    });
+
+    test("refuses a currency the rail does not declare", async () => {
+      await expect(
+        fakeProvider.createAccount({
+          store_id: "00000000-0000-0000-0000-000000000001",
+          payout_currency: "JPY",
+        }),
+      ).rejects.toThrow('The fake payout provider cannot pay in "JPY".');
+    });
+  });
+
+  describe(".getAccountStatus()", () => {
+    test("reports the account as payable only once verified", async () => {
+      const account = await fakeProvider.createAccount({
+        store_id: "00000000-0000-0000-0000-000000000001",
+        payout_currency: "USD",
+      });
+
+      const before = await fakeProvider.getAccountStatus(
+        account.provider_account_id,
+      );
+      expect(before.payouts_enabled).toBe(false);
+
+      fakeProvider.markVerified(account.provider_account_id);
+
+      const after = await fakeProvider.getAccountStatus(
+        account.provider_account_id,
+      );
+      expect(after.provider_account_id).toBe(account.provider_account_id);
+      expect(after.payouts_enabled).toBe(true);
+    });
+
+    test("refuses an account it never issued", async () => {
+      await expect(
+        fakeProvider.getAccountStatus("fake_acct_nope"),
+      ).rejects.toThrow(
+        'The fake payout provider has no account "fake_acct_nope".',
+      );
+    });
+  });
+
+  describe(".sendPayout()", () => {
+    test("pays a verified account", async () => {
+      const account = await createVerifiedAccount();
+
+      const payout = await fakeProvider.sendPayout({
+        provider_account_id: account.provider_account_id,
+        amount: new Prisma.Decimal("199.9000"),
+        currency: "USD",
+        idempotency_key: "period-2026-08:store-1",
+      });
+
+      expect(payout.provider_payout_id).toEqual(expect.any(String));
+      expect(payout.status).toBe("PAID");
+    });
+
+    test("refuses to pay an account that was never verified", async () => {
+      const account = await fakeProvider.createAccount({
+        store_id: "00000000-0000-0000-0000-000000000001",
+        payout_currency: "USD",
+      });
+
+      await expect(
+        fakeProvider.sendPayout({
+          provider_account_id: account.provider_account_id,
+          amount: new Prisma.Decimal("10.0000"),
+          currency: "USD",
+          idempotency_key: "period-2026-08:store-1",
+        }),
+      ).rejects.toThrow("is not verified");
+    });
+
+    test("refuses a non-positive amount", async () => {
+      const account = await createVerifiedAccount();
+
+      await expect(
+        fakeProvider.sendPayout({
+          provider_account_id: account.provider_account_id,
+          amount: new Prisma.Decimal("0"),
+          currency: "USD",
+          idempotency_key: "period-2026-08:store-1",
+        }),
+      ).rejects.toThrow("A payout amount must be greater than zero.");
+    });
+
+    // The property task 10's re-runnable payout run depends on: sending the
+    // same key twice is one payment, not two.
+    test("returns the first payout when the same idempotency key is resent", async () => {
+      const account = await createVerifiedAccount();
+
+      const first = await fakeProvider.sendPayout({
+        provider_account_id: account.provider_account_id,
+        amount: new Prisma.Decimal("50.0000"),
+        currency: "USD",
+        idempotency_key: "period-2026-08:store-1",
+      });
+
+      const second = await fakeProvider.sendPayout({
+        provider_account_id: account.provider_account_id,
+        amount: new Prisma.Decimal("50.0000"),
+        currency: "USD",
+        idempotency_key: "period-2026-08:store-1",
+      });
+
+      expect(second.provider_payout_id).toBe(first.provider_payout_id);
+    });
+  });
+
+  describe(".getPayoutStatus()", () => {
+    test("reads back a payout it sent", async () => {
+      const account = await createVerifiedAccount();
+
+      const sent = await fakeProvider.sendPayout({
+        provider_account_id: account.provider_account_id,
+        amount: new Prisma.Decimal("25.5000"),
+        currency: "USD",
+        idempotency_key: "period-2026-08:store-1",
+      });
+
+      const status = await fakeProvider.getPayoutStatus(
+        sent.provider_payout_id,
+      );
+
+      expect(status).toEqual({
+        provider_payout_id: sent.provider_payout_id,
+        status: "PAID",
+      });
+    });
+
+    test("refuses a payout it never sent", async () => {
+      await expect(
+        fakeProvider.getPayoutStatus("fake_po_nope"),
+      ).rejects.toThrow(
+        'The fake payout provider has no payout "fake_po_nope".',
+      );
+    });
+  });
+
+  describe(".reset()", () => {
+    test("forgets accounts, so one test cannot see another's", async () => {
+      const account = await createVerifiedAccount();
+
+      fakeProvider.reset();
+
+      await expect(
+        fakeProvider.getAccountStatus(account.provider_account_id),
+      ).rejects.toThrow("has no account");
+    });
+  });
+});

--- a/tests/unit/infra/payout_providers/index.test.ts
+++ b/tests/unit/infra/payout_providers/index.test.ts
@@ -1,0 +1,74 @@
+import payoutProviders from "infra/payout_providers";
+
+describe("infra/payout_providers/index.ts", () => {
+  describe(".providerKeys()", () => {
+    test("registers stripe and, outside production, the fake", () => {
+      const keys = payoutProviders.providerKeys();
+
+      expect(keys).toContain("STRIPE");
+      expect(keys).toContain("FAKE");
+    });
+  });
+
+  describe(".getProvider()", () => {
+    test("resolves a registered rail to an adapter that agrees with its key", () => {
+      const provider = payoutProviders.getProvider("STRIPE");
+
+      expect(provider.key).toBe("STRIPE");
+    });
+
+    test("resolves regardless of casing or surrounding space", () => {
+      expect(payoutProviders.getProvider(" stripe ").key).toBe("STRIPE");
+    });
+
+    test("refuses an unknown rail with a ValidationError", () => {
+      expect(() => payoutProviders.getProvider("PAYPAL")).toThrow(
+        '"PAYPAL" is not a supported payout provider.',
+      );
+    });
+
+    test("every registered adapter implements the whole interface", () => {
+      for (const key of payoutProviders.providerKeys()) {
+        const provider = payoutProviders.getProvider(key);
+
+        expect(typeof provider.createAccount).toBe("function");
+        expect(typeof provider.getAccountStatus).toBe("function");
+        expect(typeof provider.sendPayout).toBe("function");
+        expect(typeof provider.getPayoutStatus).toBe("function");
+        expect(provider.supportedCurrencies.length).toBeGreaterThan(0);
+      }
+    });
+
+    test("every adapter declares its currencies normalized", () => {
+      for (const key of payoutProviders.providerKeys()) {
+        const provider = payoutProviders.getProvider(key);
+
+        for (const code of provider.supportedCurrencies) {
+          expect(code).toBe(code.toUpperCase());
+        }
+      }
+    });
+  });
+
+  describe(".supportsCurrency()", () => {
+    test("matches a declared currency whatever the casing of the input", () => {
+      const provider = payoutProviders.getProvider("STRIPE");
+
+      expect(payoutProviders.supportsCurrency(provider, "usd")).toBe(true);
+      expect(payoutProviders.supportsCurrency(provider, " USD ")).toBe(true);
+    });
+
+    test("does not match a currency the rail never declared", () => {
+      const provider = payoutProviders.getProvider("STRIPE");
+
+      expect(payoutProviders.supportsCurrency(provider, "JPY")).toBe(false);
+    });
+  });
+
+  describe(".isRegistered()", () => {
+    test("answers for both a known and an unknown rail", () => {
+      expect(payoutProviders.isRegistered("stripe")).toBe(true);
+      expect(payoutProviders.isRegistered("PAYPAL")).toBe(false);
+    });
+  });
+});

--- a/tests/unit/infra/payout_providers/stripe.test.ts
+++ b/tests/unit/infra/payout_providers/stripe.test.ts
@@ -1,0 +1,38 @@
+import { Prisma } from "generated/prisma/client";
+import stripeProvider from "infra/payout_providers/stripe";
+
+// The Stripe rail is registered but not wired. These tests pin the two things
+// that must stay true while it is not: it is selectable and declares what it
+// would pay in, and it never silently succeeds.
+describe("infra/payout_providers/stripe.ts", () => {
+  test("is a selectable rail that declares its currencies", () => {
+    expect(stripeProvider.key).toBe("STRIPE");
+    expect(stripeProvider.supportedCurrencies).toContain("USD");
+  });
+
+  test("every method refuses rather than pretending to move money", async () => {
+    await expect(
+      stripeProvider.createAccount({
+        store_id: "00000000-0000-0000-0000-000000000001",
+        payout_currency: "USD",
+      }),
+    ).rejects.toThrow("Stripe payouts are not configured");
+
+    await expect(stripeProvider.getAccountStatus("acct_1")).rejects.toThrow(
+      "Stripe payouts are not configured",
+    );
+
+    await expect(
+      stripeProvider.sendPayout({
+        provider_account_id: "acct_1",
+        amount: new Prisma.Decimal("10.0000"),
+        currency: "USD",
+        idempotency_key: "period-2026-08:store-1",
+      }),
+    ).rejects.toThrow("Stripe payouts are not configured");
+
+    await expect(stripeProvider.getPayoutStatus("po_1")).rejects.toThrow(
+      "Stripe payouts are not configured",
+    );
+  });
+});


### PR DESCRIPTION
Task 7 of the payments milestone. The payout rail becomes swappable before the first one is written.

**Stacked on #202.** Based on `claude/payout-account-model-endpoints-9d0504` rather than `main`, so the diff here is task 7 alone — the registry keys on a `provider` column that only exists in #202. GitHub will retarget this to `main` when #202 merges. Review #202 first.

## Description

Four methods behind one interface — `createAccount`, `getAccountStatus`, `sendPayout`, `getPayoutStatus` — with a registry keyed on the `provider` column task 8 added. `models/payout_account` no longer keeps its own `PAYOUT_PROVIDERS` list: one place declares a rail, so there is no second list to disagree with the registry — no provider string that validates but resolves to no adapter, and no adapter nothing can select.

Three decisions worth reviewing:

- **Swappability is proven by the fake, not by Stripe.** The Stripe adapter is registered and declares the currencies it would pay in, but its four methods throw `ServiceError` until Connect is configured, and no `stripe` dependency is added. This repo mocks nothing — the suite runs against real postgres, SMTP and S3, and `jest.mock` appears nowhere in `tests/` — so a real Stripe implementation would ship as code no test ever runs, against a Connect configuration that is not settled. The in-memory fake is the adapter that works, and two adapters satisfying one interface is what the task's "done when" asked for. A rail that throws is a smaller lie than a rail that is untested.
- **The rail and the currency are validated as a pair.** Because a provider declares `supportedCurrencies`, a combination that could never be paid is refused at write time instead of failing at the transfer. It is evaluated against the state the row will hold *after* the write — the case a per-field check misses is a provider change that strands the existing currency.
- **The fake is not registered in production.** A test seam that can be selected in production is a way to mark an outlet payable without a provider ever seeing it — the same reasoning that makes `storage.clearAllBuckets()` refuse to run there.

`sendPayout` takes an `idempotency_key` that the fake honours by returning the first payout, so task 10's re-runnability is a property that can fail a test here rather than in production.

Two departures from the task text as written: the Stripe adapter declares `USD, EUR, GBP, BRL` rather than USD alone (an outlet registering a BRL account on Stripe is a case #202 already tests, and understating Stripe's reach to fit a placeholder would have broken it), and the fake's tests are unit tests rather than integration tests, since the fake does no I/O.

## Related issue

N/A — task 7 of `docs/payments-tasks.md`.

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] 📖 Documentation
- [ ] ♻️ Refactor
- [x] 🧪 Tests

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] `npm run lint:eslint:check` passes (one pre-existing unrelated warning in `pages/item/[slug].tsx`)
- [x] `npm run lint:prettier:check` passes
- [ ] `npm run test` passes — **769 passed, 1 failed**, and the failure is environmental rather than a regression: `GET /api/v1/status` asserts the database version is `"16.0"` and got `"16.13 (Ubuntu 16.13-0ubuntu0.24.04.1)"`. `infra/compose.yaml` pins `postgres:16.0-alpine3.18`, but this sandbox could not pull images and fell back to a native postgres. Nothing in this diff touches the status endpoint or the database. Worth confirming against CI.
- [x] Added or updated tests where relevant — 22 unit tests across the registry, the fake and the Stripe skeleton, plus model-level tests for rail/currency compatibility and for casing (an unnormalized `"stripe"` compared against a stored `"STRIPE"` would otherwise read as a rail change and silently reset a verified outlet to unpayable)

---
_Generated by [Claude Code](https://claude.ai/code/session_01APfsPtDDiqVQrbsNPE1pBW)_