### PR TITLE
Make distribution API resources client-neutral

### DIFF
--- a/contracts/desktop/v1.ts
+++ b/contracts/desktop/v1.ts
@@ -60,29 +60,35 @@ export const targetSchema = z.object({
   architecture: desktopArchitectureSchema,
 });
 
-export const sessionSchema = z.object({
-  token: z.string().min(1),
-  expires_at: timestampSchema,
-  user: z.object({
+export const sessionSchema = z
+  .object({
     id: identifierSchema,
-    username: z.string().min(1),
-  }),
-});
+    token: z.string().min(1),
+    user_id: identifierSchema,
+    expires_at: timestampSchema,
+    created_at: timestampSchema,
+    updated_at: timestampSchema,
+  })
+  .strict();
 
-export const createSessionRequestSchema = z.discriminatedUnion("method", [
-  z.object({
-    method: z.literal("PASSWORD"),
-    email: z.email(),
-    password: z.string().min(1),
-    api_version: desktopApiVersionSchema,
-  }),
-  z.object({
-    method: z.literal("OTP"),
-    email: z.email(),
-    otp: z.string().min(1),
-    api_version: desktopApiVersionSchema,
-  }),
-]);
+export const requestOtpSchema = z
+  .object({
+    login: z.string().trim().min(1),
+  })
+  .strict();
+
+export const otpRequestedSchema = z
+  .object({
+    message: z.string().min(1),
+  })
+  .strict();
+
+export const createSessionRequestSchema = z
+  .object({
+    login: z.string().trim().min(1),
+    code: z.string().regex(/^\d{6}$/, "Code must contain exactly six digits"),
+  })
+  .strict();
 
 export const catalogGameSchema = z.object({
   id: identifierSchema,
@@ -163,6 +169,8 @@ export const releasePatchSchema = z.object({
 export type DesktopPlatform = z.infer<typeof desktopPlatformSchema>;
 export type DesktopArchitecture = z.infer<typeof desktopArchitectureSchema>;
 export type DesktopError = z.infer<typeof desktopErrorSchema>;
+export type RequestOtpRequest = z.infer<typeof requestOtpSchema>;
+export type OtpRequested = z.infer<typeof otpRequestedSchema>;
 export type DesktopSession = z.infer<typeof sessionSchema>;
 export type CatalogGame = z.infer<typeof catalogGameSchema>;
 export type LibraryItem = z.infer<typeof libraryItemSchema>;

--- a/docs/manifold-desktop-api-compatibility.md
+++ b/docs/manifold-desktop-api-compatibility.md
@@ -1,23 +1,23 @@
-# Manifold Desktop API compatibility
+# Manifold distribution API compatibility
 
-The desktop distribution API is versioned independently from the website API.
-Its source contract is
+Release distribution is part of the same API consumed by the website, desktop
+application, and any future clients. Its source contract is
 [`docs/openapi/manifold-desktop-v1.yaml`](openapi/manifold-desktop-v1.yaml), and
 its application-independent TypeScript schemas live in
 [`contracts/desktop/v1.ts`](../contracts/desktop/v1.ts).
 
 ## Version negotiation
 
-- Every desktop session request declares `api_version`. Version `1` is the only
-  supported value for the v1 endpoint family.
-- The server returns `UNSUPPORTED_API_VERSION` for an unknown API version. It
-  must never choose a different version silently.
+- The API version is explicit in the `/api/v1` path. Clients do not send a
+  second, client-specific version field during authentication.
+- Requests for an unknown API version fail rather than silently selecting
+  another version.
 - Every install manifest declares `schema_version`. Schema version `1` is the
   only version understood by API v1.
 - Unknown manifest versions return `UNSUPPORTED_MANIFEST_VERSION` and are never
   published or served as if they were version 1.
-- Desktop clients may call an API version only when they implement every
-  required field and error behavior in that version's OpenAPI document.
+- Clients may call an API version only when they implement every required field
+  and error behavior in that version's OpenAPI document.
 
 ## Compatibility guarantees
 
@@ -31,6 +31,13 @@ API v1 uses RFC 3339 timestamps. Byte sizes are unsigned base-10 strings rather
 than JSON numbers so 64-bit artifact sizes survive languages whose JSON number
 implementation cannot represent every integer exactly. SHA-256 values use 64
 lowercase hexadecimal characters.
+
+Authentication uses the platform's existing passwordless OTP flow and opaque
+server-side sessions. The API sets the session in the secure, HTTP-only
+`session_id` cookie. API v1's existing session representation also contains the
+opaque token for backward compatibility, so clients must treat the response as
+sensitive. The Tauri native HTTP layer owns the cookie jar and must not expose
+the cookie or token field to its WebView.
 
 ## Supported targets
 
@@ -48,7 +55,7 @@ a game has no published artifact returns `NO_COMPATIBLE_RELEASE`.
 ## Deprecation
 
 A replacement API version must be available before v1 is deprecated. The
-deprecation announcement must identify the last supported desktop client
-version and provide at least 180 days between announcement and shutdown. A
-client using a retired API version receives `UNSUPPORTED_API_VERSION` rather
-than a response shaped like another version.
+deprecation announcement must identify affected clients and provide at least
+180 days between announcement and shutdown. A client using a retired API
+version receives an explicit version error rather than a response shaped like
+another version.

--- a/docs/manifold-desktop-backend-plan.md
+++ b/docs/manifold-desktop-backend-plan.md
@@ -14,7 +14,7 @@ defined in `docs/manifold-desktop-app-plan.md`.
 The repository already provides several primitives needed by the desktop app:
 
 - A public, paginated game catalog at `GET /api/v1/games`.
-- Cookie-based password and OTP sessions.
+- Cookie-based passwordless OTP sessions.
 - A centralized, authenticated library at `GET /api/v1/library`.
 - Per-platform game-file records containing a version and size.
 - Entitlement checks and short-lived signed download URLs.
@@ -25,16 +25,17 @@ The repository already provides several primitives needed by the desktop app:
 These are web-oriented primitives rather than a desktop distribution contract.
 In particular, the current model does not identify an immutable release, CPU
 architecture, archive format, entrypoint, or content hash. Downloads are not
-yet designed for URL refresh and resume, and authentication depends on a
-browser cookie.
+yet designed for URL refresh and resume. Desktop authentication will reuse the
+same passwordless OTP flow and server-side cookie sessions through a native
+Tauri HTTP client and cookie jar.
 
 ## Guiding decisions
 
 1. The website and desktop application share the backend, entitlements, and
    catalog but remain separate client projects.
-2. Existing web endpoints should be reused where their contracts are suitable.
-   Desktop-specific orchestration endpoints should live under
-   `/api/v1/desktop`.
+2. The backend is API-first: resources and business rules are client-neutral.
+   Existing `/api/v1` endpoints are reused where suitable, and new release and
+   artifact resources are not placed under a client-specific namespace.
 3. Published releases and artifacts are immutable. A correction creates a new
    release.
 4. Full artifact downloads are the required fallback for every update path.
@@ -45,7 +46,7 @@ browser cookie.
 7. The repository's existing security, authorization, output-filtering, money,
    migration, and test conventions continue to apply.
 
-## Phase 1 — Specify the desktop API contract
+## Phase 1 — Specify the distribution API contract
 
 ### Work
 
@@ -56,7 +57,7 @@ browser cookie.
   32-bit targets.
 - Define the API error envelope, retryable error codes, pagination, timestamps,
   and size representations.
-- Establish a compatibility policy between desktop app versions, API versions,
+- Establish a compatibility policy between consuming clients, API versions,
   and manifest schema versions.
 - Publish an OpenAPI document or equivalent machine-readable schema from which
   the desktop repository can generate or validate types.
@@ -67,35 +68,38 @@ browser cookie.
 
 - The complete login-to-download sequence is expressible using documented
   request and response schemas.
-- Desktop types can be produced without importing application-internal model
+- Client types can be produced without importing application-internal model
   types.
 - Unknown manifest and API versions fail explicitly rather than being silently
   accepted.
 
-## Phase 2 — Add desktop-compatible authentication
+## Phase 2 — Integrate cookie sessions with the desktop client
 
 ### Work
 
-- Extend authentication middleware to accept
-  `Authorization: Bearer <session-token>` while preserving cookie sessions for
-  the website.
-- Reuse the existing password and OTP authentication flows.
-- Define logout, token expiration, revocation, and disabled-user behavior.
-- Add rate limiting and abuse controls to password and OTP endpoints.
-- Prevent session tokens, OTPs, signed URLs, and authorization headers from
-  appearing in logs.
-- Decide whether desktop network calls use native HTTP exclusively. If WebView
-  requests remain possible, define a narrow origin/CORS policy rather than a
-  wildcard policy.
+- Reuse the existing passwordless OTP request, verification, session creation,
+  renewal, and revocation behavior.
+- Authenticate API requests with the existing secure, HTTP-only
+  `session_id` cookie; do not add a bearer-token transport.
+- Have narrow Tauri Rust commands own HTTP requests and the cookie jar so the
+  session credential is never exposed to the WebView.
+- Define logout, session expiration, revocation, and disabled-user behavior.
+- Define secure cookie persistence and deletion behavior across application
+  restarts and logout.
+- Add rate limiting and abuse controls to OTP endpoints.
+- Prevent session cookies, OTPs, and signed URLs from appearing in logs.
+- Keep authenticated desktop network calls in native Rust. If WebView requests
+  are introduced later, require a separate security review and a narrow
+  origin/CORS policy.
 - Add integration tests for valid, missing, expired, revoked, and malformed
-  bearer tokens.
+  session cookies.
 
 ### Acceptance criteria
 
-- A command-line client can authenticate, call `GET /api/v1/library`, and obtain
-  download authorization without browser cookie handling.
+- A Tauri-native HTTP client can request and verify an OTP, retain the issued
+  cookie, call the desktop library, and obtain download authorization.
 - Existing website login and session tests continue to pass unchanged.
-- Logging out invalidates the token server-side.
+- Logging out clears the cookie and invalidates the session server-side.
 
 ## Phase 3 — Model immutable releases, artifacts, and manifests
 
@@ -185,26 +189,28 @@ browser cookie.
 - Repeating a confirmation or publication request does not create duplicates.
 - A published artifact's storage object and hash remain stable.
 
-## Phase 5 — Expose desktop orchestration endpoints
+## Phase 5 — Expose client-neutral distribution resources
 
 ### Recommended surface
 
-- `GET /api/v1/desktop/config`
-- `POST /api/v1/desktop/sessions`
-- `DELETE /api/v1/desktop/sessions/current`
-- `GET /api/v1/desktop/catalog`
-- `GET /api/v1/desktop/library`
-- `GET /api/v1/desktop/games/:slug/releases/latest?platform=&arch=`
-- `GET /api/v1/desktop/releases/:release_id/manifest`
-- `POST /api/v1/desktop/artifacts/:artifact_id/download`
+- `POST /api/v1/otp` (existing)
+- `POST /api/v1/otp/sessions` (existing)
+- `DELETE /api/v1/sessions` (existing)
+- `GET /api/v1/games` (existing)
+- `GET /api/v1/library?platform=&arch=`
+- `GET /api/v1/games/:slug/releases/latest?platform=&arch=`
+- `GET /api/v1/releases/:release_id/manifest`
+- `POST /api/v1/artifacts/:artifact_id/download`
 
-The desktop library response should include a latest-compatible-release
-summary so the client does not make one release request for every library item.
+When both target parameters are supplied, the library response should include a
+latest-compatible-release summary so clients do not make one release request
+for every library item. Calls without a target retain the existing library
+response for backward compatibility.
 
 ### Work
 
 - Reuse catalog, pricing, entitlement, and authorization models rather than
-  duplicating their rules in desktop controllers.
+  duplicating their rules in distribution controllers.
 - Return only published artifacts compatible with the requested target.
 - Ensure download authorization checks entitlement immediately before signing.
 - Include stable IDs, hashes, sizes, and manifest versions in responses.
@@ -213,7 +219,8 @@ summary so the client does not make one release request for every library item.
 
 ### Acceptance criteria
 
-- The entire first-run desktop flow can be completed using the desktop API.
+- The entire first-run desktop flow can be completed using API v1 without
+  client-specific endpoints.
 - An unentitled user cannot list private artifact data or obtain a signed URL.
 - A client receives a clear `NO_COMPATIBLE_RELEASE` result when appropriate.
 
@@ -319,7 +326,7 @@ patching begins.
 - Add staging smoke tests for every supported platform/architecture target.
 - Add compatibility tests against the machine-readable desktop contract.
 - Define incident procedures for a compromised signing key, corrupted artifact,
-  broken release, or leaked session token.
+  broken release, or leaked session cookie.
 
 ### Acceptance criteria
 
@@ -333,7 +340,7 @@ patching begins.
 Each numbered item should be a small, independently testable delivery slice:
 
 1. Contract and target vocabulary.
-2. Bearer-token authentication.
+2. Passwordless cookie-session integration.
 3. Release/artifact schema and models.
 4. Publication state machine.
 5. Compatible-release and manifest reads.

--- a/docs/openapi/manifold-desktop-v1.yaml
+++ b/docs/openapi/manifold-desktop-v1.yaml
@@ -1,19 +1,40 @@
 openapi: 3.1.0
 info:
-  title: Manifold Desktop API
+  title: Manifold Distribution API
   version: 1.0.0
-  description: Contract for the Manifold Desktop login-to-download workflow.
+  description: Client-neutral contract for Manifold authentication and release distribution.
   license:
     name: MIT
     identifier: MIT
 servers:
-  - url: /api/v1/desktop
+  - url: /api/v1
 security: []
 paths:
-  /sessions:
+  /otp:
     post:
-      summary: Create a desktop session
-      operationId: createDesktopSession
+      summary: Request a passwordless login code
+      operationId: requestOtp
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RequestOtpRequest"
+      responses:
+        "201":
+          description: The one-time code was accepted for delivery.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OtpRequested"
+        "400":
+          $ref: "#/components/responses/Error"
+        default:
+          $ref: "#/components/responses/Error"
+  /otp/sessions:
+    post:
+      summary: Verify a one-time code and create a cookie session
+      operationId: createOtpSession
       requestBody:
         required: true
         content:
@@ -22,7 +43,12 @@ paths:
               $ref: "#/components/schemas/CreateSessionRequest"
       responses:
         "201":
-          description: Authenticated desktop session.
+          description: Authenticated session.
+          headers:
+            Set-Cookie:
+              description: Secure, HTTP-only `session_id` cookie.
+              schema:
+                type: string
           content:
             application/json:
               schema:
@@ -31,23 +57,28 @@ paths:
           $ref: "#/components/responses/Error"
         default:
           $ref: "#/components/responses/Error"
-  /sessions/current:
+  /sessions:
     delete:
-      summary: Revoke the current desktop session
-      operationId: revokeDesktopSession
+      summary: Revoke the current session
+      operationId: revokeSession
       security:
-        - bearerAuth: []
+        - cookieAuth: []
       responses:
         "204":
           description: Session revoked.
+          headers:
+            Set-Cookie:
+              description: Clears the `session_id` cookie.
+              schema:
+                type: string
         "400":
           $ref: "#/components/responses/Error"
         default:
           $ref: "#/components/responses/Error"
-  /catalog:
+  /games:
     get:
-      summary: List the desktop catalog
-      operationId: listDesktopCatalog
+      summary: List games
+      operationId: listGames
       parameters:
         - $ref: "#/components/parameters/Page"
         - $ref: "#/components/parameters/Limit"
@@ -72,10 +103,10 @@ paths:
           $ref: "#/components/responses/Error"
   /library:
     get:
-      summary: List the current user's desktop library
-      operationId: listDesktopLibrary
+      summary: List the current user's library with compatible releases
+      operationId: listLibrary
       security:
-        - bearerAuth: []
+        - cookieAuth: []
       parameters:
         - $ref: "#/components/parameters/Platform"
         - $ref: "#/components/parameters/Architecture"
@@ -105,7 +136,7 @@ paths:
       summary: Resolve the latest compatible game release
       operationId: getLatestCompatibleRelease
       security:
-        - bearerAuth: []
+        - cookieAuth: []
       parameters:
         - name: slug
           in: path
@@ -130,7 +161,7 @@ paths:
       summary: Get a release install manifest
       operationId: getInstallManifest
       security:
-        - bearerAuth: []
+        - cookieAuth: []
       parameters:
         - $ref: "#/components/parameters/ReleaseId"
         - name: schema_version
@@ -154,7 +185,7 @@ paths:
       summary: Authorize an artifact download
       operationId: authorizeArtifactDownload
       security:
-        - bearerAuth: []
+        - cookieAuth: []
       parameters:
         - name: artifact_id
           in: path
@@ -177,7 +208,7 @@ paths:
       summary: List compatible patches for a release
       operationId: listReleasePatches
       security:
-        - bearerAuth: []
+        - cookieAuth: []
       parameters:
         - $ref: "#/components/parameters/ReleaseId"
         - $ref: "#/components/parameters/Platform"
@@ -201,10 +232,10 @@ paths:
           $ref: "#/components/responses/Error"
 components:
   securitySchemes:
-    bearerAuth:
-      type: http
-      scheme: bearer
-      bearerFormat: opaque-session-token
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: session_id
   parameters:
     Page:
       name: page
@@ -241,7 +272,7 @@ components:
         $ref: "#/components/schemas/Identifier"
   responses:
     Error:
-      description: Desktop API error.
+      description: API error.
       content:
         application/json:
           schema:
@@ -275,52 +306,50 @@ components:
           $ref: "#/components/schemas/Platform"
         architecture:
           $ref: "#/components/schemas/Architecture"
+    RequestOtpRequest:
+      type: object
+      additionalProperties: false
+      required: [login]
+      properties:
+        login:
+          type: string
+          minLength: 1
+    OtpRequested:
+      type: object
+      additionalProperties: false
+      required: [message]
+      properties:
+        message:
+          type: string
     CreateSessionRequest:
-      oneOf:
-        - type: object
-          additionalProperties: false
-          required: [method, email, password, api_version]
-          properties:
-            method:
-              const: PASSWORD
-            email:
-              type: string
-              format: email
-            password:
-              type: string
-              minLength: 1
-            api_version:
-              const: "1"
-        - type: object
-          additionalProperties: false
-          required: [method, email, otp, api_version]
-          properties:
-            method:
-              const: OTP
-            email:
-              type: string
-              format: email
-            otp:
-              type: string
-              minLength: 1
-            api_version:
-              const: "1"
+      type: object
+      additionalProperties: false
+      required: [login, code]
+      properties:
+        login:
+          type: string
+          minLength: 1
+        code:
+          type: string
+          pattern: "^[0-9]{6}$"
     Session:
       type: object
-      required: [token, expires_at, user]
+      additionalProperties: false
+      required: [id, token, user_id, expires_at, created_at, updated_at]
       properties:
+        id:
+          $ref: "#/components/schemas/Identifier"
         token:
           type: string
+          description: Legacy response field. Cookie-based clients must not expose it to untrusted UI code.
+        user_id:
+          $ref: "#/components/schemas/Identifier"
         expires_at:
           $ref: "#/components/schemas/Timestamp"
-        user:
-          type: object
-          required: [id, username]
-          properties:
-            id:
-              $ref: "#/components/schemas/Identifier"
-            username:
-              type: string
+        created_at:
+          $ref: "#/components/schemas/Timestamp"
+        updated_at:
+          $ref: "#/components/schemas/Timestamp"
     CatalogGame:
       type: object
       required: [id, slug, title, description, cover_url, platforms]

--- a/tests/unit/contracts/desktop-v1.test.ts
+++ b/tests/unit/contracts/desktop-v1.test.ts
@@ -1,30 +1,45 @@
 import {
   byteSizeSchema,
   createSessionRequestSchema,
+  desktopApiVersionSchema,
   desktopArchitectureSchema,
   desktopPlatformSchema,
   installManifestSchema,
   manifestSchemaVersionSchema,
+  requestOtpSchema,
 } from "contracts/desktop/v1";
 
 const releaseId = "11111111-1111-4111-8111-111111111111";
 const artifactId = "22222222-2222-4222-8222-222222222222";
 
-describe("desktop API v1 contract", () => {
+describe("distribution API v1 contract", () => {
   test("defines the supported target vocabulary", () => {
     expect(desktopPlatformSchema.options).toEqual(["WINDOWS", "MAC", "LINUX"]);
     expect(desktopArchitectureSchema.options).toEqual(["X86_64", "AARCH64"]);
   });
 
   test("rejects an unknown API version", () => {
-    const result = createSessionRequestSchema.safeParse({
-      method: "PASSWORD",
-      email: "player@example.com",
-      password: "secret",
-      api_version: "2",
-    });
+    expect(desktopApiVersionSchema.safeParse("2").success).toBe(false);
+  });
 
-    expect(result.success).toBe(false);
+  test("defines a passwordless OTP login flow", () => {
+    expect(
+      requestOtpSchema.safeParse({
+        login: "player@example.com",
+      }).success,
+    ).toBe(true);
+    expect(
+      createSessionRequestSchema.safeParse({
+        login: "player@example.com",
+        code: "123456",
+      }).success,
+    ).toBe(true);
+    expect(
+      createSessionRequestSchema.safeParse({
+        login: "player@example.com",
+        code: "password",
+      }).success,
+    ).toBe(false);
   });
 
   test("rejects an unknown manifest schema version", () => {


### PR DESCRIPTION
## Summary

- replace the proposed `/api/v1/desktop` namespace with shared `/api/v1` resources
- reuse the existing OTP, session, games, and library endpoints
- define client-neutral release, manifest, artifact, and patch resources
- keep cookie-backed passwordless authentication in the distribution contract
- update the backend plan, compatibility policy, OpenAPI document, Zod schemas, and contract tests

## Why

Manifold is an API-first service. Authentication, catalog, ownership, and distribution resources should not vary based on whether the consumer is the website, Tauri application, or a future client.

## Impact

The contract now uses the existing shared authentication and catalog routes. New distribution capabilities live directly under `/api/v1`, without duplicating business rules in a client-specific controller tree.

## Validation

- `npx jest tests/unit/contracts/desktop-v1.test.ts --runInBand`
- `npx eslint contracts/desktop/v1.ts tests/unit/contracts/desktop-v1.test.ts`
- Prettier check for all changed files
- parsed the OpenAPI YAML and verified the expected `/api/v1` resource paths