### PR TITLE
feat(desktop): add bearer session authentication

### DIFF
--- a/contracts/desktop/v1.ts
+++ b/contracts/desktop/v1.ts
@@ -1,0 +1,172 @@
+import { z } from "zod";
+
+export const DESKTOP_API_VERSION = "1" as const;
+export const INSTALL_MANIFEST_SCHEMA_VERSION = "1" as const;
+
+export const desktopPlatformSchema = z.enum(["WINDOWS", "MAC", "LINUX"]);
+export const desktopArchitectureSchema = z.enum(["X86_64", "AARCH64"]);
+export const archiveFormatSchema = z.enum(["ZIP", "TAR_GZ"]);
+
+export const identifierSchema = z.uuid();
+export const timestampSchema = z.iso.datetime({ offset: true });
+export const byteSizeSchema = z
+  .string()
+  .regex(/^(0|[1-9]\d*)$/, "Size must be an unsigned decimal string");
+export const sha256Schema = z
+  .string()
+  .regex(/^[a-f0-9]{64}$/, "SHA-256 must be lowercase hexadecimal");
+
+export const desktopApiVersionSchema = z.literal(DESKTOP_API_VERSION);
+export const manifestSchemaVersionSchema = z.literal(
+  INSTALL_MANIFEST_SCHEMA_VERSION,
+);
+
+export const desktopErrorCodeSchema = z.enum([
+  "INVALID_REQUEST",
+  "UNSUPPORTED_API_VERSION",
+  "UNSUPPORTED_MANIFEST_VERSION",
+  "AUTHENTICATION_REQUIRED",
+  "INVALID_CREDENTIALS",
+  "SESSION_EXPIRED",
+  "SESSION_REVOKED",
+  "ACCOUNT_DISABLED",
+  "ENTITLEMENT_REQUIRED",
+  "NO_COMPATIBLE_RELEASE",
+  "RELEASE_RETIRED",
+  "INTEGRITY_FAILURE",
+  "RATE_LIMITED",
+  "SERVICE_UNAVAILABLE",
+]);
+
+export const desktopErrorSchema = z.object({
+  error: z.object({
+    code: desktopErrorCodeSchema,
+    message: z.string().min(1),
+    retryable: z.boolean(),
+    request_id: z.string().min(1).optional(),
+    details: z.record(z.string(), z.unknown()).optional(),
+  }),
+});
+
+export const paginationSchema = z.object({
+  page: z.number().int().positive(),
+  limit: z.number().int().positive(),
+  total: z.number().int().nonnegative(),
+  pages: z.number().int().nonnegative(),
+});
+
+export const targetSchema = z.object({
+  platform: desktopPlatformSchema,
+  architecture: desktopArchitectureSchema,
+});
+
+export const sessionSchema = z.object({
+  token: z.string().min(1),
+  expires_at: timestampSchema,
+  user: z.object({
+    id: identifierSchema,
+    username: z.string().min(1),
+  }),
+});
+
+export const createSessionRequestSchema = z.discriminatedUnion("method", [
+  z.object({
+    method: z.literal("PASSWORD"),
+    email: z.email(),
+    password: z.string().min(1),
+    api_version: desktopApiVersionSchema,
+  }),
+  z.object({
+    method: z.literal("OTP"),
+    email: z.email(),
+    otp: z.string().min(1),
+    api_version: desktopApiVersionSchema,
+  }),
+]);
+
+export const catalogGameSchema = z.object({
+  id: identifierSchema,
+  slug: z.string().min(1),
+  title: z.string().min(1),
+  description: z.string(),
+  cover_url: z.url().nullable(),
+  platforms: z.array(desktopPlatformSchema),
+});
+
+export const releaseSummarySchema = z.object({
+  id: identifierSchema,
+  version: z.string().min(1),
+  release_number: z.number().int().positive(),
+  published_at: timestampSchema,
+  artifact_id: identifierSchema,
+  target: targetSchema,
+  compressed_size_bytes: byteSizeSchema,
+  installed_size_bytes: byteSizeSchema,
+  sha256: sha256Schema,
+  manifest_schema_version: manifestSchemaVersionSchema,
+});
+
+export const libraryItemSchema = z.object({
+  game: catalogGameSchema,
+  acquired_at: timestampSchema,
+  latest_compatible_release: releaseSummarySchema.nullable(),
+});
+
+const relativePathSchema = z
+  .string()
+  .min(1)
+  .refine((path) => !path.startsWith("/") && !path.startsWith("\\"), {
+    message: "Path must be relative",
+  })
+  .refine(
+    (path) =>
+      !path
+        .replaceAll("\\", "/")
+        .split("/")
+        .some((segment) => segment === ".."),
+    { message: "Path must not traverse outside the installation root" },
+  );
+
+export const installManifestSchema = z.object({
+  schema_version: manifestSchemaVersionSchema,
+  release_id: identifierSchema,
+  artifact_id: identifierSchema,
+  entrypoint: relativePathSchema,
+  launch_arguments: z.array(z.string()).default([]),
+  working_directory: relativePathSchema.optional(),
+  executables: z.array(relativePathSchema).default([]),
+  environment: z.record(z.string(), z.string()).default({}),
+});
+
+export const downloadAuthorizationSchema = z.object({
+  artifact_id: identifierSchema,
+  url: z.url(),
+  expires_at: timestampSchema,
+  total_size_bytes: byteSizeSchema,
+  sha256: sha256Schema,
+  etag: z.string().min(1).optional(),
+});
+
+export const releasePatchSchema = z.object({
+  id: identifierSchema,
+  source_release_id: identifierSchema,
+  target_release_id: identifierSchema,
+  target: targetSchema,
+  algorithm: z.string().min(1),
+  format_version: z.string().min(1),
+  size_bytes: byteSizeSchema,
+  sha256: sha256Schema,
+  expected_installation_sha256: sha256Schema,
+  published_at: timestampSchema,
+});
+
+export type DesktopPlatform = z.infer<typeof desktopPlatformSchema>;
+export type DesktopArchitecture = z.infer<typeof desktopArchitectureSchema>;
+export type DesktopError = z.infer<typeof desktopErrorSchema>;
+export type DesktopSession = z.infer<typeof sessionSchema>;
+export type CatalogGame = z.infer<typeof catalogGameSchema>;
+export type LibraryItem = z.infer<typeof libraryItemSchema>;
+export type ReleaseSummary = z.infer<typeof releaseSummarySchema>;
+export type InstallManifest = z.infer<typeof installManifestSchema>;
+export type DownloadAuthorization = z.infer<typeof downloadAuthorizationSchema>;
+export type ReleasePatch = z.infer<typeof releasePatchSchema>;

--- a/contracts/desktop/v1.ts
+++ b/contracts/desktop/v1.ts
@@ -115,9 +115,13 @@ export const libraryItemSchema = z.object({
 const relativePathSchema = z
   .string()
   .min(1)
-  .refine((path) => !path.startsWith("/") && !path.startsWith("\\"), {
-    message: "Path must be relative",
-  })
+  .refine(
+    (path) =>
+      !path.startsWith("/") &&
+      !path.startsWith("\\") &&
+      !/^[A-Za-z]:/.test(path),
+    { message: "Path must be relative" },
+  )
   .refine(
     (path) =>
       !path

--- a/docs/manifold-desktop-api-compatibility.md
+++ b/docs/manifold-desktop-api-compatibility.md
@@ -1,0 +1,54 @@
+# Manifold Desktop API compatibility
+
+The desktop distribution API is versioned independently from the website API.
+Its source contract is
+[`docs/openapi/manifold-desktop-v1.yaml`](openapi/manifold-desktop-v1.yaml), and
+its application-independent TypeScript schemas live in
+[`contracts/desktop/v1.ts`](../contracts/desktop/v1.ts).
+
+## Version negotiation
+
+- Every desktop session request declares `api_version`. Version `1` is the only
+  supported value for the v1 endpoint family.
+- The server returns `UNSUPPORTED_API_VERSION` for an unknown API version. It
+  must never choose a different version silently.
+- Every install manifest declares `schema_version`. Schema version `1` is the
+  only version understood by API v1.
+- Unknown manifest versions return `UNSUPPORTED_MANIFEST_VERSION` and are never
+  published or served as if they were version 1.
+- Desktop clients may call an API version only when they implement every
+  required field and error behavior in that version's OpenAPI document.
+
+## Compatibility guarantees
+
+Within API v1, the server may add optional response fields and new retryable
+error codes. It will not remove fields, change their meaning or representation,
+add required request fields, or add platform and architecture enum values
+without publishing a new contract version. Clients must ignore unknown optional
+response fields, but must reject unknown API and manifest versions.
+
+API v1 uses RFC 3339 timestamps. Byte sizes are unsigned base-10 strings rather
+than JSON numbers so 64-bit artifact sizes survive languages whose JSON number
+implementation cannot represent every integer exactly. SHA-256 values use 64
+lowercase hexadecimal characters.
+
+## Supported targets
+
+API v1 supports these target values:
+
+| Dimension    | Values                    |
+| ------------ | ------------------------- |
+| Platform     | `WINDOWS`, `MAC`, `LINUX` |
+| Architecture | `X86_64`, `AARCH64`       |
+| Archive      | `ZIP`, `TAR_GZ`           |
+
+Additional targets require a contract revision. A recognized target for which
+a game has no published artifact returns `NO_COMPATIBLE_RELEASE`.
+
+## Deprecation
+
+A replacement API version must be available before v1 is deprecated. The
+deprecation announcement must identify the last supported desktop client
+version and provide at least 180 days between announcement and shutdown. A
+client using a retired API version receives `UNSUPPORTED_API_VERSION` rather
+than a response shaped like another version.

--- a/docs/manifold-desktop-backend-plan.md
+++ b/docs/manifold-desktop-backend-plan.md
@@ -1,0 +1,347 @@
+# Manifold Desktop — Backend and API Implementation Plan
+
+## Purpose
+
+Prepare the existing Manifold platform to support a secure, resilient desktop
+client. This plan belongs to the `manifoldpowered.com` repository and covers
+only backend, API, storage, publication, and operational work.
+
+The desktop client itself is intentionally out of scope. Its implementation is
+defined in `docs/manifold-desktop-app-plan.md`.
+
+## Current baseline
+
+The repository already provides several primitives needed by the desktop app:
+
+- A public, paginated game catalog at `GET /api/v1/games`.
+- Cookie-based password and OTP sessions.
+- A centralized, authenticated library at `GET /api/v1/library`.
+- Per-platform game-file records containing a version and size.
+- Entitlement checks and short-lived signed download URLs.
+- Object storage backed by S3-compatible infrastructure.
+- Stores, studios, curation, sales, ledger entries, statements, and payout
+  account records.
+
+These are web-oriented primitives rather than a desktop distribution contract.
+In particular, the current model does not identify an immutable release, CPU
+architecture, archive format, entrypoint, or content hash. Downloads are not
+yet designed for URL refresh and resume, and authentication depends on a
+browser cookie.
+
+## Guiding decisions
+
+1. The website and desktop application share the backend, entitlements, and
+   catalog but remain separate client projects.
+2. Existing web endpoints should be reused where their contracts are suitable.
+   Desktop-specific orchestration endpoints should live under
+   `/api/v1/desktop`.
+3. Published releases and artifacts are immutable. A correction creates a new
+   release.
+4. Full artifact downloads are the required fallback for every update path.
+5. Delta patching is an optimization and must not precede a reliable full
+   download and update flow.
+6. Payment-provider and payout completion remains a parallel project. It does
+   not block downloading games already present in a user's library.
+7. The repository's existing security, authorization, output-filtering, money,
+   migration, and test conventions continue to apply.
+
+## Phase 1 — Specify the desktop API contract
+
+### Work
+
+- Define versioned schemas for authentication, catalog, library, compatible
+  releases, manifests, download authorization, and patches.
+- Standardize platform values (`WINDOWS`, `MAC`, `LINUX`) and introduce CPU
+  architecture values such as `X86_64`, `AARCH64`, and any explicitly supported
+  32-bit targets.
+- Define the API error envelope, retryable error codes, pagination, timestamps,
+  and size representations.
+- Establish a compatibility policy between desktop app versions, API versions,
+  and manifest schema versions.
+- Publish an OpenAPI document or equivalent machine-readable schema from which
+  the desktop repository can generate or validate types.
+- Create stable staging fixtures, including one test game for every supported
+  platform and architecture.
+
+### Acceptance criteria
+
+- The complete login-to-download sequence is expressible using documented
+  request and response schemas.
+- Desktop types can be produced without importing application-internal model
+  types.
+- Unknown manifest and API versions fail explicitly rather than being silently
+  accepted.
+
+## Phase 2 — Add desktop-compatible authentication
+
+### Work
+
+- Extend authentication middleware to accept
+  `Authorization: Bearer <session-token>` while preserving cookie sessions for
+  the website.
+- Reuse the existing password and OTP authentication flows.
+- Define logout, token expiration, revocation, and disabled-user behavior.
+- Add rate limiting and abuse controls to password and OTP endpoints.
+- Prevent session tokens, OTPs, signed URLs, and authorization headers from
+  appearing in logs.
+- Decide whether desktop network calls use native HTTP exclusively. If WebView
+  requests remain possible, define a narrow origin/CORS policy rather than a
+  wildcard policy.
+- Add integration tests for valid, missing, expired, revoked, and malformed
+  bearer tokens.
+
+### Acceptance criteria
+
+- A command-line client can authenticate, call `GET /api/v1/library`, and obtain
+  download authorization without browser cookie handling.
+- Existing website login and session tests continue to pass unchanged.
+- Logging out invalidates the token server-side.
+
+## Phase 3 — Model immutable releases, artifacts, and manifests
+
+### Proposed concepts
+
+`GameRelease`:
+
+- `id`
+- `game_id`
+- Human-readable `version`
+- Monotonic `release_number`
+- `status` (`DRAFT`, `PROCESSING`, `PUBLISHED`, `FAILED`, `RETIRED`)
+- Release notes
+- Published and created timestamps
+
+`GameArtifact`:
+
+- `id`
+- `release_id`
+- Platform and architecture
+- Archive format
+- Storage object key
+- Compressed and installed sizes
+- SHA-256
+- Upload/verification status
+- Created timestamp
+
+`InstallManifest`:
+
+- Manifest schema version
+- Artifact or release ID
+- Relative entrypoint
+- Optional launch arguments
+- Optional working directory
+- Executable file declarations or permissions
+- Optional environment configuration restricted by an allowlist
+
+### Work
+
+- Add the new schema through migrations without foreign keys, following the
+  repository's existing referential-integrity policy.
+- Define model-layer validation for all logical references.
+- Use an immutable release ID and monotonic release number for ordering; do not
+  infer ordering from arbitrary version strings.
+- Define uniqueness so that a published release has at most one active artifact
+  for each supported platform/architecture combination.
+- Preserve current `GameFile` behavior during migration, then migrate or retire
+  it only after the new read path is live.
+- Add authorization features and `filterOutput` branches in the same changes
+  that expose each endpoint.
+
+### Acceptance criteria
+
+- The backend can answer which exact artifact is compatible with a specified
+  platform and architecture.
+- Published release metadata cannot be edited in place.
+- All new API outputs are explicitly filtered.
+
+## Phase 4 — Implement a transactional publication workflow
+
+### Workflow
+
+1. Create a draft release.
+2. Create a pending artifact.
+3. Issue a signed upload URL.
+4. Confirm that the upload completed.
+5. Validate object existence and size.
+6. Calculate or validate SHA-256.
+7. Validate the install manifest and entrypoint.
+8. Mark the artifact ready.
+9. Publish the release only when all required artifacts are ready.
+
+### Work
+
+- Make publication idempotent and safe to retry.
+- Prevent pending, failed, or incomplete artifacts from appearing in player
+  endpoints.
+- Add cleanup for abandoned uploads and unreferenced objects.
+- Prevent deletion of artifacts required by a published release or patch.
+- Audit release creation, publication, retirement, and destructive
+  administrative actions.
+- Add model and endpoint integration tests for every publication transition.
+
+### Acceptance criteria
+
+- An incomplete or corrupted upload cannot be published.
+- Repeating a confirmation or publication request does not create duplicates.
+- A published artifact's storage object and hash remain stable.
+
+## Phase 5 — Expose desktop orchestration endpoints
+
+### Recommended surface
+
+- `GET /api/v1/desktop/config`
+- `POST /api/v1/desktop/sessions`
+- `DELETE /api/v1/desktop/sessions/current`
+- `GET /api/v1/desktop/catalog`
+- `GET /api/v1/desktop/library`
+- `GET /api/v1/desktop/games/:slug/releases/latest?platform=&arch=`
+- `GET /api/v1/desktop/releases/:release_id/manifest`
+- `POST /api/v1/desktop/artifacts/:artifact_id/download`
+
+The desktop library response should include a latest-compatible-release
+summary so the client does not make one release request for every library item.
+
+### Work
+
+- Reuse catalog, pricing, entitlement, and authorization models rather than
+  duplicating their rules in desktop controllers.
+- Return only published artifacts compatible with the requested target.
+- Ensure download authorization checks entitlement immediately before signing.
+- Include stable IDs, hashes, sizes, and manifest versions in responses.
+- Add end-to-end API tests for login → library → release → manifest → signed
+  artifact URL.
+
+### Acceptance criteria
+
+- The entire first-run desktop flow can be completed using the desktop API.
+- An unentitled user cannot list private artifact data or obtain a signed URL.
+- A client receives a clear `NO_COMPATIBLE_RELEASE` result when appropriate.
+
+## Phase 6 — Support resilient and resumable downloads
+
+### Work
+
+- Verify HTTP Range and stable ETag behavior in development and production
+  object storage.
+- Return artifact metadata with each signed URL: artifact ID, total size,
+  SHA-256, ETag where reliable, and URL expiry.
+- Allow an entitled client to refresh an expired signed URL for the same
+  immutable artifact.
+- Define behavior when an artifact is retired while a download is in progress.
+- Distinguish retryable failures from terminal authorization, compatibility, and
+  integrity failures.
+- Record download authorization and completion metrics without persisting
+  signed URLs.
+
+### Acceptance criteria
+
+- A large download can continue after its first signed URL expires.
+- A resumed Range request returns bytes from the same immutable artifact.
+- Metrics expose authorization failures and transferred bytes without leaking
+  secrets.
+
+## Phase 7 — Complete integrity and security hardening
+
+### Work
+
+- Require SHA-256 for every published full artifact.
+- Version manifests and reject unknown versions.
+- Restrict supported archive formats.
+- Validate that manifest paths are relative, normalized, and confined to the
+  installation root.
+- Restrict launch arguments and environment configuration to documented safe
+  representations.
+- Optionally sign manifests independently so the client can verify provenance
+  after download.
+- Create fixtures for path traversal, absolute paths, malicious symlinks,
+  missing entrypoints, duplicate files, oversized expansions, and hash
+  mismatches.
+
+### Acceptance criteria
+
+- Malicious manifests and archives are rejected before publication.
+- The client has authoritative hashes and metadata for complete verification.
+- The backend test suite covers both valid and hostile distribution fixtures.
+
+## Backend MVP checkpoint
+
+Phases 1–7 form the backend MVP. At this checkpoint, the supported flow is:
+
+```text
+Authenticate → list library → resolve compatible release → obtain manifest
+→ authorize resumable full download → verify artifact
+```
+
+The first desktop MVP should be validated against this checkpoint before delta
+patching begins.
+
+## Phase 8 — Generate and serve delta patches
+
+### Proposed `ReleasePatch`
+
+- Source and target release IDs
+- Platform and architecture
+- Patch algorithm and format version
+- Storage object key
+- Patch size and SHA-256
+- Expected final installation hash
+- Generation/verification status
+- Created and published timestamps
+
+### Work
+
+- Generate patches asynchronously after the target full artifact is published.
+- Initially support only the immediately previous compatible release to the
+  latest release.
+- Make patch generation idempotent.
+- Apply every generated patch in an isolated verification job and publish it
+  only when it reproduces the target installation hash.
+- Offer a patch only when it is materially smaller than the full artifact.
+- Add an update-resolution endpoint or extend the release endpoint to return
+  either the best patch or the full artifact fallback.
+- Preserve source artifacts for as long as published patches depend on them.
+
+### Acceptance criteria
+
+- A verified patch reproduces exactly the published target installation.
+- Missing, failed, inefficient, or incompatible patches resolve to a full
+  artifact without blocking the update.
+- Metrics report full size, patch size, and bytes saved.
+
+## Phase 9 — Production operations
+
+### Work
+
+- Track publication failures, download authorization failures, integrity
+  failures, patch success rates, and byte savings.
+- Establish artifact and patch retention rules.
+- Provide administrative release retirement and rollback procedures.
+- Add staging smoke tests for every supported platform/architecture target.
+- Add compatibility tests against the machine-readable desktop contract.
+- Define incident procedures for a compromised signing key, corrupted artifact,
+  broken release, or leaked session token.
+
+### Acceptance criteria
+
+- Operators can identify and retire a bad release without deleting historical
+  records.
+- A known-good full artifact remains available when patch delivery is disabled.
+- API compatibility failures are detected before production deployment.
+
+## Recommended delivery sequence
+
+Each numbered item should be a small, independently testable delivery slice:
+
+1. Contract and target vocabulary.
+2. Bearer-token authentication.
+3. Release/artifact schema and models.
+4. Publication state machine.
+5. Compatible-release and manifest reads.
+6. Refreshable download authorization.
+7. End-to-end full-download API test.
+8. Integrity and hostile-fixture hardening.
+9. Patch schema and asynchronous generation.
+10. Patch resolution and metrics.
+
+Every backend slice must pass the full repository test and lint suite before it
+is considered complete.

--- a/docs/openapi/manifold-desktop-v1.yaml
+++ b/docs/openapi/manifold-desktop-v1.yaml
@@ -410,21 +410,26 @@ components:
         artifact_id:
           $ref: "#/components/schemas/Identifier"
         entrypoint:
-          type: string
+          $ref: "#/components/schemas/RelativePath"
         launch_arguments:
           type: array
           items:
             type: string
         working_directory:
-          type: string
+          $ref: "#/components/schemas/RelativePath"
         executables:
           type: array
           items:
-            type: string
+            $ref: "#/components/schemas/RelativePath"
         environment:
           type: object
           additionalProperties:
             type: string
+    RelativePath:
+      type: string
+      minLength: 1
+      pattern: "^(?![A-Za-z]:)(?![\\\\/])(?!.*(?:^|[\\\\/])\\.\\.(?:[\\\\/]|$)).+$"
+      description: A normalized path relative to the installation root; drive-qualified, rooted, and parent-traversing paths are rejected.
     DownloadAuthorization:
       type: object
       required: [artifact_id, url, expires_at, total_size_bytes, sha256]

--- a/docs/openapi/manifold-desktop-v1.yaml
+++ b/docs/openapi/manifold-desktop-v1.yaml
@@ -1,0 +1,534 @@
+openapi: 3.1.0
+info:
+  title: Manifold Desktop API
+  version: 1.0.0
+  description: Contract for the Manifold Desktop login-to-download workflow.
+  license:
+    name: MIT
+    identifier: MIT
+servers:
+  - url: /api/v1/desktop
+security: []
+paths:
+  /sessions:
+    post:
+      summary: Create a desktop session
+      operationId: createDesktopSession
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateSessionRequest"
+      responses:
+        "201":
+          description: Authenticated desktop session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Session"
+        "400":
+          $ref: "#/components/responses/Error"
+        default:
+          $ref: "#/components/responses/Error"
+  /sessions/current:
+    delete:
+      summary: Revoke the current desktop session
+      operationId: revokeDesktopSession
+      security:
+        - bearerAuth: []
+      responses:
+        "204":
+          description: Session revoked.
+        "400":
+          $ref: "#/components/responses/Error"
+        default:
+          $ref: "#/components/responses/Error"
+  /catalog:
+    get:
+      summary: List the desktop catalog
+      operationId: listDesktopCatalog
+      parameters:
+        - $ref: "#/components/parameters/Page"
+        - $ref: "#/components/parameters/Limit"
+      responses:
+        "200":
+          description: Paginated public catalog.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [games, pagination]
+                properties:
+                  games:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/CatalogGame"
+                  pagination:
+                    $ref: "#/components/schemas/Pagination"
+        "400":
+          $ref: "#/components/responses/Error"
+        default:
+          $ref: "#/components/responses/Error"
+  /library:
+    get:
+      summary: List the current user's desktop library
+      operationId: listDesktopLibrary
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/Platform"
+        - $ref: "#/components/parameters/Architecture"
+        - $ref: "#/components/parameters/Page"
+        - $ref: "#/components/parameters/Limit"
+      responses:
+        "200":
+          description: Entitled games and their latest compatible releases.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items, pagination]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/LibraryItem"
+                  pagination:
+                    $ref: "#/components/schemas/Pagination"
+        "400":
+          $ref: "#/components/responses/Error"
+        default:
+          $ref: "#/components/responses/Error"
+  /games/{slug}/releases/latest:
+    get:
+      summary: Resolve the latest compatible game release
+      operationId: getLatestCompatibleRelease
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/Platform"
+        - $ref: "#/components/parameters/Architecture"
+      responses:
+        "200":
+          description: Latest published release compatible with the target.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReleaseSummary"
+        "400":
+          $ref: "#/components/responses/Error"
+        default:
+          $ref: "#/components/responses/Error"
+  /releases/{release_id}/manifest:
+    get:
+      summary: Get a release install manifest
+      operationId: getInstallManifest
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/ReleaseId"
+        - name: schema_version
+          in: query
+          required: true
+          schema:
+            const: "1"
+      responses:
+        "200":
+          description: Versioned install manifest.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InstallManifest"
+        "400":
+          $ref: "#/components/responses/Error"
+        default:
+          $ref: "#/components/responses/Error"
+  /artifacts/{artifact_id}/download:
+    post:
+      summary: Authorize an artifact download
+      operationId: authorizeArtifactDownload
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: artifact_id
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Identifier"
+      responses:
+        "200":
+          description: Refreshable authorization for an immutable artifact.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DownloadAuthorization"
+        "400":
+          $ref: "#/components/responses/Error"
+        default:
+          $ref: "#/components/responses/Error"
+  /releases/{release_id}/patches:
+    get:
+      summary: List compatible patches for a release
+      operationId: listReleasePatches
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/ReleaseId"
+        - $ref: "#/components/parameters/Platform"
+        - $ref: "#/components/parameters/Architecture"
+      responses:
+        "200":
+          description: Published patches targeting the release.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [patches]
+                properties:
+                  patches:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ReleasePatch"
+        "400":
+          $ref: "#/components/responses/Error"
+        default:
+          $ref: "#/components/responses/Error"
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: opaque-session-token
+  parameters:
+    Page:
+      name: page
+      in: query
+      schema:
+        type: integer
+        minimum: 1
+        default: 1
+    Limit:
+      name: limit
+      in: query
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 20
+    Platform:
+      name: platform
+      in: query
+      required: true
+      schema:
+        $ref: "#/components/schemas/Platform"
+    Architecture:
+      name: arch
+      in: query
+      required: true
+      schema:
+        $ref: "#/components/schemas/Architecture"
+    ReleaseId:
+      name: release_id
+      in: path
+      required: true
+      schema:
+        $ref: "#/components/schemas/Identifier"
+  responses:
+    Error:
+      description: Desktop API error.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorEnvelope"
+  schemas:
+    Identifier:
+      type: string
+      format: uuid
+    Timestamp:
+      type: string
+      format: date-time
+    ByteSize:
+      type: string
+      pattern: "^(0|[1-9][0-9]*)$"
+      description: Unsigned byte count encoded as a base-10 string.
+    Sha256:
+      type: string
+      pattern: "^[a-f0-9]{64}$"
+    Platform:
+      type: string
+      enum: [WINDOWS, MAC, LINUX]
+    Architecture:
+      type: string
+      enum: [X86_64, AARCH64]
+    Target:
+      type: object
+      additionalProperties: false
+      required: [platform, architecture]
+      properties:
+        platform:
+          $ref: "#/components/schemas/Platform"
+        architecture:
+          $ref: "#/components/schemas/Architecture"
+    CreateSessionRequest:
+      oneOf:
+        - type: object
+          additionalProperties: false
+          required: [method, email, password, api_version]
+          properties:
+            method:
+              const: PASSWORD
+            email:
+              type: string
+              format: email
+            password:
+              type: string
+              minLength: 1
+            api_version:
+              const: "1"
+        - type: object
+          additionalProperties: false
+          required: [method, email, otp, api_version]
+          properties:
+            method:
+              const: OTP
+            email:
+              type: string
+              format: email
+            otp:
+              type: string
+              minLength: 1
+            api_version:
+              const: "1"
+    Session:
+      type: object
+      required: [token, expires_at, user]
+      properties:
+        token:
+          type: string
+        expires_at:
+          $ref: "#/components/schemas/Timestamp"
+        user:
+          type: object
+          required: [id, username]
+          properties:
+            id:
+              $ref: "#/components/schemas/Identifier"
+            username:
+              type: string
+    CatalogGame:
+      type: object
+      required: [id, slug, title, description, cover_url, platforms]
+      properties:
+        id:
+          $ref: "#/components/schemas/Identifier"
+        slug:
+          type: string
+        title:
+          type: string
+        description:
+          type: string
+        cover_url:
+          type: [string, "null"]
+          format: uri
+        platforms:
+          type: array
+          items:
+            $ref: "#/components/schemas/Platform"
+    ReleaseSummary:
+      type: object
+      required:
+        [
+          id,
+          version,
+          release_number,
+          published_at,
+          artifact_id,
+          target,
+          compressed_size_bytes,
+          installed_size_bytes,
+          sha256,
+          manifest_schema_version,
+        ]
+      properties:
+        id:
+          $ref: "#/components/schemas/Identifier"
+        version:
+          type: string
+        release_number:
+          type: integer
+          minimum: 1
+        published_at:
+          $ref: "#/components/schemas/Timestamp"
+        artifact_id:
+          $ref: "#/components/schemas/Identifier"
+        target:
+          $ref: "#/components/schemas/Target"
+        compressed_size_bytes:
+          $ref: "#/components/schemas/ByteSize"
+        installed_size_bytes:
+          $ref: "#/components/schemas/ByteSize"
+        sha256:
+          $ref: "#/components/schemas/Sha256"
+        manifest_schema_version:
+          const: "1"
+    LibraryItem:
+      type: object
+      required: [game, acquired_at, latest_compatible_release]
+      properties:
+        game:
+          $ref: "#/components/schemas/CatalogGame"
+        acquired_at:
+          $ref: "#/components/schemas/Timestamp"
+        latest_compatible_release:
+          oneOf:
+            - $ref: "#/components/schemas/ReleaseSummary"
+            - type: "null"
+    InstallManifest:
+      type: object
+      additionalProperties: false
+      required:
+        [
+          schema_version,
+          release_id,
+          artifact_id,
+          entrypoint,
+          launch_arguments,
+          executables,
+          environment,
+        ]
+      properties:
+        schema_version:
+          const: "1"
+        release_id:
+          $ref: "#/components/schemas/Identifier"
+        artifact_id:
+          $ref: "#/components/schemas/Identifier"
+        entrypoint:
+          type: string
+        launch_arguments:
+          type: array
+          items:
+            type: string
+        working_directory:
+          type: string
+        executables:
+          type: array
+          items:
+            type: string
+        environment:
+          type: object
+          additionalProperties:
+            type: string
+    DownloadAuthorization:
+      type: object
+      required: [artifact_id, url, expires_at, total_size_bytes, sha256]
+      properties:
+        artifact_id:
+          $ref: "#/components/schemas/Identifier"
+        url:
+          type: string
+          format: uri
+        expires_at:
+          $ref: "#/components/schemas/Timestamp"
+        total_size_bytes:
+          $ref: "#/components/schemas/ByteSize"
+        sha256:
+          $ref: "#/components/schemas/Sha256"
+        etag:
+          type: string
+    ReleasePatch:
+      type: object
+      required:
+        [
+          id,
+          source_release_id,
+          target_release_id,
+          target,
+          algorithm,
+          format_version,
+          size_bytes,
+          sha256,
+          expected_installation_sha256,
+          published_at,
+        ]
+      properties:
+        id:
+          $ref: "#/components/schemas/Identifier"
+        source_release_id:
+          $ref: "#/components/schemas/Identifier"
+        target_release_id:
+          $ref: "#/components/schemas/Identifier"
+        target:
+          $ref: "#/components/schemas/Target"
+        algorithm:
+          type: string
+        format_version:
+          type: string
+        size_bytes:
+          $ref: "#/components/schemas/ByteSize"
+        sha256:
+          $ref: "#/components/schemas/Sha256"
+        expected_installation_sha256:
+          $ref: "#/components/schemas/Sha256"
+        published_at:
+          $ref: "#/components/schemas/Timestamp"
+    Pagination:
+      type: object
+      required: [page, limit, total, pages]
+      properties:
+        page:
+          type: integer
+          minimum: 1
+        limit:
+          type: integer
+          minimum: 1
+        total:
+          type: integer
+          minimum: 0
+        pages:
+          type: integer
+          minimum: 0
+    ErrorEnvelope:
+      type: object
+      additionalProperties: false
+      required: [error]
+      properties:
+        error:
+          type: object
+          additionalProperties: false
+          required: [code, message, retryable]
+          properties:
+            code:
+              type: string
+              enum:
+                [
+                  INVALID_REQUEST,
+                  UNSUPPORTED_API_VERSION,
+                  UNSUPPORTED_MANIFEST_VERSION,
+                  AUTHENTICATION_REQUIRED,
+                  INVALID_CREDENTIALS,
+                  SESSION_EXPIRED,
+                  SESSION_REVOKED,
+                  ACCOUNT_DISABLED,
+                  ENTITLEMENT_REQUIRED,
+                  NO_COMPATIBLE_RELEASE,
+                  RELEASE_RETIRED,
+                  INTEGRITY_FAILURE,
+                  RATE_LIMITED,
+                  SERVICE_UNAVAILABLE,
+                ]
+            message:
+              type: string
+            retryable:
+              type: boolean
+            request_id:
+              type: string
+            details:
+              type: object
+              additionalProperties: true

--- a/infra/auth_rate_limit.ts
+++ b/infra/auth_rate_limit.ts
@@ -1,0 +1,59 @@
+import { createHash } from "node:crypto";
+import { NextApiRequest } from "next";
+
+const WINDOW_MS = 10 * 60 * 1000;
+const MAX_ATTEMPTS = 10;
+
+type Bucket = { attempts: number; resetsAt: number };
+const buckets = new Map<string, Bucket>();
+
+function clientAddress(req: NextApiRequest) {
+  const forwarded = req.headers["x-forwarded-for"];
+  const value = Array.isArray(forwarded) ? forwarded[0] : forwarded;
+  return (
+    value?.split(",", 1)[0].trim() || req.socket.remoteAddress || "unknown"
+  );
+}
+
+function keysFor(req: NextApiRequest, login: string) {
+  // Hashing avoids retaining email addresses in process memory and diagnostics.
+  const address = clientAddress(req);
+  const normalizedLogin = login.trim().toLowerCase();
+  return [
+    createHash("sha256").update(`address\0${address}`).digest("hex"),
+    createHash("sha256").update(`login\0${normalizedLogin}`).digest("hex"),
+  ];
+}
+
+function consume(req: NextApiRequest, login: string, now = Date.now()) {
+  const updated = keysFor(req, login).map((key) => {
+    const existing = buckets.get(key);
+    const bucket =
+      !existing || existing.resetsAt <= now
+        ? { attempts: 0, resetsAt: now + WINDOW_MS }
+        : existing;
+
+    bucket.attempts += 1;
+    buckets.set(key, bucket);
+    return bucket;
+  });
+
+  const mostRestricted = updated.reduce((left, right) =>
+    left.attempts >= right.attempts ? left : right,
+  );
+
+  return {
+    allowed: updated.every((bucket) => bucket.attempts <= MAX_ATTEMPTS),
+    retryAfterSeconds: Math.max(
+      1,
+      Math.ceil((mostRestricted.resetsAt - now) / 1000),
+    ),
+  };
+}
+
+function reset(req: NextApiRequest, login: string) {
+  for (const key of keysFor(req, login)) buckets.delete(key);
+}
+
+const authRateLimit = { consume, reset, MAX_ATTEMPTS, WINDOW_MS };
+export default authRateLimit;

--- a/infra/auth_rate_limit.ts
+++ b/infra/auth_rate_limit.ts
@@ -25,6 +25,12 @@ function keysFor(req: NextApiRequest, login: string) {
   ];
 }
 
+function loginKeyFor(login: string) {
+  return createHash("sha256")
+    .update(`login\0${login.trim().toLowerCase()}`)
+    .digest("hex");
+}
+
 function consume(req: NextApiRequest, login: string, now = Date.now()) {
   const updated = keysFor(req, login).map((key) => {
     const existing = buckets.get(key);
@@ -51,8 +57,11 @@ function consume(req: NextApiRequest, login: string, now = Date.now()) {
   };
 }
 
-function reset(req: NextApiRequest, login: string) {
-  for (const key of keysFor(req, login)) buckets.delete(key);
+function reset(login: string) {
+  // A successful login proves only that account is legitimate. Retaining the
+  // address bucket prevents an attacker from using their own account to reset
+  // the password-spraying limit for every other login.
+  buckets.delete(loginKeyFor(login));
 }
 
 const authRateLimit = { consume, reset, MAX_ATTEMPTS, WINDOW_MS };

--- a/infra/controller.ts
+++ b/infra/controller.ts
@@ -20,6 +20,12 @@ declare module "next" {
   export interface NextApiRequest {
     context?: {
       user: Partial<User>;
+      session?: {
+        id: string;
+        token: string;
+        expires_at: Date;
+      };
+      authentication?: "bearer" | "cookie";
     };
   }
 }
@@ -70,7 +76,9 @@ function logServerError(
   console.error(
     JSON.stringify({
       method: req.method,
-      path: req.url,
+      // Query strings may contain signed URLs or other credentials. Logging
+      // only the pathname keeps those secrets out of operational logs.
+      path: req.url?.split("?", 1)[0],
       name: error.name,
       status_code: error.statusCode,
       message: error.message,
@@ -112,8 +120,14 @@ async function injectAnonymousOrUser(
   res: NextApiResponse,
   next: NextHandler,
 ) {
+  const bearerToken = readBearerToken(req.headers.authorization);
+  if (bearerToken) {
+    await injectAuthenticatedUser(req, bearerToken, "bearer");
+    return next();
+  }
+
   if (req.cookies?.session_id) {
-    await injectAuthenticatedUser(req);
+    await injectAuthenticatedUser(req, req.cookies.session_id, "cookie");
     return next();
   }
 
@@ -121,11 +135,33 @@ async function injectAnonymousOrUser(
   return next();
 }
 
-async function injectAuthenticatedUser(req: NextApiRequest) {
-  const sessionToken = req.cookies?.session_id;
+function readBearerToken(authorizationHeader: string | undefined) {
+  if (authorizationHeader === undefined) return undefined;
+
+  const match = /^Bearer ([A-Za-z0-9_-]+)$/.exec(authorizationHeader);
+  if (!match) {
+    throw new UnauthorizedError({
+      message: "Malformed bearer authorization header",
+      action: "Use Authorization: Bearer <session-token>",
+    });
+  }
+
+  return match[1];
+}
+
+async function injectAuthenticatedUser(
+  req: NextApiRequest,
+  sessionToken: string,
+  authentication: "bearer" | "cookie",
+) {
   const validSession = await session.findOneValidByToken(sessionToken);
   const authenticatedUser = await user.findOneById(validSession.user_id);
-  req.context = { ...req.context, user: authenticatedUser };
+  req.context = {
+    ...req.context,
+    user: authenticatedUser,
+    session: validSession,
+    authentication,
+  };
 }
 
 function injectAnonymousUser(req: NextApiRequest) {
@@ -157,6 +193,7 @@ const controller = {
   setSessionCookie,
   clearSessionCookie,
   injectAnonymousOrUser,
+  readBearerToken,
   canRequest,
 };
 

--- a/infra/controller.ts
+++ b/infra/controller.ts
@@ -4,6 +4,7 @@ import {
   InternalServerError,
   MethodNotAllowedError,
   NotFoundError,
+  RateLimitError,
   ServiceError,
   UnauthorizedError,
   ValidationError,
@@ -44,6 +45,7 @@ const onErrorHandler = (
     error instanceof ValidationError ||
     error instanceof NotFoundError ||
     error instanceof ForbiddenError ||
+    error instanceof RateLimitError ||
     error instanceof ServiceError
   ) {
     if (error instanceof ServiceError) {
@@ -194,6 +196,7 @@ const controller = {
   clearSessionCookie,
   injectAnonymousOrUser,
   readBearerToken,
+  logServerError,
   canRequest,
 };
 

--- a/infra/desktop_api.ts
+++ b/infra/desktop_api.ts
@@ -1,0 +1,63 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import controller from "infra/controller";
+import { UnauthorizedError } from "infra/errors";
+
+export type DesktopErrorCode =
+  | "INVALID_REQUEST"
+  | "UNSUPPORTED_API_VERSION"
+  | "AUTHENTICATION_REQUIRED"
+  | "INVALID_CREDENTIALS"
+  | "SESSION_EXPIRED"
+  | "SESSION_REVOKED"
+  | "ACCOUNT_DISABLED"
+  | "RATE_LIMITED"
+  | "SERVICE_UNAVAILABLE";
+
+export class DesktopApiError extends Error {
+  constructor(
+    public code: DesktopErrorCode,
+    message: string,
+    public statusCode: number,
+    public retryable = false,
+    public details?: Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = "DesktopApiError";
+  }
+}
+
+export function sendDesktopError(res: NextApiResponse, error: DesktopApiError) {
+  if (error.code === "RATE_LIMITED" && error.details?.retry_after_seconds) {
+    res.setHeader("Retry-After", String(error.details.retry_after_seconds));
+  }
+  return res.status(error.statusCode).json({
+    error: {
+      code: error.code,
+      message: error.message,
+      retryable: error.retryable,
+      ...(error.details ? { details: error.details } : {}),
+    },
+  });
+}
+
+export const desktopErrorHandlers = {
+  onNoMatch: controller.errorHandlers.onNoMatch,
+  onError(error: Error, req: NextApiRequest, res: NextApiResponse) {
+    if (error instanceof DesktopApiError) return sendDesktopError(res, error);
+    if (error instanceof UnauthorizedError) {
+      return sendDesktopError(
+        res,
+        new DesktopApiError(
+          req.headers.authorization
+            ? "SESSION_EXPIRED"
+            : "AUTHENTICATION_REQUIRED",
+          req.headers.authorization
+            ? "The bearer session is invalid or expired"
+            : "Authentication is required",
+          401,
+        ),
+      );
+    }
+    return controller.errorHandlers.onError(error, req, res);
+  },
+};

--- a/infra/desktop_api.ts
+++ b/infra/desktop_api.ts
@@ -41,7 +41,16 @@ export function sendDesktopError(res: NextApiResponse, error: DesktopApiError) {
 }
 
 export const desktopErrorHandlers = {
-  onNoMatch: controller.errorHandlers.onNoMatch,
+  onNoMatch(req: NextApiRequest, res: NextApiResponse) {
+    return sendDesktopError(
+      res,
+      new DesktopApiError(
+        "INVALID_REQUEST",
+        `Method ${req.method ?? "UNKNOWN"} is not allowed for this endpoint`,
+        405,
+      ),
+    );
+  },
   onError(error: Error, req: NextApiRequest, res: NextApiResponse) {
     if (error instanceof DesktopApiError) return sendDesktopError(res, error);
     if (error instanceof UnauthorizedError) {
@@ -58,6 +67,15 @@ export const desktopErrorHandlers = {
         ),
       );
     }
-    return controller.errorHandlers.onError(error, req, res);
+    controller.logServerError(error, req);
+    return sendDesktopError(
+      res,
+      new DesktopApiError(
+        "SERVICE_UNAVAILABLE",
+        "The desktop service is temporarily unavailable",
+        503,
+        true,
+      ),
+    );
   },
 };

--- a/infra/errors.ts
+++ b/infra/errors.ts
@@ -82,6 +82,33 @@ export class ServiceError extends Error {
   }
 }
 
+export class RateLimitError extends Error {
+  public statusCode: number;
+  public action: string;
+
+  constructor({
+    message,
+    action,
+  }: {
+    message?: string;
+    action?: string;
+  } = {}) {
+    super(message || "Too many requests");
+    this.name = "RateLimitError";
+    this.statusCode = 429;
+    this.action = action || "Try again later";
+  }
+
+  toJSON() {
+    return {
+      message: this.message,
+      name: this.name,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
 export class ValidationError extends Error {
   public statusCode: number;
   public action: string;

--- a/pages/api/v1/desktop/sessions/current/index.ts
+++ b/pages/api/v1/desktop/sessions/current/index.ts
@@ -1,0 +1,23 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { createRouter } from "next-connect";
+import controller from "infra/controller";
+import { DesktopApiError, desktopErrorHandlers } from "infra/desktop_api";
+import session from "models/session";
+
+export default createRouter<NextApiRequest, NextApiResponse>()
+  .use(controller.injectAnonymousOrUser)
+  .delete(deleteHandler)
+  .handler(desktopErrorHandlers);
+
+async function deleteHandler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.context?.authentication !== "bearer" || !req.context.session) {
+    throw new DesktopApiError(
+      "AUTHENTICATION_REQUIRED",
+      "A bearer session is required",
+      401,
+    );
+  }
+
+  await session.expireById(req.context.session.id);
+  return res.status(204).end();
+}

--- a/pages/api/v1/desktop/sessions/index.ts
+++ b/pages/api/v1/desktop/sessions/index.ts
@@ -1,0 +1,80 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { createRouter } from "next-connect";
+import { createSessionRequestSchema } from "contracts/desktop/v1";
+import authRateLimit from "infra/auth_rate_limit";
+import controller from "infra/controller";
+import { DesktopApiError, desktopErrorHandlers } from "infra/desktop_api";
+import { UnauthorizedError } from "infra/errors";
+import authentication from "models/authentication";
+import authorization from "models/authorization";
+import otp from "models/otp";
+import session from "models/session";
+
+export default createRouter<NextApiRequest, NextApiResponse>()
+  .use(controller.injectAnonymousOrUser)
+  .post(postHandler)
+  .handler(desktopErrorHandlers);
+
+async function postHandler(req: NextApiRequest, res: NextApiResponse) {
+  const parsed = createSessionRequestSchema.safeParse(req.body);
+  if (!parsed.success) {
+    const unsupportedVersion =
+      typeof req.body === "object" &&
+      req.body !== null &&
+      "api_version" in req.body &&
+      req.body.api_version !== "1";
+    throw new DesktopApiError(
+      unsupportedVersion ? "UNSUPPORTED_API_VERSION" : "INVALID_REQUEST",
+      unsupportedVersion
+        ? "This API version is not supported"
+        : "One or more fields are invalid",
+      400,
+    );
+  }
+
+  const login = parsed.data.email;
+  const limit = authRateLimit.consume(req, login);
+  if (!limit.allowed) {
+    throw new DesktopApiError(
+      "RATE_LIMITED",
+      "Too many authentication attempts",
+      429,
+      true,
+      { retry_after_seconds: limit.retryAfterSeconds },
+    );
+  }
+
+  let authUser;
+  try {
+    authUser =
+      parsed.data.method === "PASSWORD"
+        ? await authentication.getUser(login, parsed.data.password)
+        : await otp.validateAndConsume(login, parsed.data.otp);
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      throw new DesktopApiError(
+        "INVALID_CREDENTIALS",
+        "Invalid credentials",
+        401,
+      );
+    }
+    throw error;
+  }
+
+  if (!authorization.can(authUser, "create:session")) {
+    throw new DesktopApiError(
+      "ACCOUNT_DISABLED",
+      "This account cannot create sessions",
+      403,
+    );
+  }
+
+  const newSession = await session.create(authUser.id);
+  authRateLimit.reset(req, login);
+
+  return res.status(201).json({
+    token: newSession.token,
+    expires_at: newSession.expires_at.toISOString(),
+    user: { id: authUser.id, username: authUser.username },
+  });
+}

--- a/pages/api/v1/desktop/sessions/index.ts
+++ b/pages/api/v1/desktop/sessions/index.ts
@@ -70,7 +70,7 @@ async function postHandler(req: NextApiRequest, res: NextApiResponse) {
   }
 
   const newSession = await session.create(authUser.id);
-  authRateLimit.reset(req, login);
+  authRateLimit.reset(login);
 
   return res.status(201).json({
     token: newSession.token,

--- a/pages/api/v1/otp/sessions/index.ts
+++ b/pages/api/v1/otp/sessions/index.ts
@@ -4,7 +4,7 @@ import controller from "infra/controller";
 import otp from "models/otp";
 import session from "models/session";
 import authorization from "models/authorization";
-import { ForbiddenError, ValidationError } from "infra/errors";
+import { ForbiddenError, RateLimitError, ValidationError } from "infra/errors";
 import { z } from "zod";
 import authRateLimit from "infra/auth_rate_limit";
 
@@ -32,11 +32,8 @@ async function postHandler(req: NextApiRequest, res: NextApiResponse) {
   const limit = authRateLimit.consume(req, result.data.login);
   if (!limit.allowed) {
     res.setHeader("Retry-After", String(limit.retryAfterSeconds));
-    return res.status(429).json({
+    throw new RateLimitError({
       message: "Too many authentication attempts",
-      name: "RateLimitError",
-      action: "Try again later",
-      status_code: 429,
     });
   }
 
@@ -53,7 +50,7 @@ async function postHandler(req: NextApiRequest, res: NextApiResponse) {
   }
 
   const newSession = await session.create(authUser.id);
-  authRateLimit.reset(req, result.data.login);
+  authRateLimit.reset(result.data.login);
 
   controller.setSessionCookie(res, newSession.token);
 

--- a/pages/api/v1/otp/sessions/index.ts
+++ b/pages/api/v1/otp/sessions/index.ts
@@ -6,6 +6,7 @@ import session from "models/session";
 import authorization from "models/authorization";
 import { ForbiddenError, ValidationError } from "infra/errors";
 import { z } from "zod";
+import authRateLimit from "infra/auth_rate_limit";
 
 const verifyOtpSchema = z.object({
   login: z.string().trim().min(1),
@@ -28,6 +29,17 @@ async function postHandler(req: NextApiRequest, res: NextApiResponse) {
     });
   }
 
+  const limit = authRateLimit.consume(req, result.data.login);
+  if (!limit.allowed) {
+    res.setHeader("Retry-After", String(limit.retryAfterSeconds));
+    return res.status(429).json({
+      message: "Too many authentication attempts",
+      name: "RateLimitError",
+      action: "Try again later",
+      status_code: 429,
+    });
+  }
+
   const authUser = await otp.validateAndConsume(
     result.data.login,
     result.data.code,
@@ -41,6 +53,7 @@ async function postHandler(req: NextApiRequest, res: NextApiResponse) {
   }
 
   const newSession = await session.create(authUser.id);
+  authRateLimit.reset(req, result.data.login);
 
   controller.setSessionCookie(res, newSession.token);
 

--- a/pages/api/v1/sessions/index.ts
+++ b/pages/api/v1/sessions/index.ts
@@ -5,6 +5,7 @@ import authentication from "models/authentication";
 import session from "models/session";
 import authorization from "models/authorization";
 import { ForbiddenError } from "infra/errors";
+import authRateLimit from "infra/auth_rate_limit";
 
 export default createRouter<NextApiRequest, NextApiResponse>()
   .use(controller.injectAnonymousOrUser)
@@ -14,6 +15,17 @@ export default createRouter<NextApiRequest, NextApiResponse>()
 
 async function postHandler(req: NextApiRequest, res: NextApiResponse) {
   const userAuthDto = req.body;
+
+  const limit = authRateLimit.consume(req, String(userAuthDto?.email ?? ""));
+  if (!limit.allowed) {
+    res.setHeader("Retry-After", String(limit.retryAfterSeconds));
+    return res.status(429).json({
+      message: "Too many authentication attempts",
+      name: "RateLimitError",
+      action: "Try again later",
+      status_code: 429,
+    });
+  }
 
   const authUser = await authentication.getUser(
     userAuthDto.email,
@@ -28,6 +40,7 @@ async function postHandler(req: NextApiRequest, res: NextApiResponse) {
   }
 
   const newSession = await session.create(authUser.id);
+  authRateLimit.reset(req, userAuthDto.email);
 
   controller.setSessionCookie(res, newSession.token);
 

--- a/pages/api/v1/sessions/index.ts
+++ b/pages/api/v1/sessions/index.ts
@@ -4,7 +4,7 @@ import controller from "infra/controller";
 import authentication from "models/authentication";
 import session from "models/session";
 import authorization from "models/authorization";
-import { ForbiddenError } from "infra/errors";
+import { ForbiddenError, RateLimitError } from "infra/errors";
 import authRateLimit from "infra/auth_rate_limit";
 
 export default createRouter<NextApiRequest, NextApiResponse>()
@@ -19,11 +19,8 @@ async function postHandler(req: NextApiRequest, res: NextApiResponse) {
   const limit = authRateLimit.consume(req, String(userAuthDto?.email ?? ""));
   if (!limit.allowed) {
     res.setHeader("Retry-After", String(limit.retryAfterSeconds));
-    return res.status(429).json({
+    throw new RateLimitError({
       message: "Too many authentication attempts",
-      name: "RateLimitError",
-      action: "Try again later",
-      status_code: 429,
     });
   }
 
@@ -40,7 +37,7 @@ async function postHandler(req: NextApiRequest, res: NextApiResponse) {
   }
 
   const newSession = await session.create(authUser.id);
-  authRateLimit.reset(req, userAuthDto.email);
+  authRateLimit.reset(userAuthDto.email);
 
   controller.setSessionCookie(res, newSession.token);
 

--- a/tests/integration/_use-cases/passwordless-login-flow.test.ts
+++ b/tests/integration/_use-cases/passwordless-login-flow.test.ts
@@ -2,6 +2,10 @@ import { User } from "generated/prisma/client";
 import webserver from "infra/webserver";
 import orchestrator from "tests/orchestrator";
 
+const testClientAddress = orchestrator.createTestClientAddress(
+  "passwordless-login-flow",
+);
+
 beforeAll(async () => {
   await orchestrator.waitForAllServices();
   await orchestrator.clearDatabaseRows();
@@ -44,7 +48,10 @@ describe("Use case: Passwordless login flow via OTP (all successful)", () => {
       `${webserver.getOrigin()}/api/v1/otp/sessions`,
       {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          "X-Forwarded-For": testClientAddress,
+        },
         body: JSON.stringify({ login: newUser.email, code }),
       },
     );
@@ -79,7 +86,10 @@ describe("Use case: Passwordless login flow via OTP (all successful)", () => {
       `${webserver.getOrigin()}/api/v1/otp/sessions`,
       {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          "X-Forwarded-For": testClientAddress,
+        },
         body: JSON.stringify({ login: newUser.email, code }),
       },
     );

--- a/tests/integration/_use-cases/purchase-and-download-flow.test.ts
+++ b/tests/integration/_use-cases/purchase-and-download-flow.test.ts
@@ -3,6 +3,10 @@ import webserver from "infra/webserver";
 import orchestrator from "tests/orchestrator";
 import gameModel from "models/game";
 
+const testClientAddress = orchestrator.createTestClientAddress(
+  "purchase-and-download-flow",
+);
+
 beforeAll(async () => {
   await orchestrator.waitForAllServices();
   await orchestrator.clearDatabaseRows();
@@ -58,7 +62,10 @@ describe("Use case: Purchase and Download Flow", () => {
         `${webserver.getOrigin()}/api/v1/sessions`,
         {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            "X-Forwarded-For": testClientAddress,
+          },
           body: JSON.stringify({
             email: sellerData.email,
             password: sellerData.password,
@@ -195,7 +202,10 @@ describe("Use case: Purchase and Download Flow", () => {
         `${webserver.getOrigin()}/api/v1/sessions`,
         {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            "X-Forwarded-For": testClientAddress,
+          },
           body: JSON.stringify({
             email: buyerData.email,
             password: buyerData.password,

--- a/tests/integration/_use-cases/purchase-and-review-flow.test.ts
+++ b/tests/integration/_use-cases/purchase-and-review-flow.test.ts
@@ -3,6 +3,10 @@ import webserver from "infra/webserver";
 import orchestrator from "tests/orchestrator";
 import gameModel from "models/game";
 
+const testClientAddress = orchestrator.createTestClientAddress(
+  "purchase-and-review-flow",
+);
+
 beforeAll(async () => {
   await orchestrator.waitForAllServices();
   await orchestrator.clearDatabaseRows();
@@ -55,7 +59,10 @@ describe("Use case: Purchase and Review Flow", () => {
         `${webserver.getOrigin()}/api/v1/sessions`,
         {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            "X-Forwarded-For": testClientAddress,
+          },
           body: JSON.stringify({
             email: sellerData.email,
             password: sellerData.password,
@@ -140,7 +147,10 @@ describe("Use case: Purchase and Review Flow", () => {
         `${webserver.getOrigin()}/api/v1/sessions`,
         {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            "X-Forwarded-For": testClientAddress,
+          },
           body: JSON.stringify({
             email: buyerData.email,
             password: buyerData.password,

--- a/tests/integration/_use-cases/registration-flow.test.ts
+++ b/tests/integration/_use-cases/registration-flow.test.ts
@@ -4,6 +4,9 @@ import activation from "models/activation";
 import user from "models/user";
 import orchestrator from "tests/orchestrator";
 
+const testClientAddress =
+  orchestrator.createTestClientAddress("registration-flow");
+
 beforeAll(async () => {
   await orchestrator.waitForAllServices();
   await orchestrator.clearDatabaseRows();
@@ -138,6 +141,7 @@ describe("Use case: Registration Flow (all successful)", () => {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          "X-Forwarded-For": testClientAddress,
         },
         body: JSON.stringify({
           email: "registration-flow@manifoldpowered.com",

--- a/tests/integration/api/v1/otp/sessions/post.test.ts
+++ b/tests/integration/api/v1/otp/sessions/post.test.ts
@@ -4,6 +4,10 @@ import session from "models/session";
 import setCookieParser from "set-cookie-parser";
 import webserver from "infra/webserver";
 
+const testClientAddress = orchestrator.createTestClientAddress(
+  "api-v1-otp-sessions-post",
+);
+
 beforeAll(async () => {
   await orchestrator.waitForAllServices();
   await orchestrator.clearDatabaseRows();
@@ -21,7 +25,10 @@ describe("POST /api/v1/otp/sessions", () => {
         `${webserver.getOrigin()}/api/v1/otp/sessions`,
         {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            "X-Forwarded-For": testClientAddress,
+          },
           body: JSON.stringify({ login: user.email, code }),
         },
       );
@@ -59,7 +66,10 @@ describe("POST /api/v1/otp/sessions", () => {
         `${webserver.getOrigin()}/api/v1/otp/sessions`,
         {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            "X-Forwarded-For": testClientAddress,
+          },
           body: JSON.stringify({ login: user.username, code }),
         },
       );
@@ -79,7 +89,10 @@ describe("POST /api/v1/otp/sessions", () => {
         `${webserver.getOrigin()}/api/v1/otp/sessions`,
         {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            "X-Forwarded-For": testClientAddress,
+          },
           body: JSON.stringify({ login: user.email, code: "000000" }),
         },
       );
@@ -100,7 +113,10 @@ describe("POST /api/v1/otp/sessions", () => {
         `${webserver.getOrigin()}/api/v1/otp/sessions`,
         {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            "X-Forwarded-For": testClientAddress,
+          },
           body: JSON.stringify({
             login: "non-existent@pedro.tec.br",
             code: "123456",
@@ -136,7 +152,10 @@ describe("POST /api/v1/otp/sessions", () => {
         `${webserver.getOrigin()}/api/v1/otp/sessions`,
         {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            "X-Forwarded-For": testClientAddress,
+          },
           body: JSON.stringify({ login: user.email, code }),
         },
       );
@@ -161,7 +180,10 @@ describe("POST /api/v1/otp/sessions", () => {
         `${webserver.getOrigin()}/api/v1/otp/sessions`,
         {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            "X-Forwarded-For": testClientAddress,
+          },
           body: JSON.stringify({ login: user.email, code }),
         },
       );
@@ -171,7 +193,10 @@ describe("POST /api/v1/otp/sessions", () => {
         `${webserver.getOrigin()}/api/v1/otp/sessions`,
         {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            "X-Forwarded-For": testClientAddress,
+          },
           body: JSON.stringify({ login: user.email, code }),
         },
       );
@@ -195,7 +220,10 @@ describe("POST /api/v1/otp/sessions", () => {
         `${webserver.getOrigin()}/api/v1/otp/sessions`,
         {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            "X-Forwarded-For": testClientAddress,
+          },
           body: JSON.stringify({ login: user.email, code }),
         },
       );
@@ -216,7 +244,10 @@ describe("POST /api/v1/otp/sessions", () => {
         `${webserver.getOrigin()}/api/v1/otp/sessions`,
         {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            "X-Forwarded-For": testClientAddress,
+          },
           body: JSON.stringify({ login: "someone", code: "1" }),
         },
       );

--- a/tests/integration/api/v1/sessions/post.test.ts
+++ b/tests/integration/api/v1/sessions/post.test.ts
@@ -4,6 +4,10 @@ import session from "models/session";
 import setCookieParser from "set-cookie-parser";
 import webserver from "infra/webserver";
 
+const testClientAddress = orchestrator.createTestClientAddress(
+  "api-v1-sessions-post",
+);
+
 beforeAll(async () => {
   await orchestrator.waitForAllServices();
   await orchestrator.clearDatabaseRows();
@@ -21,6 +25,7 @@ describe("POST /api/v1/sessions", () => {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          "X-Forwarded-For": testClientAddress,
         },
         body: JSON.stringify({
           email: "wrong@pedro.tec.br",
@@ -48,6 +53,7 @@ describe("POST /api/v1/sessions", () => {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          "X-Forwarded-For": testClientAddress,
         },
         body: JSON.stringify({
           email: "test2@pedro.tec.br",
@@ -72,6 +78,7 @@ describe("POST /api/v1/sessions", () => {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          "X-Forwarded-For": testClientAddress,
         },
         body: JSON.stringify({
           email: "wrong2@pedro.tec.br",
@@ -100,6 +107,7 @@ describe("POST /api/v1/sessions", () => {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          "X-Forwarded-For": testClientAddress,
         },
         body: JSON.stringify({
           email: "passwordless@pedro.tec.br",
@@ -129,6 +137,7 @@ describe("POST /api/v1/sessions", () => {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          "X-Forwarded-For": testClientAddress,
         },
         body: JSON.stringify({
           email: "correct@pedro.tec.br",

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import retry from "async-retry";
 import * as database from "infra/database";
 import storage from "infra/storage";
@@ -39,6 +39,15 @@ const DO_NOT_FAKE_TIMERS_FOR_PRISMA = [
   "setTimeout",
   "clearTimeout",
 ];
+
+const createTestClientAddress = (suiteId) => {
+  const digest = createHash("sha256").update(suiteId).digest("hex");
+  const groups = [0, 4, 8, 12].map((offset) =>
+    digest.slice(offset, offset + 4),
+  );
+
+  return `2001:db8:${groups.join(":")}`;
+};
 
 const waitForAllServices = async () => {
   await waitForWebServer();
@@ -382,6 +391,7 @@ const recordLedgerSale = async (saleData = {}) => {
 };
 
 const orchestrator = {
+  createTestClientAddress,
   waitForAllServices,
   clearDatabase,
   clearDatabaseRows,

--- a/tests/unit/contracts/desktop-v1.test.ts
+++ b/tests/unit/contracts/desktop-v1.test.ts
@@ -1,0 +1,81 @@
+import {
+  byteSizeSchema,
+  createSessionRequestSchema,
+  desktopArchitectureSchema,
+  desktopPlatformSchema,
+  installManifestSchema,
+  manifestSchemaVersionSchema,
+} from "contracts/desktop/v1";
+
+const releaseId = "11111111-1111-4111-8111-111111111111";
+const artifactId = "22222222-2222-4222-8222-222222222222";
+
+describe("desktop API v1 contract", () => {
+  test("defines the supported target vocabulary", () => {
+    expect(desktopPlatformSchema.options).toEqual(["WINDOWS", "MAC", "LINUX"]);
+    expect(desktopArchitectureSchema.options).toEqual(["X86_64", "AARCH64"]);
+  });
+
+  test("rejects an unknown API version", () => {
+    const result = createSessionRequestSchema.safeParse({
+      method: "PASSWORD",
+      email: "player@example.com",
+      password: "secret",
+      api_version: "2",
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects an unknown manifest schema version", () => {
+    expect(manifestSchemaVersionSchema.safeParse("2").success).toBe(false);
+    expect(
+      installManifestSchema.safeParse({
+        schema_version: "2",
+        release_id: releaseId,
+        artifact_id: artifactId,
+        entrypoint: "game/start.exe",
+      }).success,
+    ).toBe(false);
+  });
+
+  test("accepts a complete version 1 manifest", () => {
+    const manifest = installManifestSchema.parse({
+      schema_version: "1",
+      release_id: releaseId,
+      artifact_id: artifactId,
+      entrypoint: "game/start.exe",
+    });
+
+    expect(manifest).toEqual({
+      schema_version: "1",
+      release_id: releaseId,
+      artifact_id: artifactId,
+      entrypoint: "game/start.exe",
+      launch_arguments: [],
+      executables: [],
+      environment: {},
+    });
+  });
+
+  test.each(["/game/start", "../game/start", "game/../../start"])(
+    "rejects unsafe manifest path %s",
+    (entrypoint) => {
+      const result = installManifestSchema.safeParse({
+        schema_version: "1",
+        release_id: releaseId,
+        artifact_id: artifactId,
+        entrypoint,
+      });
+
+      expect(result.success).toBe(false);
+    },
+  );
+
+  test("represents byte sizes as unsigned decimal strings", () => {
+    expect(byteSizeSchema.safeParse("9007199254740993").success).toBe(true);
+    expect(byteSizeSchema.safeParse(9007199254740992).success).toBe(false);
+    expect(byteSizeSchema.safeParse("-1").success).toBe(false);
+    expect(byteSizeSchema.safeParse("01").success).toBe(false);
+  });
+});

--- a/tests/unit/contracts/desktop-v1.test.ts
+++ b/tests/unit/contracts/desktop-v1.test.ts
@@ -72,6 +72,21 @@ describe("desktop API v1 contract", () => {
     },
   );
 
+  test.each([
+    "C:\\Windows\\System32\\cmd.exe",
+    "C:/Windows/System32/cmd.exe",
+    "C:drive-relative.exe",
+  ])("rejects drive-qualified manifest path %s", (entrypoint) => {
+    const result = installManifestSchema.safeParse({
+      schema_version: "1",
+      release_id: releaseId,
+      artifact_id: artifactId,
+      entrypoint,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
   test("represents byte sizes as unsigned decimal strings", () => {
     expect(byteSizeSchema.safeParse("9007199254740993").success).toBe(true);
     expect(byteSizeSchema.safeParse(9007199254740992).success).toBe(false);

--- a/tests/unit/infra/auth_rate_limit.test.ts
+++ b/tests/unit/infra/auth_rate_limit.test.ts
@@ -1,0 +1,46 @@
+import authRateLimit from "infra/auth_rate_limit";
+import { NextApiRequest } from "next";
+
+function request(address: string) {
+  return {
+    headers: { "x-forwarded-for": address },
+    socket: {},
+  } as unknown as NextApiRequest;
+}
+
+describe("authentication rate limiting", () => {
+  test("limits repeated attempts without retaining the login in its key", () => {
+    const req = request("192.0.2.10");
+    const login = `person-${Date.now()}@example.com`;
+
+    for (let attempt = 0; attempt < authRateLimit.MAX_ATTEMPTS; attempt += 1) {
+      expect(authRateLimit.consume(req, login, 1).allowed).toBe(true);
+    }
+
+    const limited = authRateLimit.consume(req, login, 1);
+    expect(limited.allowed).toBe(false);
+    expect(limited.retryAfterSeconds).toBe(authRateLimit.WINDOW_MS / 1000);
+  });
+
+  test("successful authentication resets the bucket", () => {
+    const req = request("192.0.2.11");
+    const login = `reset-${Date.now()}@example.com`;
+    authRateLimit.consume(req, login, 1);
+    authRateLimit.reset(req, login);
+
+    expect(authRateLimit.consume(req, login, 1).allowed).toBe(true);
+  });
+
+  test("limits an address even when login identifiers rotate", () => {
+    const req = request("192.0.2.12");
+    for (let attempt = 0; attempt < authRateLimit.MAX_ATTEMPTS; attempt += 1) {
+      expect(
+        authRateLimit.consume(req, `${attempt}@example.com`, 1).allowed,
+      ).toBe(true);
+    }
+
+    expect(authRateLimit.consume(req, "new@example.com", 1).allowed).toBe(
+      false,
+    );
+  });
+});

--- a/tests/unit/infra/auth_rate_limit.test.ts
+++ b/tests/unit/infra/auth_rate_limit.test.ts
@@ -26,7 +26,7 @@ describe("authentication rate limiting", () => {
     const req = request("192.0.2.11");
     const login = `reset-${Date.now()}@example.com`;
     authRateLimit.consume(req, login, 1);
-    authRateLimit.reset(req, login);
+    authRateLimit.reset(login);
 
     expect(authRateLimit.consume(req, login, 1).allowed).toBe(true);
   });
@@ -42,5 +42,17 @@ describe("authentication rate limiting", () => {
     expect(authRateLimit.consume(req, "new@example.com", 1).allowed).toBe(
       false,
     );
+  });
+
+  test("successful authentication preserves the address bucket", () => {
+    const req = request("192.0.2.13");
+    for (let attempt = 0; attempt < authRateLimit.MAX_ATTEMPTS; attempt += 1) {
+      authRateLimit.consume(req, `victim-${attempt}@example.com`, 1);
+    }
+
+    authRateLimit.reset("attacker@example.com");
+    expect(
+      authRateLimit.consume(req, "next-victim@example.com", 1).allowed,
+    ).toBe(false);
   });
 });

--- a/tests/unit/infra/controller.test.ts
+++ b/tests/unit/infra/controller.test.ts
@@ -1,0 +1,25 @@
+import controller from "infra/controller";
+import { UnauthorizedError } from "infra/errors";
+
+describe("bearer authorization", () => {
+  test("extracts a bearer session token", () => {
+    expect(controller.readBearerToken("Bearer abc_123-XYZ")).toBe(
+      "abc_123-XYZ",
+    );
+  });
+
+  test("returns undefined only when the header is absent", () => {
+    expect(controller.readBearerToken(undefined)).toBeUndefined();
+  });
+
+  test.each([
+    "",
+    "Basic abc",
+    "bearer abc",
+    "Bearer",
+    "Bearer  abc",
+    "Bearer abc def",
+  ])("rejects malformed authorization header %p", (header) => {
+    expect(() => controller.readBearerToken(header)).toThrow(UnauthorizedError);
+  });
+});

--- a/tests/unit/infra/desktop_api.test.ts
+++ b/tests/unit/infra/desktop_api.test.ts
@@ -1,0 +1,57 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { desktopErrorHandlers } from "infra/desktop_api";
+
+function response() {
+  const body: { value?: unknown } = {};
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn((value: unknown) => {
+      body.value = value;
+      return value;
+    }),
+    setHeader: jest.fn(),
+  } as unknown as NextApiResponse;
+  return { body, res };
+}
+
+describe("desktop API error handling", () => {
+  test("wraps unexpected failures in the desktop error envelope", () => {
+    const { body, res } = response();
+    const req = {
+      method: "POST",
+      headers: {},
+      url: "/api/v1/desktop/sessions",
+    } as unknown as NextApiRequest;
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    desktopErrorHandlers.onError(new Error("database secret"), req, res);
+
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(body.value).toEqual({
+      error: {
+        code: "SERVICE_UNAVAILABLE",
+        message: "The desktop service is temporarily unavailable",
+        retryable: true,
+      },
+    });
+    consoleError.mockRestore();
+  });
+
+  test("wraps unsupported methods in the desktop error envelope", () => {
+    const { body, res } = response();
+    const req = { method: "PATCH" } as unknown as NextApiRequest;
+
+    desktopErrorHandlers.onNoMatch(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(405);
+    expect(body.value).toEqual({
+      error: {
+        code: "INVALID_REQUEST",
+        message: "Method PATCH is not allowed for this endpoint",
+        retryable: false,
+      },
+    });
+  });
+});


### PR DESCRIPTION
### Motivation

- Allow desktop clients to authenticate with `Authorization: Bearer <session-token>` while preserving existing cookie sessions for the web client.
- Enable server-side revocation of bearer sessions and ensure authentication failures do not silently fall back to cookies.
- Add abuse controls for password/OTP endpoints and prevent leakage of sensitive data in logs.

### Description

- Extend request middleware to accept and validate bearer tokens via `readBearerToken` and to prefer bearer authentication over cookie sessions, and enrich `req.context` with the resolved `session` and `authentication` method.
- Redact query strings from error logging so signed URLs and other secrets are not written to operational logs by using the request pathname only in `logServerError`.
- Add a lightweight in-process authentication rate limiter (`infra/auth_rate_limit.ts`) that combines client-address and login buckets (stored as hashed keys) and expose `consume`/`reset` helpers for endpoints.
- Introduce a desktop API error envelope and helpers (`infra/desktop_api.ts`) to standardize responses for `RATE_LIMITED`, `AUTHENTICATION_REQUIRED`, `SESSION_EXPIRED`, and related failures with `Retry-After` support.
- Add desktop session endpoints under `/api/v1/desktop`: `POST /sessions` to create bearer sessions using the existing password/OTP flows and `DELETE /sessions/current` to revoke the current bearer session server-side.
- Wire rate limiting into existing web login endpoints so they share abuse controls while preserving cookie-based behavior and reset limits on successful authentication.
- Add unit tests covering `readBearerToken` (valid/missing/malformed headers) and the authentication rate limiter behavior (limits, reset, and address-based limiting).

### Testing

- Ran `npx jest --runInBand tests/unit` and all unit tests passed (`41` tests across `5` suites).
- Built the application with `npm run build` which completed production compilation, static generation, and TypeScript checks successfully.
- Ran formatting and lint checks with `npm run lint:prettier:check` and `npm run lint:eslint:check` (ESLint reported two pre-existing `<img>` warnings only).
- Ran `npx prisma generate` successfully to regenerate the Prisma client.
- Integration test suite could not be executed in this environment because Docker is unavailable, and `npx tsc --noEmit` reports test-runner globals are not present in the standalone TypeScript config (this is an existing repository configuration issue rather than a regression from these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a84ddd22db8832787a233910f383fde)