### PR TITLE
Add Manifold Desktop API v1 contract, OpenAPI spec, docs, and tests

### DIFF
--- a/contracts/desktop/v1.ts
+++ b/contracts/desktop/v1.ts
@@ -1,0 +1,172 @@
+import { z } from "zod";
+
+export const DESKTOP_API_VERSION = "1" as const;
+export const INSTALL_MANIFEST_SCHEMA_VERSION = "1" as const;
+
+export const desktopPlatformSchema = z.enum(["WINDOWS", "MAC", "LINUX"]);
+export const desktopArchitectureSchema = z.enum(["X86_64", "AARCH64"]);
+export const archiveFormatSchema = z.enum(["ZIP", "TAR_GZ"]);
+
+export const identifierSchema = z.uuid();
+export const timestampSchema = z.iso.datetime({ offset: true });
+export const byteSizeSchema = z
+  .string()
+  .regex(/^(0|[1-9]\d*)$/, "Size must be an unsigned decimal string");
+export const sha256Schema = z
+  .string()
+  .regex(/^[a-f0-9]{64}$/, "SHA-256 must be lowercase hexadecimal");
+
+export const desktopApiVersionSchema = z.literal(DESKTOP_API_VERSION);
+export const manifestSchemaVersionSchema = z.literal(
+  INSTALL_MANIFEST_SCHEMA_VERSION,
+);
+
+export const desktopErrorCodeSchema = z.enum([
+  "INVALID_REQUEST",
+  "UNSUPPORTED_API_VERSION",
+  "UNSUPPORTED_MANIFEST_VERSION",
+  "AUTHENTICATION_REQUIRED",
+  "INVALID_CREDENTIALS",
+  "SESSION_EXPIRED",
+  "SESSION_REVOKED",
+  "ACCOUNT_DISABLED",
+  "ENTITLEMENT_REQUIRED",
+  "NO_COMPATIBLE_RELEASE",
+  "RELEASE_RETIRED",
+  "INTEGRITY_FAILURE",
+  "RATE_LIMITED",
+  "SERVICE_UNAVAILABLE",
+]);
+
+export const desktopErrorSchema = z.object({
+  error: z.object({
+    code: desktopErrorCodeSchema,
+    message: z.string().min(1),
+    retryable: z.boolean(),
+    request_id: z.string().min(1).optional(),
+    details: z.record(z.string(), z.unknown()).optional(),
+  }),
+});
+
+export const paginationSchema = z.object({
+  page: z.number().int().positive(),
+  limit: z.number().int().positive(),
+  total: z.number().int().nonnegative(),
+  pages: z.number().int().nonnegative(),
+});
+
+export const targetSchema = z.object({
+  platform: desktopPlatformSchema,
+  architecture: desktopArchitectureSchema,
+});
+
+export const sessionSchema = z.object({
+  token: z.string().min(1),
+  expires_at: timestampSchema,
+  user: z.object({
+    id: identifierSchema,
+    username: z.string().min(1),
+  }),
+});
+
+export const createSessionRequestSchema = z.discriminatedUnion("method", [
+  z.object({
+    method: z.literal("PASSWORD"),
+    email: z.email(),
+    password: z.string().min(1),
+    api_version: desktopApiVersionSchema,
+  }),
+  z.object({
+    method: z.literal("OTP"),
+    email: z.email(),
+    otp: z.string().min(1),
+    api_version: desktopApiVersionSchema,
+  }),
+]);
+
+export const catalogGameSchema = z.object({
+  id: identifierSchema,
+  slug: z.string().min(1),
+  title: z.string().min(1),
+  description: z.string(),
+  cover_url: z.url().nullable(),
+  platforms: z.array(desktopPlatformSchema),
+});
+
+export const releaseSummarySchema = z.object({
+  id: identifierSchema,
+  version: z.string().min(1),
+  release_number: z.number().int().positive(),
+  published_at: timestampSchema,
+  artifact_id: identifierSchema,
+  target: targetSchema,
+  compressed_size_bytes: byteSizeSchema,
+  installed_size_bytes: byteSizeSchema,
+  sha256: sha256Schema,
+  manifest_schema_version: manifestSchemaVersionSchema,
+});
+
+export const libraryItemSchema = z.object({
+  game: catalogGameSchema,
+  acquired_at: timestampSchema,
+  latest_compatible_release: releaseSummarySchema.nullable(),
+});
+
+const relativePathSchema = z
+  .string()
+  .min(1)
+  .refine((path) => !path.startsWith("/") && !path.startsWith("\\"), {
+    message: "Path must be relative",
+  })
+  .refine(
+    (path) =>
+      !path
+        .replaceAll("\\", "/")
+        .split("/")
+        .some((segment) => segment === ".."),
+    { message: "Path must not traverse outside the installation root" },
+  );
+
+export const installManifestSchema = z.object({
+  schema_version: manifestSchemaVersionSchema,
+  release_id: identifierSchema,
+  artifact_id: identifierSchema,
+  entrypoint: relativePathSchema,
+  launch_arguments: z.array(z.string()).default([]),
+  working_directory: relativePathSchema.optional(),
+  executables: z.array(relativePathSchema).default([]),
+  environment: z.record(z.string(), z.string()).default({}),
+});
+
+export const downloadAuthorizationSchema = z.object({
+  artifact_id: identifierSchema,
+  url: z.url(),
+  expires_at: timestampSchema,
+  total_size_bytes: byteSizeSchema,
+  sha256: sha256Schema,
+  etag: z.string().min(1).optional(),
+});
+
+export const releasePatchSchema = z.object({
+  id: identifierSchema,
+  source_release_id: identifierSchema,
+  target_release_id: identifierSchema,
+  target: targetSchema,
+  algorithm: z.string().min(1),
+  format_version: z.string().min(1),
+  size_bytes: byteSizeSchema,
+  sha256: sha256Schema,
+  expected_installation_sha256: sha256Schema,
+  published_at: timestampSchema,
+});
+
+export type DesktopPlatform = z.infer<typeof desktopPlatformSchema>;
+export type DesktopArchitecture = z.infer<typeof desktopArchitectureSchema>;
+export type DesktopError = z.infer<typeof desktopErrorSchema>;
+export type DesktopSession = z.infer<typeof sessionSchema>;
+export type CatalogGame = z.infer<typeof catalogGameSchema>;
+export type LibraryItem = z.infer<typeof libraryItemSchema>;
+export type ReleaseSummary = z.infer<typeof releaseSummarySchema>;
+export type InstallManifest = z.infer<typeof installManifestSchema>;
+export type DownloadAuthorization = z.infer<typeof downloadAuthorizationSchema>;
+export type ReleasePatch = z.infer<typeof releasePatchSchema>;

--- a/docs/manifold-desktop-api-compatibility.md
+++ b/docs/manifold-desktop-api-compatibility.md
@@ -1,0 +1,54 @@
+# Manifold Desktop API compatibility
+
+The desktop distribution API is versioned independently from the website API.
+Its source contract is
+[`docs/openapi/manifold-desktop-v1.yaml`](openapi/manifold-desktop-v1.yaml), and
+its application-independent TypeScript schemas live in
+[`contracts/desktop/v1.ts`](../contracts/desktop/v1.ts).
+
+## Version negotiation
+
+- Every desktop session request declares `api_version`. Version `1` is the only
+  supported value for the v1 endpoint family.
+- The server returns `UNSUPPORTED_API_VERSION` for an unknown API version. It
+  must never choose a different version silently.
+- Every install manifest declares `schema_version`. Schema version `1` is the
+  only version understood by API v1.
+- Unknown manifest versions return `UNSUPPORTED_MANIFEST_VERSION` and are never
+  published or served as if they were version 1.
+- Desktop clients may call an API version only when they implement every
+  required field and error behavior in that version's OpenAPI document.
+
+## Compatibility guarantees
+
+Within API v1, the server may add optional response fields and new retryable
+error codes. It will not remove fields, change their meaning or representation,
+add required request fields, or add platform and architecture enum values
+without publishing a new contract version. Clients must ignore unknown optional
+response fields, but must reject unknown API and manifest versions.
+
+API v1 uses RFC 3339 timestamps. Byte sizes are unsigned base-10 strings rather
+than JSON numbers so 64-bit artifact sizes survive languages whose JSON number
+implementation cannot represent every integer exactly. SHA-256 values use 64
+lowercase hexadecimal characters.
+
+## Supported targets
+
+API v1 supports these target values:
+
+| Dimension    | Values                    |
+| ------------ | ------------------------- |
+| Platform     | `WINDOWS`, `MAC`, `LINUX` |
+| Architecture | `X86_64`, `AARCH64`       |
+| Archive      | `ZIP`, `TAR_GZ`           |
+
+Additional targets require a contract revision. A recognized target for which
+a game has no published artifact returns `NO_COMPATIBLE_RELEASE`.
+
+## Deprecation
+
+A replacement API version must be available before v1 is deprecated. The
+deprecation announcement must identify the last supported desktop client
+version and provide at least 180 days between announcement and shutdown. A
+client using a retired API version receives `UNSUPPORTED_API_VERSION` rather
+than a response shaped like another version.

--- a/docs/manifold-desktop-backend-plan.md
+++ b/docs/manifold-desktop-backend-plan.md
@@ -1,0 +1,347 @@
+# Manifold Desktop — Backend and API Implementation Plan
+
+## Purpose
+
+Prepare the existing Manifold platform to support a secure, resilient desktop
+client. This plan belongs to the `manifoldpowered.com` repository and covers
+only backend, API, storage, publication, and operational work.
+
+The desktop client itself is intentionally out of scope. Its implementation is
+defined in `docs/manifold-desktop-app-plan.md`.
+
+## Current baseline
+
+The repository already provides several primitives needed by the desktop app:
+
+- A public, paginated game catalog at `GET /api/v1/games`.
+- Cookie-based password and OTP sessions.
+- A centralized, authenticated library at `GET /api/v1/library`.
+- Per-platform game-file records containing a version and size.
+- Entitlement checks and short-lived signed download URLs.
+- Object storage backed by S3-compatible infrastructure.
+- Stores, studios, curation, sales, ledger entries, statements, and payout
+  account records.
+
+These are web-oriented primitives rather than a desktop distribution contract.
+In particular, the current model does not identify an immutable release, CPU
+architecture, archive format, entrypoint, or content hash. Downloads are not
+yet designed for URL refresh and resume, and authentication depends on a
+browser cookie.
+
+## Guiding decisions
+
+1. The website and desktop application share the backend, entitlements, and
+   catalog but remain separate client projects.
+2. Existing web endpoints should be reused where their contracts are suitable.
+   Desktop-specific orchestration endpoints should live under
+   `/api/v1/desktop`.
+3. Published releases and artifacts are immutable. A correction creates a new
+   release.
+4. Full artifact downloads are the required fallback for every update path.
+5. Delta patching is an optimization and must not precede a reliable full
+   download and update flow.
+6. Payment-provider and payout completion remains a parallel project. It does
+   not block downloading games already present in a user's library.
+7. The repository's existing security, authorization, output-filtering, money,
+   migration, and test conventions continue to apply.
+
+## Phase 1 — Specify the desktop API contract
+
+### Work
+
+- Define versioned schemas for authentication, catalog, library, compatible
+  releases, manifests, download authorization, and patches.
+- Standardize platform values (`WINDOWS`, `MAC`, `LINUX`) and introduce CPU
+  architecture values such as `X86_64`, `AARCH64`, and any explicitly supported
+  32-bit targets.
+- Define the API error envelope, retryable error codes, pagination, timestamps,
+  and size representations.
+- Establish a compatibility policy between desktop app versions, API versions,
+  and manifest schema versions.
+- Publish an OpenAPI document or equivalent machine-readable schema from which
+  the desktop repository can generate or validate types.
+- Create stable staging fixtures, including one test game for every supported
+  platform and architecture.
+
+### Acceptance criteria
+
+- The complete login-to-download sequence is expressible using documented
+  request and response schemas.
+- Desktop types can be produced without importing application-internal model
+  types.
+- Unknown manifest and API versions fail explicitly rather than being silently
+  accepted.
+
+## Phase 2 — Add desktop-compatible authentication
+
+### Work
+
+- Extend authentication middleware to accept
+  `Authorization: Bearer <session-token>` while preserving cookie sessions for
+  the website.
+- Reuse the existing password and OTP authentication flows.
+- Define logout, token expiration, revocation, and disabled-user behavior.
+- Add rate limiting and abuse controls to password and OTP endpoints.
+- Prevent session tokens, OTPs, signed URLs, and authorization headers from
+  appearing in logs.
+- Decide whether desktop network calls use native HTTP exclusively. If WebView
+  requests remain possible, define a narrow origin/CORS policy rather than a
+  wildcard policy.
+- Add integration tests for valid, missing, expired, revoked, and malformed
+  bearer tokens.
+
+### Acceptance criteria
+
+- A command-line client can authenticate, call `GET /api/v1/library`, and obtain
+  download authorization without browser cookie handling.
+- Existing website login and session tests continue to pass unchanged.
+- Logging out invalidates the token server-side.
+
+## Phase 3 — Model immutable releases, artifacts, and manifests
+
+### Proposed concepts
+
+`GameRelease`:
+
+- `id`
+- `game_id`
+- Human-readable `version`
+- Monotonic `release_number`
+- `status` (`DRAFT`, `PROCESSING`, `PUBLISHED`, `FAILED`, `RETIRED`)
+- Release notes
+- Published and created timestamps
+
+`GameArtifact`:
+
+- `id`
+- `release_id`
+- Platform and architecture
+- Archive format
+- Storage object key
+- Compressed and installed sizes
+- SHA-256
+- Upload/verification status
+- Created timestamp
+
+`InstallManifest`:
+
+- Manifest schema version
+- Artifact or release ID
+- Relative entrypoint
+- Optional launch arguments
+- Optional working directory
+- Executable file declarations or permissions
+- Optional environment configuration restricted by an allowlist
+
+### Work
+
+- Add the new schema through migrations without foreign keys, following the
+  repository's existing referential-integrity policy.
+- Define model-layer validation for all logical references.
+- Use an immutable release ID and monotonic release number for ordering; do not
+  infer ordering from arbitrary version strings.
+- Define uniqueness so that a published release has at most one active artifact
+  for each supported platform/architecture combination.
+- Preserve current `GameFile` behavior during migration, then migrate or retire
+  it only after the new read path is live.
+- Add authorization features and `filterOutput` branches in the same changes
+  that expose each endpoint.
+
+### Acceptance criteria
+
+- The backend can answer which exact artifact is compatible with a specified
+  platform and architecture.
+- Published release metadata cannot be edited in place.
+- All new API outputs are explicitly filtered.
+
+## Phase 4 — Implement a transactional publication workflow
+
+### Workflow
+
+1. Create a draft release.
+2. Create a pending artifact.
+3. Issue a signed upload URL.
+4. Confirm that the upload completed.
+5. Validate object existence and size.
+6. Calculate or validate SHA-256.
+7. Validate the install manifest and entrypoint.
+8. Mark the artifact ready.
+9. Publish the release only when all required artifacts are ready.
+
+### Work
+
+- Make publication idempotent and safe to retry.
+- Prevent pending, failed, or incomplete artifacts from appearing in player
+  endpoints.
+- Add cleanup for abandoned uploads and unreferenced objects.
+- Prevent deletion of artifacts required by a published release or patch.
+- Audit release creation, publication, retirement, and destructive
+  administrative actions.
+- Add model and endpoint integration tests for every publication transition.
+
+### Acceptance criteria
+
+- An incomplete or corrupted upload cannot be published.
+- Repeating a confirmation or publication request does not create duplicates.
+- A published artifact's storage object and hash remain stable.
+
+## Phase 5 — Expose desktop orchestration endpoints
+
+### Recommended surface
+
+- `GET /api/v1/desktop/config`
+- `POST /api/v1/desktop/sessions`
+- `DELETE /api/v1/desktop/sessions/current`
+- `GET /api/v1/desktop/catalog`
+- `GET /api/v1/desktop/library`
+- `GET /api/v1/desktop/games/:slug/releases/latest?platform=&arch=`
+- `GET /api/v1/desktop/releases/:release_id/manifest`
+- `POST /api/v1/desktop/artifacts/:artifact_id/download`
+
+The desktop library response should include a latest-compatible-release
+summary so the client does not make one release request for every library item.
+
+### Work
+
+- Reuse catalog, pricing, entitlement, and authorization models rather than
+  duplicating their rules in desktop controllers.
+- Return only published artifacts compatible with the requested target.
+- Ensure download authorization checks entitlement immediately before signing.
+- Include stable IDs, hashes, sizes, and manifest versions in responses.
+- Add end-to-end API tests for login → library → release → manifest → signed
+  artifact URL.
+
+### Acceptance criteria
+
+- The entire first-run desktop flow can be completed using the desktop API.
+- An unentitled user cannot list private artifact data or obtain a signed URL.
+- A client receives a clear `NO_COMPATIBLE_RELEASE` result when appropriate.
+
+## Phase 6 — Support resilient and resumable downloads
+
+### Work
+
+- Verify HTTP Range and stable ETag behavior in development and production
+  object storage.
+- Return artifact metadata with each signed URL: artifact ID, total size,
+  SHA-256, ETag where reliable, and URL expiry.
+- Allow an entitled client to refresh an expired signed URL for the same
+  immutable artifact.
+- Define behavior when an artifact is retired while a download is in progress.
+- Distinguish retryable failures from terminal authorization, compatibility, and
+  integrity failures.
+- Record download authorization and completion metrics without persisting
+  signed URLs.
+
+### Acceptance criteria
+
+- A large download can continue after its first signed URL expires.
+- A resumed Range request returns bytes from the same immutable artifact.
+- Metrics expose authorization failures and transferred bytes without leaking
+  secrets.
+
+## Phase 7 — Complete integrity and security hardening
+
+### Work
+
+- Require SHA-256 for every published full artifact.
+- Version manifests and reject unknown versions.
+- Restrict supported archive formats.
+- Validate that manifest paths are relative, normalized, and confined to the
+  installation root.
+- Restrict launch arguments and environment configuration to documented safe
+  representations.
+- Optionally sign manifests independently so the client can verify provenance
+  after download.
+- Create fixtures for path traversal, absolute paths, malicious symlinks,
+  missing entrypoints, duplicate files, oversized expansions, and hash
+  mismatches.
+
+### Acceptance criteria
+
+- Malicious manifests and archives are rejected before publication.
+- The client has authoritative hashes and metadata for complete verification.
+- The backend test suite covers both valid and hostile distribution fixtures.
+
+## Backend MVP checkpoint
+
+Phases 1–7 form the backend MVP. At this checkpoint, the supported flow is:
+
+```text
+Authenticate → list library → resolve compatible release → obtain manifest
+→ authorize resumable full download → verify artifact
+```
+
+The first desktop MVP should be validated against this checkpoint before delta
+patching begins.
+
+## Phase 8 — Generate and serve delta patches
+
+### Proposed `ReleasePatch`
+
+- Source and target release IDs
+- Platform and architecture
+- Patch algorithm and format version
+- Storage object key
+- Patch size and SHA-256
+- Expected final installation hash
+- Generation/verification status
+- Created and published timestamps
+
+### Work
+
+- Generate patches asynchronously after the target full artifact is published.
+- Initially support only the immediately previous compatible release to the
+  latest release.
+- Make patch generation idempotent.
+- Apply every generated patch in an isolated verification job and publish it
+  only when it reproduces the target installation hash.
+- Offer a patch only when it is materially smaller than the full artifact.
+- Add an update-resolution endpoint or extend the release endpoint to return
+  either the best patch or the full artifact fallback.
+- Preserve source artifacts for as long as published patches depend on them.
+
+### Acceptance criteria
+
+- A verified patch reproduces exactly the published target installation.
+- Missing, failed, inefficient, or incompatible patches resolve to a full
+  artifact without blocking the update.
+- Metrics report full size, patch size, and bytes saved.
+
+## Phase 9 — Production operations
+
+### Work
+
+- Track publication failures, download authorization failures, integrity
+  failures, patch success rates, and byte savings.
+- Establish artifact and patch retention rules.
+- Provide administrative release retirement and rollback procedures.
+- Add staging smoke tests for every supported platform/architecture target.
+- Add compatibility tests against the machine-readable desktop contract.
+- Define incident procedures for a compromised signing key, corrupted artifact,
+  broken release, or leaked session token.
+
+### Acceptance criteria
+
+- Operators can identify and retire a bad release without deleting historical
+  records.
+- A known-good full artifact remains available when patch delivery is disabled.
+- API compatibility failures are detected before production deployment.
+
+## Recommended delivery sequence
+
+Each numbered item should be a small, independently testable delivery slice:
+
+1. Contract and target vocabulary.
+2. Bearer-token authentication.
+3. Release/artifact schema and models.
+4. Publication state machine.
+5. Compatible-release and manifest reads.
+6. Refreshable download authorization.
+7. End-to-end full-download API test.
+8. Integrity and hostile-fixture hardening.
+9. Patch schema and asynchronous generation.
+10. Patch resolution and metrics.
+
+Every backend slice must pass the full repository test and lint suite before it
+is considered complete.

--- a/docs/openapi/manifold-desktop-v1.yaml
+++ b/docs/openapi/manifold-desktop-v1.yaml
@@ -1,0 +1,534 @@
+openapi: 3.1.0
+info:
+  title: Manifold Desktop API
+  version: 1.0.0
+  description: Contract for the Manifold Desktop login-to-download workflow.
+  license:
+    name: MIT
+    identifier: MIT
+servers:
+  - url: /api/v1/desktop
+security: []
+paths:
+  /sessions:
+    post:
+      summary: Create a desktop session
+      operationId: createDesktopSession
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateSessionRequest"
+      responses:
+        "201":
+          description: Authenticated desktop session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Session"
+        "400":
+          $ref: "#/components/responses/Error"
+        default:
+          $ref: "#/components/responses/Error"
+  /sessions/current:
+    delete:
+      summary: Revoke the current desktop session
+      operationId: revokeDesktopSession
+      security:
+        - bearerAuth: []
+      responses:
+        "204":
+          description: Session revoked.
+        "400":
+          $ref: "#/components/responses/Error"
+        default:
+          $ref: "#/components/responses/Error"
+  /catalog:
+    get:
+      summary: List the desktop catalog
+      operationId: listDesktopCatalog
+      parameters:
+        - $ref: "#/components/parameters/Page"
+        - $ref: "#/components/parameters/Limit"
+      responses:
+        "200":
+          description: Paginated public catalog.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [games, pagination]
+                properties:
+                  games:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/CatalogGame"
+                  pagination:
+                    $ref: "#/components/schemas/Pagination"
+        "400":
+          $ref: "#/components/responses/Error"
+        default:
+          $ref: "#/components/responses/Error"
+  /library:
+    get:
+      summary: List the current user's desktop library
+      operationId: listDesktopLibrary
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/Platform"
+        - $ref: "#/components/parameters/Architecture"
+        - $ref: "#/components/parameters/Page"
+        - $ref: "#/components/parameters/Limit"
+      responses:
+        "200":
+          description: Entitled games and their latest compatible releases.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items, pagination]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/LibraryItem"
+                  pagination:
+                    $ref: "#/components/schemas/Pagination"
+        "400":
+          $ref: "#/components/responses/Error"
+        default:
+          $ref: "#/components/responses/Error"
+  /games/{slug}/releases/latest:
+    get:
+      summary: Resolve the latest compatible game release
+      operationId: getLatestCompatibleRelease
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/Platform"
+        - $ref: "#/components/parameters/Architecture"
+      responses:
+        "200":
+          description: Latest published release compatible with the target.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReleaseSummary"
+        "400":
+          $ref: "#/components/responses/Error"
+        default:
+          $ref: "#/components/responses/Error"
+  /releases/{release_id}/manifest:
+    get:
+      summary: Get a release install manifest
+      operationId: getInstallManifest
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/ReleaseId"
+        - name: schema_version
+          in: query
+          required: true
+          schema:
+            const: "1"
+      responses:
+        "200":
+          description: Versioned install manifest.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InstallManifest"
+        "400":
+          $ref: "#/components/responses/Error"
+        default:
+          $ref: "#/components/responses/Error"
+  /artifacts/{artifact_id}/download:
+    post:
+      summary: Authorize an artifact download
+      operationId: authorizeArtifactDownload
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: artifact_id
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Identifier"
+      responses:
+        "200":
+          description: Refreshable authorization for an immutable artifact.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DownloadAuthorization"
+        "400":
+          $ref: "#/components/responses/Error"
+        default:
+          $ref: "#/components/responses/Error"
+  /releases/{release_id}/patches:
+    get:
+      summary: List compatible patches for a release
+      operationId: listReleasePatches
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/ReleaseId"
+        - $ref: "#/components/parameters/Platform"
+        - $ref: "#/components/parameters/Architecture"
+      responses:
+        "200":
+          description: Published patches targeting the release.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [patches]
+                properties:
+                  patches:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ReleasePatch"
+        "400":
+          $ref: "#/components/responses/Error"
+        default:
+          $ref: "#/components/responses/Error"
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: opaque-session-token
+  parameters:
+    Page:
+      name: page
+      in: query
+      schema:
+        type: integer
+        minimum: 1
+        default: 1
+    Limit:
+      name: limit
+      in: query
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 20
+    Platform:
+      name: platform
+      in: query
+      required: true
+      schema:
+        $ref: "#/components/schemas/Platform"
+    Architecture:
+      name: arch
+      in: query
+      required: true
+      schema:
+        $ref: "#/components/schemas/Architecture"
+    ReleaseId:
+      name: release_id
+      in: path
+      required: true
+      schema:
+        $ref: "#/components/schemas/Identifier"
+  responses:
+    Error:
+      description: Desktop API error.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorEnvelope"
+  schemas:
+    Identifier:
+      type: string
+      format: uuid
+    Timestamp:
+      type: string
+      format: date-time
+    ByteSize:
+      type: string
+      pattern: "^(0|[1-9][0-9]*)$"
+      description: Unsigned byte count encoded as a base-10 string.
+    Sha256:
+      type: string
+      pattern: "^[a-f0-9]{64}$"
+    Platform:
+      type: string
+      enum: [WINDOWS, MAC, LINUX]
+    Architecture:
+      type: string
+      enum: [X86_64, AARCH64]
+    Target:
+      type: object
+      additionalProperties: false
+      required: [platform, architecture]
+      properties:
+        platform:
+          $ref: "#/components/schemas/Platform"
+        architecture:
+          $ref: "#/components/schemas/Architecture"
+    CreateSessionRequest:
+      oneOf:
+        - type: object
+          additionalProperties: false
+          required: [method, email, password, api_version]
+          properties:
+            method:
+              const: PASSWORD
+            email:
+              type: string
+              format: email
+            password:
+              type: string
+              minLength: 1
+            api_version:
+              const: "1"
+        - type: object
+          additionalProperties: false
+          required: [method, email, otp, api_version]
+          properties:
+            method:
+              const: OTP
+            email:
+              type: string
+              format: email
+            otp:
+              type: string
+              minLength: 1
+            api_version:
+              const: "1"
+    Session:
+      type: object
+      required: [token, expires_at, user]
+      properties:
+        token:
+          type: string
+        expires_at:
+          $ref: "#/components/schemas/Timestamp"
+        user:
+          type: object
+          required: [id, username]
+          properties:
+            id:
+              $ref: "#/components/schemas/Identifier"
+            username:
+              type: string
+    CatalogGame:
+      type: object
+      required: [id, slug, title, description, cover_url, platforms]
+      properties:
+        id:
+          $ref: "#/components/schemas/Identifier"
+        slug:
+          type: string
+        title:
+          type: string
+        description:
+          type: string
+        cover_url:
+          type: [string, "null"]
+          format: uri
+        platforms:
+          type: array
+          items:
+            $ref: "#/components/schemas/Platform"
+    ReleaseSummary:
+      type: object
+      required:
+        [
+          id,
+          version,
+          release_number,
+          published_at,
+          artifact_id,
+          target,
+          compressed_size_bytes,
+          installed_size_bytes,
+          sha256,
+          manifest_schema_version,
+        ]
+      properties:
+        id:
+          $ref: "#/components/schemas/Identifier"
+        version:
+          type: string
+        release_number:
+          type: integer
+          minimum: 1
+        published_at:
+          $ref: "#/components/schemas/Timestamp"
+        artifact_id:
+          $ref: "#/components/schemas/Identifier"
+        target:
+          $ref: "#/components/schemas/Target"
+        compressed_size_bytes:
+          $ref: "#/components/schemas/ByteSize"
+        installed_size_bytes:
+          $ref: "#/components/schemas/ByteSize"
+        sha256:
+          $ref: "#/components/schemas/Sha256"
+        manifest_schema_version:
+          const: "1"
+    LibraryItem:
+      type: object
+      required: [game, acquired_at, latest_compatible_release]
+      properties:
+        game:
+          $ref: "#/components/schemas/CatalogGame"
+        acquired_at:
+          $ref: "#/components/schemas/Timestamp"
+        latest_compatible_release:
+          oneOf:
+            - $ref: "#/components/schemas/ReleaseSummary"
+            - type: "null"
+    InstallManifest:
+      type: object
+      additionalProperties: false
+      required:
+        [
+          schema_version,
+          release_id,
+          artifact_id,
+          entrypoint,
+          launch_arguments,
+          executables,
+          environment,
+        ]
+      properties:
+        schema_version:
+          const: "1"
+        release_id:
+          $ref: "#/components/schemas/Identifier"
+        artifact_id:
+          $ref: "#/components/schemas/Identifier"
+        entrypoint:
+          type: string
+        launch_arguments:
+          type: array
+          items:
+            type: string
+        working_directory:
+          type: string
+        executables:
+          type: array
+          items:
+            type: string
+        environment:
+          type: object
+          additionalProperties:
+            type: string
+    DownloadAuthorization:
+      type: object
+      required: [artifact_id, url, expires_at, total_size_bytes, sha256]
+      properties:
+        artifact_id:
+          $ref: "#/components/schemas/Identifier"
+        url:
+          type: string
+          format: uri
+        expires_at:
+          $ref: "#/components/schemas/Timestamp"
+        total_size_bytes:
+          $ref: "#/components/schemas/ByteSize"
+        sha256:
+          $ref: "#/components/schemas/Sha256"
+        etag:
+          type: string
+    ReleasePatch:
+      type: object
+      required:
+        [
+          id,
+          source_release_id,
+          target_release_id,
+          target,
+          algorithm,
+          format_version,
+          size_bytes,
+          sha256,
+          expected_installation_sha256,
+          published_at,
+        ]
+      properties:
+        id:
+          $ref: "#/components/schemas/Identifier"
+        source_release_id:
+          $ref: "#/components/schemas/Identifier"
+        target_release_id:
+          $ref: "#/components/schemas/Identifier"
+        target:
+          $ref: "#/components/schemas/Target"
+        algorithm:
+          type: string
+        format_version:
+          type: string
+        size_bytes:
+          $ref: "#/components/schemas/ByteSize"
+        sha256:
+          $ref: "#/components/schemas/Sha256"
+        expected_installation_sha256:
+          $ref: "#/components/schemas/Sha256"
+        published_at:
+          $ref: "#/components/schemas/Timestamp"
+    Pagination:
+      type: object
+      required: [page, limit, total, pages]
+      properties:
+        page:
+          type: integer
+          minimum: 1
+        limit:
+          type: integer
+          minimum: 1
+        total:
+          type: integer
+          minimum: 0
+        pages:
+          type: integer
+          minimum: 0
+    ErrorEnvelope:
+      type: object
+      additionalProperties: false
+      required: [error]
+      properties:
+        error:
+          type: object
+          additionalProperties: false
+          required: [code, message, retryable]
+          properties:
+            code:
+              type: string
+              enum:
+                [
+                  INVALID_REQUEST,
+                  UNSUPPORTED_API_VERSION,
+                  UNSUPPORTED_MANIFEST_VERSION,
+                  AUTHENTICATION_REQUIRED,
+                  INVALID_CREDENTIALS,
+                  SESSION_EXPIRED,
+                  SESSION_REVOKED,
+                  ACCOUNT_DISABLED,
+                  ENTITLEMENT_REQUIRED,
+                  NO_COMPATIBLE_RELEASE,
+                  RELEASE_RETIRED,
+                  INTEGRITY_FAILURE,
+                  RATE_LIMITED,
+                  SERVICE_UNAVAILABLE,
+                ]
+            message:
+              type: string
+            retryable:
+              type: boolean
+            request_id:
+              type: string
+            details:
+              type: object
+              additionalProperties: true

--- a/tests/unit/contracts/desktop-v1.test.ts
+++ b/tests/unit/contracts/desktop-v1.test.ts
@@ -1,0 +1,81 @@
+import {
+  byteSizeSchema,
+  createSessionRequestSchema,
+  desktopArchitectureSchema,
+  desktopPlatformSchema,
+  installManifestSchema,
+  manifestSchemaVersionSchema,
+} from "contracts/desktop/v1";
+
+const releaseId = "11111111-1111-4111-8111-111111111111";
+const artifactId = "22222222-2222-4222-8222-222222222222";
+
+describe("desktop API v1 contract", () => {
+  test("defines the supported target vocabulary", () => {
+    expect(desktopPlatformSchema.options).toEqual(["WINDOWS", "MAC", "LINUX"]);
+    expect(desktopArchitectureSchema.options).toEqual(["X86_64", "AARCH64"]);
+  });
+
+  test("rejects an unknown API version", () => {
+    const result = createSessionRequestSchema.safeParse({
+      method: "PASSWORD",
+      email: "player@example.com",
+      password: "secret",
+      api_version: "2",
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects an unknown manifest schema version", () => {
+    expect(manifestSchemaVersionSchema.safeParse("2").success).toBe(false);
+    expect(
+      installManifestSchema.safeParse({
+        schema_version: "2",
+        release_id: releaseId,
+        artifact_id: artifactId,
+        entrypoint: "game/start.exe",
+      }).success,
+    ).toBe(false);
+  });
+
+  test("accepts a complete version 1 manifest", () => {
+    const manifest = installManifestSchema.parse({
+      schema_version: "1",
+      release_id: releaseId,
+      artifact_id: artifactId,
+      entrypoint: "game/start.exe",
+    });
+
+    expect(manifest).toEqual({
+      schema_version: "1",
+      release_id: releaseId,
+      artifact_id: artifactId,
+      entrypoint: "game/start.exe",
+      launch_arguments: [],
+      executables: [],
+      environment: {},
+    });
+  });
+
+  test.each(["/game/start", "../game/start", "game/../../start"])(
+    "rejects unsafe manifest path %s",
+    (entrypoint) => {
+      const result = installManifestSchema.safeParse({
+        schema_version: "1",
+        release_id: releaseId,
+        artifact_id: artifactId,
+        entrypoint,
+      });
+
+      expect(result.success).toBe(false);
+    },
+  );
+
+  test("represents byte sizes as unsigned decimal strings", () => {
+    expect(byteSizeSchema.safeParse("9007199254740993").success).toBe(true);
+    expect(byteSizeSchema.safeParse(9007199254740992).success).toBe(false);
+    expect(byteSizeSchema.safeParse("-1").success).toBe(false);
+    expect(byteSizeSchema.safeParse("01").success).toBe(false);
+  });
+});


### PR DESCRIPTION
### Motivation

- Define a versioned, application-independent contract for a desktop distribution API so clients and server can negotiate releases, manifests, and downloads.
- Document compatibility guarantees and a backend implementation plan to guide phased delivery of authentication, publication, and download flows.
- Capture security and integrity requirements (immutable releases, manifest validation, byte/sha256 representations) to prevent hostile manifests and enable resumable downloads.

### Description

- Add a TypeScript Zod contract in `contracts/desktop/v1.ts` that exports API constants, schemas, and types for sessions, catalog items, targets, release summaries, install manifests, download authorizations, release patches, errors, and pagination.
- Implement strict validation rules including API/manifest version literals, RFC3339 timestamps, byte-size as unsigned decimal strings, lowercase SHA-256 hex, and relative-path manifest validation that prevents path traversal.
- Add an OpenAPI document at `docs/openapi/manifold-desktop-v1.yaml` describing the desktop endpoints and schemas for `POST /sessions`, `GET /catalog`, `GET /library`, `GET /games/{slug}/releases/latest`, `GET /releases/{release_id}/manifest`, `POST /artifacts/{artifact_id}/download`, and patch listing.
- Add planning and compatibility docs at `docs/manifold-desktop-backend-plan.md` and `docs/manifold-desktop-api-compatibility.md` describing the phased backend rollout, compatibility policy, and supported targets.
- Add unit tests in `tests/unit/contracts/desktop-v1.test.ts` that exercise target vocabulary, API/manifest version rejection, manifest defaults and safety checks, and byte-size representation rules.

### Testing

- Ran the new unit test file `tests/unit/contracts/desktop-v1.test.ts`, which verifies platform/architecture enums, API and manifest version validation, manifest defaults and path-safety checks, and `ByteSize` behavior, and the tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a84ddd22db8832787a233910f383fde)