### PR TITLE
feat(activation): log the user in automatically on account activation

### DIFF
--- a/pages/api/v1/activations/[activation_id]/index.ts
+++ b/pages/api/v1/activations/[activation_id]/index.ts
@@ -3,6 +3,7 @@ import { createRouter } from "next-connect";
 import controller from "infra/controller";
 import activation from "models/activation";
 import authorization from "models/authorization";
+import session from "models/session";
 
 export default createRouter<NextApiRequest, NextApiResponse>()
   .use(controller.injectAnonymousOrUser)
@@ -21,11 +22,22 @@ async function patchHandler(req: NextApiRequest, res: NextApiResponse) {
 
   const updatedActivation = await activation.markAsUsed(validActivation.id);
 
+  const newSession = await session.create(validatedUser.id);
+  controller.setSessionCookie(res, newSession.token);
+
   const secureOutputValues = authorization.filterOutput(
     validatedUser,
     "read:activation_token",
     updatedActivation,
   );
 
-  return res.status(200).json(secureOutputValues);
+  const secureSessionOutputValues = authorization.filterOutput(
+    validatedUser,
+    "read:session",
+    newSession,
+  );
+
+  return res
+    .status(200)
+    .json({ ...secureOutputValues, session: secureSessionOutputValues });
 }

--- a/pages/signup/activate/[activation_token].tsx
+++ b/pages/signup/activate/[activation_token].tsx
@@ -79,13 +79,13 @@ export default function ActivateSignup() {
           </p>
           <div className="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
             <Link
-              href="/login?callbackUrl=/store"
+              href="/store"
               className="flex-1 inline-flex items-center justify-center rounded-lg border-2 border-[var(--color-purple-dark)] px-6 py-3 font-bold text-[var(--color-purple-dark)] transition-colors hover:bg-[var(--color-purple-dark)] hover:text-[var(--bg-primary)]"
             >
               I want to play
             </Link>
             <Link
-              href="/login?callbackUrl=/onboarding/create"
+              href="/onboarding/create"
               className="flex-1 inline-flex items-center justify-center rounded-lg bg-[var(--color-purple-dark)] px-6 py-3 font-bold text-[var(--bg-primary)] transition-colors hover:bg-black"
             >
               I want to publish games

--- a/tests/integration/_use-cases/registration-flow.test.ts
+++ b/tests/integration/_use-cases/registration-flow.test.ts
@@ -86,8 +86,10 @@ describe("Use case: Registration Flow (all successful)", () => {
       expires_at: activationObj.expires_at,
       created_at: activationObj.created_at,
       updated_at: activationObj.updated_at,
+      session: activationObj.session,
     });
     expect(activationObj.used_at).not.toBeNull();
+    expect(activationObj.session.user_id).toBe(newUser.id);
 
     const activatedUser = await user.findOneById(newUser.id);
     const newUserWithPassword = await orchestrator.getUserById(newUser.id);

--- a/tests/integration/api/v1/activations/[activation_id]/post.test.ts
+++ b/tests/integration/api/v1/activations/[activation_id]/post.test.ts
@@ -1,8 +1,10 @@
 import orchestrator from "tests/orchestrator";
 import activation from "models/activation";
 import user from "models/user";
+import session from "models/session";
 import { version as uuidVersion } from "uuid";
 import webserver from "infra/webserver";
+import setCookieParser from "set-cookie-parser";
 
 beforeAll(async () => {
   await orchestrator.waitForAllServices();
@@ -100,8 +102,37 @@ describe("PATCH /api/v1/activations/[activation_id]", () => {
         expires_at: activationObj.expires_at,
         created_at: activationObj.created_at,
         updated_at: activationObj.updated_at,
+        session: activationObj.session,
       });
       expect(activationObj.used_at).not.toBeNull();
+
+      // Activating should log the user in automatically: a session is created
+      // and set as a cookie, so they don't have to go request an OTP right after.
+      expect(activationObj.session).toEqual({
+        id: activationObj.session.id,
+        token: activationObj.session.token,
+        user_id: createdUser.id,
+        expires_at: activationObj.session.expires_at,
+        created_at: activationObj.session.created_at,
+        updated_at: activationObj.session.updated_at,
+      });
+
+      const parsedSetCookie = setCookieParser(activateAccountResponse, {
+        map: true,
+      });
+      expect(parsedSetCookie.session_id).toEqual({
+        name: "session_id",
+        value: activationObj.session.token,
+        path: "/",
+        maxAge: session.EXPIRATION_IN_MILLISECONDS / 1000,
+        httpOnly: true,
+        sameSite: "Lax",
+      });
+
+      const foundSession = await session.findOneValidByToken(
+        activationObj.session.token,
+      );
+      expect(foundSession.user_id).toBe(createdUser.id);
 
       expect(uuidVersion(activationObj.id)).toBe(4);
       expect(uuidVersion(activationObj.user_id)).toBe(4);


### PR DESCRIPTION
## Description

Activating an account only marked the activation token as used and returned the activation row. The user then had to go to `/login`, request an OTP, wait for a second email, and enter the code just to get a session — despite already proving ownership of that email by clicking the activation link.

`PATCH /api/v1/activations/[activation_id]` now also creates a session for the user and sets the `session_id` cookie (same as `POST /api/v1/otp/sessions` does), returning the session alongside the activation payload. The activation page (`/signup/activate/[activation_token]`) now links straight to `/store` and `/onboarding/create` instead of routing back through `/login`.

## Related issue

<!-- e.g. Closes #123 -->

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📖 Documentation
- [ ] ♻️ Refactor
- [ ] 🧪 Tests

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] `npm run lint:eslint:check` passes
- [x] `npm run lint:prettier:check` passes
- [x] `npm run test` passes (744/745 — the one failure is a pre-existing environment mismatch on the exact Postgres version string in `status/get.test.ts`, unrelated to this change)
- [x] Added or updated tests where relevant


---
_Generated by [Claude Code](https://claude.ai/code/session_01XtHgaLkqQ9MA9tP9EsekVG)_