### PR TITLE
Add signed publisher artifact uploads

### DIFF
--- a/infra/controller.ts
+++ b/infra/controller.ts
@@ -155,6 +155,21 @@ function canRequest(feature: string) {
   };
 }
 
+function requireAuthentication(
+  req: NextApiRequest,
+  _res: NextApiResponse,
+  next: NextHandler,
+) {
+  if (!req.context?.user?.id) {
+    throw new UnauthorizedError({
+      message: "Authentication required",
+      action: "Sign in and send the session_id cookie",
+    });
+  }
+
+  return next();
+}
+
 const controller = {
   errorHandlers: {
     onNoMatch: onNoMatchHandler,
@@ -163,6 +178,7 @@ const controller = {
   setSessionCookie,
   clearSessionCookie,
   injectAnonymousOrUser,
+  requireAuthentication,
   logServerError,
   canRequest,
 };

--- a/infra/storage.ts
+++ b/infra/storage.ts
@@ -10,6 +10,7 @@ import {
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { InternalServerError } from "./errors";
+import { GameArchiveFormat } from "generated/prisma/client";
 
 const s3Client = new S3Client({
   region: process.env.NODE_ENV === "production" ? "auto" : "us-east-1",
@@ -45,6 +46,68 @@ export async function getUploadUrl(
   return await getSignedUrl(s3Client, command, {
     expiresIn: UPLOAD_EXPIRES_IN_SECONDS,
   });
+}
+
+const ARTIFACT_CONTENT_TYPES: Record<GameArchiveFormat, string> = {
+  ZIP: "application/zip",
+  TAR_GZ: "application/gzip",
+};
+
+export interface ArtifactUploadAuthorization {
+  url: string;
+  expires_at: string;
+  required_headers: Record<string, string>;
+}
+
+export async function getArtifactUploadAuthorization({
+  key,
+  artifactId,
+  archiveFormat,
+  compressedSizeBytes,
+  sha256,
+}: {
+  key: string;
+  artifactId: string;
+  archiveFormat: GameArchiveFormat;
+  compressedSizeBytes: string;
+  sha256: string;
+}): Promise<ArtifactUploadAuthorization> {
+  const contentType = ARTIFACT_CONTENT_TYPES[archiveFormat];
+  const checksum = Buffer.from(sha256, "hex").toString("base64");
+  const requiredHeaders = {
+    "content-type": contentType,
+    "x-amz-checksum-sha256": checksum,
+    "x-amz-meta-artifact-id": artifactId,
+    "x-amz-meta-declared-size-bytes": compressedSizeBytes,
+    "x-amz-meta-sha256": sha256,
+  };
+  const command = new PutObjectCommand({
+    Bucket: bucketName,
+    Key: key,
+    ContentType: contentType,
+    ChecksumSHA256: checksum,
+    Metadata: {
+      "artifact-id": artifactId,
+      "declared-size-bytes": compressedSizeBytes,
+      sha256,
+    },
+  });
+
+  const url = await getSignedUrl(s3Client, command, {
+    expiresIn: UPLOAD_EXPIRES_IN_SECONDS,
+    // Keep integrity metadata in the signed headers instead of hoisting it to
+    // the query string. The uploader must send exactly these values.
+    unhoistableHeaders: new Set(Object.keys(requiredHeaders).slice(1)),
+    signableHeaders: new Set(["content-type"]),
+  });
+
+  return {
+    url,
+    expires_at: new Date(
+      Date.now() + UPLOAD_EXPIRES_IN_SECONDS * 1000,
+    ).toISOString(),
+    required_headers: requiredHeaders,
+  };
 }
 
 export async function getDownloadUrl(key: string): Promise<string> {
@@ -124,6 +187,7 @@ export async function createBucket(
 
 const storage = {
   getUploadUrl,
+  getArtifactUploadAuthorization,
   getDownloadUrl,
   deleteFile,
   clearAllBuckets,

--- a/models/authorization.ts
+++ b/models/authorization.ts
@@ -89,6 +89,9 @@ const AVAILABLE_FEATURES = [
   "read:game_file",
   "delete:game_file",
 
+  // Immutable release artifacts
+  "create:game_artifact",
+
   // Library
   "read:library",
   "create:library",
@@ -284,6 +287,7 @@ function can(user: Partial<User>, feature: string, resource?: unknown) {
     (feature === "update:game" ||
       feature === "create:game_file" ||
       feature === "delete:game_file" ||
+      feature === "create:game_artifact" ||
       feature === "read:game_price" ||
       feature === "update:game_price") &&
     resource
@@ -605,6 +609,38 @@ function filterOutput(user: Partial<User>, feature: string, resource: unknown) {
       version: fileOutput.version,
       created_at: fileOutput.created_at,
       updated_at: fileOutput.updated_at,
+    };
+  }
+
+  if (feature === "create:game_artifact") {
+    interface GameArtifactUploadOutput {
+      id: string;
+      release_id: string;
+      platform: string;
+      architecture: string;
+      archive_format: string;
+      compressed_size_bytes: string | bigint | null;
+      installed_size_bytes: string | bigint | null;
+      sha256: string | null;
+      manifest: unknown;
+      status: string;
+      created_at: Date;
+      updated_at: Date;
+    }
+    const artifact = resource as GameArtifactUploadOutput;
+    return {
+      id: artifact.id,
+      release_id: artifact.release_id,
+      platform: artifact.platform,
+      architecture: artifact.architecture,
+      archive_format: artifact.archive_format,
+      compressed_size_bytes: artifact.compressed_size_bytes?.toString() ?? null,
+      installed_size_bytes: artifact.installed_size_bytes?.toString() ?? null,
+      sha256: artifact.sha256,
+      manifest: artifact.manifest,
+      status: artifact.status,
+      created_at: artifact.created_at,
+      updated_at: artifact.updated_at,
     };
   }
 

--- a/models/game.ts
+++ b/models/game.ts
@@ -417,6 +417,24 @@ async function findOneBySlug(slug: string) {
   });
 }
 
+async function findOneById(id: string) {
+  return await prisma.game.findUnique({ where: { id } });
+}
+
+async function findOneByIdWithStudio(id: string) {
+  const gameResource = await findOneById(id);
+
+  if (!gameResource) {
+    return null;
+  }
+
+  const studioWithMembers = await studioModel.findOneByIdWithMembers(
+    gameResource.studio_id,
+  );
+
+  return { ...gameResource, studio: studioWithMembers };
+}
+
 async function findOneBySlugWithStudio(slug: string) {
   const gameResource = await findOneBySlug(slug);
 
@@ -736,6 +754,8 @@ async function makePublic(id: string) {
 const game = {
   create,
   update,
+  findOneById,
+  findOneByIdWithStudio,
   findOneBySlug,
   findOneBySlugWithStudio,
   findOneBySteamAppId,

--- a/models/game_artifact.ts
+++ b/models/game_artifact.ts
@@ -15,6 +15,8 @@ import {
 import gameRelease from "models/game_release";
 import storage from "infra/storage";
 import { z } from "zod";
+import { randomUUID } from "node:crypto";
+import { isDeepStrictEqual } from "node:util";
 
 export const gameArtifactCreateSchema = z.object({
   release_id: z.uuid(),
@@ -36,8 +38,185 @@ export const gameArtifactReadySchema = z.object({
   manifest: manifestInputSchema,
 });
 
+const positiveByteSizeSchema = byteSizeSchema.refine(
+  (value) => BigInt(value) > BigInt(0),
+  "Size must be greater than zero",
+);
+
+export const gameArtifactUploadSchema = z.object({
+  platform: z.nativeEnum(GamePlatform),
+  architecture: z.nativeEnum(GameArchitecture),
+  archive_format: z.nativeEnum(GameArchiveFormat),
+  compressed_size_bytes: positiveByteSizeSchema,
+  installed_size_bytes: positiveByteSizeSchema,
+  sha256: sha256Schema,
+  manifest: manifestInputSchema,
+});
+
 export type GameArtifactCreateDto = z.infer<typeof gameArtifactCreateSchema>;
 export type GameArtifactReadyDto = z.infer<typeof gameArtifactReadySchema>;
+export type GameArtifactUploadDto = z.infer<typeof gameArtifactUploadSchema>;
+
+const archiveExtensions: Record<GameArchiveFormat, string> = {
+  ZIP: "zip",
+  TAR_GZ: "tar.gz",
+};
+
+async function initiateUpload(
+  releaseId: string,
+  actorUserId: string,
+  input: GameArtifactUploadDto,
+) {
+  const parsedReleaseId = z.uuid().parse(releaseId);
+  const parsedActorUserId = z.uuid().parse(actorUserId);
+  const data = gameArtifactUploadSchema.parse(input);
+  let result: Awaited<ReturnType<typeof createUploadArtifact>> | undefined;
+
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    try {
+      result = await createUploadArtifact(
+        parsedReleaseId,
+        parsedActorUserId,
+        data,
+      );
+      break;
+    } catch (error) {
+      if (attempt < 3 && isRetryableTransactionError(error)) continue;
+      throw error;
+    }
+  }
+
+  if (!result) throw new Error("Unreachable artifact upload state");
+
+  const artifact = serialize(result.artifact);
+  const upload = await storage.getArtifactUploadAuthorization({
+    key: artifact.storage_object_key,
+    artifactId: artifact.id,
+    archiveFormat: artifact.archive_format,
+    compressedSizeBytes: artifact.compressed_size_bytes!,
+    sha256: artifact.sha256!,
+  });
+
+  return { artifact, upload, created: result.created };
+}
+
+async function createUploadArtifact(
+  releaseId: string,
+  actorUserId: string,
+  data: GameArtifactUploadDto,
+) {
+  return prisma.$transaction(
+    async (tx) => {
+      const release = await tx.gameRelease.findUnique({
+        where: { id: releaseId },
+      });
+      if (!release) {
+        throw new NotFoundError({
+          message: `Release "${releaseId}" was not found.`,
+          action: "Check the release id and try again.",
+        });
+      }
+      gameRelease.assertReleaseMutable(release);
+
+      const existing = await tx.gameArtifact.findUnique({
+        where: {
+          release_id_platform_architecture: {
+            release_id: releaseId,
+            platform: data.platform,
+            architecture: data.architecture,
+          },
+        },
+      });
+
+      if (existing) {
+        if (isSameUploadDeclaration(existing, data)) {
+          return { artifact: existing, created: false };
+        }
+
+        throw new ValidationError({
+          message: `Release "${releaseId}" already has an artifact for ${data.platform}/${data.architecture}.`,
+          action:
+            "Remove the unpublished artifact before uploading a replacement with different metadata.",
+        });
+      }
+
+      const artifactId = randomUUID();
+      const manifest = installManifestSchema.parse({
+        ...data.manifest,
+        release_id: releaseId,
+        artifact_id: artifactId,
+      });
+      const storageObjectKey = [
+        "games",
+        release.game_id,
+        "releases",
+        releaseId,
+        "artifacts",
+        `${artifactId}.${archiveExtensions[data.archive_format]}`,
+      ].join("/");
+
+      const artifact = await tx.gameArtifact.create({
+        data: {
+          id: artifactId,
+          release_id: releaseId,
+          platform: data.platform,
+          architecture: data.architecture,
+          archive_format: data.archive_format,
+          storage_object_key: storageObjectKey,
+          created_by_user_id: actorUserId,
+          compressed_size_bytes: BigInt(data.compressed_size_bytes),
+          installed_size_bytes: BigInt(data.installed_size_bytes),
+          sha256: data.sha256,
+          manifest_schema_version: manifest.schema_version,
+          manifest: manifest as Prisma.InputJsonValue,
+        },
+      });
+
+      return { artifact, created: true };
+    },
+    { isolationLevel: "Serializable" },
+  );
+}
+
+function isSameUploadDeclaration(
+  artifact: {
+    platform: GamePlatform;
+    architecture: GameArchitecture;
+    archive_format: GameArchiveFormat;
+    compressed_size_bytes: bigint | null;
+    installed_size_bytes: bigint | null;
+    sha256: string | null;
+    manifest: Prisma.JsonValue | null;
+    status: GameArtifactStatus;
+  },
+  data: GameArtifactUploadDto,
+) {
+  if (!artifact.manifest || typeof artifact.manifest !== "object") return false;
+  if (Array.isArray(artifact.manifest)) return false;
+  const manifestInput = { ...artifact.manifest };
+  delete manifestInput.release_id;
+  delete manifestInput.artifact_id;
+
+  return (
+    artifact.status === GameArtifactStatus.PENDING &&
+    artifact.platform === data.platform &&
+    artifact.architecture === data.architecture &&
+    artifact.archive_format === data.archive_format &&
+    artifact.compressed_size_bytes?.toString() === data.compressed_size_bytes &&
+    artifact.installed_size_bytes?.toString() === data.installed_size_bytes &&
+    artifact.sha256 === data.sha256 &&
+    isDeepStrictEqual(manifestInput, data.manifest)
+  );
+}
+
+function isRetryableTransactionError(error: unknown) {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error.code === "P2002" || error.code === "P2034")
+  );
+}
 
 async function createPending(input: GameArtifactCreateDto) {
   const data = gameArtifactCreateSchema.parse(input);
@@ -225,6 +404,7 @@ function invalidTransition(
 }
 
 const gameArtifact = {
+  initiateUpload,
   createPending,
   findById,
   markVerifying,

--- a/models/studio.ts
+++ b/models/studio.ts
@@ -22,6 +22,7 @@ export const MEMBER_PERMISSIONS = [
   "update:game",
   "create:game_file",
   "delete:game_file",
+  "create:game_artifact",
   "read:game_price",
   "update:game_price",
   // Sales of the studio's games. Delegable like the rest: someone can be given

--- a/pages/api/v1/releases/[release_id]/artifacts/upload-url/index.ts
+++ b/pages/api/v1/releases/[release_id]/artifacts/upload-url/index.ts
@@ -1,0 +1,74 @@
+import { createRouter } from "next-connect";
+import { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import controller from "infra/controller";
+import { ForbiddenError, NotFoundError, ValidationError } from "infra/errors";
+import authorization from "models/authorization";
+import game from "models/game";
+import gameArtifact, { gameArtifactUploadSchema } from "models/game_artifact";
+import gameRelease from "models/game_release";
+
+const querySchema = z.object({ release_id: z.uuid() });
+
+export default createRouter<NextApiRequest, NextApiResponse>()
+  .use(controller.injectAnonymousOrUser)
+  .post(
+    controller.requireAuthentication,
+    controller.canRequest("create:game_artifact"),
+    postHandler,
+  )
+  .handler(controller.errorHandlers);
+
+async function postHandler(req: NextApiRequest, res: NextApiResponse) {
+  const query = querySchema.safeParse(req.query);
+  if (!query.success) {
+    throw new ValidationError({
+      message: "Invalid release id",
+      action: "Check the URL and try again",
+      cause: query.error,
+    });
+  }
+
+  const release = await gameRelease.findById(query.data.release_id);
+  const gameResource = await game.findOneByIdWithStudio(release.game_id);
+  if (!gameResource) {
+    throw new NotFoundError({
+      message: "The release's game was not found",
+      action: "Check the release and try again",
+    });
+  }
+
+  if (
+    !authorization.can(req.context.user, "create:game_artifact", gameResource)
+  ) {
+    throw new ForbiddenError({
+      message: "You are not allowed to upload artifacts for this game",
+      action: "Use a studio owner or member with artifact upload permission",
+    });
+  }
+
+  const body = gameArtifactUploadSchema.safeParse(req.body);
+  if (!body.success) {
+    throw new ValidationError({
+      message: "Invalid artifact upload declaration",
+      action: "Check the target, sizes, SHA-256 and manifest",
+      cause: body.error,
+    });
+  }
+
+  const result = await gameArtifact.initiateUpload(
+    release.id,
+    req.context.user.id,
+    body.data,
+  );
+  const artifact = authorization.filterOutput(
+    req.context.user,
+    "create:game_artifact",
+    result.artifact,
+  );
+
+  return res.status(result.created ? 201 : 200).json({
+    artifact,
+    upload: result.upload,
+  });
+}

--- a/prisma/migrations/20260819220000_add_artifact_upload_actor/migration.sql
+++ b/prisma/migrations/20260819220000_add_artifact_upload_actor/migration.sql
@@ -1,0 +1,16 @@
+-- Record the authenticated publisher who initiated each direct artifact upload.
+-- Nullable keeps existing pending artifacts deployable; the new upload workflow
+-- always supplies this value.
+ALTER TABLE "game_artifacts" ADD COLUMN "created_by_user_id" TEXT;
+
+-- Existing activated studio owners need the route-level feature gate that new
+-- owners receive from MEMBER_PERMISSIONS. Members do not gain this new
+-- publishing capability implicitly; an owner must grant it explicitly.
+UPDATE "users"
+SET
+  "features" = array_append("features", 'create:game_artifact'),
+  "updated_at" = CURRENT_TIMESTAMP
+WHERE
+  "id" IN (SELECT "owner_id" FROM "studios")
+  AND "features" @> ARRAY['update:user']::TEXT[]
+  AND NOT "features" @> ARRAY['create:game_artifact']::TEXT[];

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -256,6 +256,7 @@ model GameArtifact {
   architecture            GameArchitecture
   archive_format          GameArchiveFormat
   storage_object_key      String             @unique @db.VarChar(1024)
+  created_by_user_id      String? // Logical reference to the publisher User who initiated the upload
   compressed_size_bytes   BigInt?
   installed_size_bytes    BigInt?
   sha256                  String?            @db.Char(64)

--- a/tests/integration/api/v1/releases/[release_id]/artifacts/upload-url/post.test.ts
+++ b/tests/integration/api/v1/releases/[release_id]/artifacts/upload-url/post.test.ts
@@ -1,0 +1,172 @@
+import { createHash } from "node:crypto";
+import webserver from "infra/webserver";
+import gameRelease from "models/game_release";
+import orchestrator from "tests/orchestrator";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+  await orchestrator.clearStorage();
+});
+
+beforeEach(async () => {
+  await orchestrator.clearDatabaseRows();
+});
+
+describe("POST /api/v1/releases/[release_id]/artifacts/upload-url", () => {
+  test("requires the existing session cookie", async () => {
+    const response = await fetch(
+      `${webserver.getOrigin()}/api/v1/releases/11111111-1111-4111-8111-111111111111/artifacts/upload-url`,
+      { method: "POST" },
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({
+      name: "UnauthorizedError",
+      action: "Sign in and send the session_id cookie",
+    });
+  });
+
+  test("rejects an authenticated user who does not control the game", async () => {
+    const { release } = await createRelease();
+    const attacker = await orchestrator.createUser();
+    await orchestrator.activateUser(attacker.id);
+    await orchestrator.addFeaturesToUser(attacker.id, ["create:game_artifact"]);
+    const session = await orchestrator.createSession(attacker.id);
+
+    const response = await requestUpload(
+      release.id,
+      session.token,
+      artifactDeclaration(Buffer.from("not-a-zip")),
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      name: "ForbiddenError",
+      message: "You are not allowed to upload artifacts for this game",
+    });
+  });
+
+  test("creates one pending artifact and reuses it on an identical retry", async () => {
+    const { owner, game, release } = await createRelease();
+    const session = await orchestrator.createSession(owner.id);
+    const archive = Buffer.from("small-windows-x64-zip-fixture");
+    const declaration = artifactDeclaration(archive);
+
+    const firstResponse = await requestUpload(
+      release.id,
+      session.token,
+      declaration,
+    );
+    expect(firstResponse.status).toBe(201);
+    const first = await firstResponse.json();
+
+    expect(first.artifact).toMatchObject({
+      release_id: release.id,
+      platform: "WINDOWS",
+      architecture: "X86_64",
+      archive_format: "ZIP",
+      compressed_size_bytes: archive.byteLength.toString(),
+      installed_size_bytes: "4096",
+      sha256: declaration.sha256,
+      status: "PENDING",
+    });
+    expect(first.artifact).not.toHaveProperty("storage_object_key");
+    expect(first.artifact).not.toHaveProperty("created_by_user_id");
+    expect(first.upload.url).toContain("http://");
+    expect(new Date(first.upload.expires_at).getTime()).toBeGreaterThan(
+      Date.now(),
+    );
+    expect(first.upload.required_headers).toEqual({
+      "content-type": "application/zip",
+      "x-amz-checksum-sha256": Buffer.from(declaration.sha256, "hex").toString(
+        "base64",
+      ),
+      "x-amz-meta-artifact-id": first.artifact.id,
+      "x-amz-meta-declared-size-bytes": archive.byteLength.toString(),
+      "x-amz-meta-sha256": declaration.sha256,
+    });
+
+    const uploadResponse = await fetch(first.upload.url, {
+      method: "PUT",
+      headers: first.upload.required_headers,
+      body: archive,
+    });
+    expect(uploadResponse.status).toBe(200);
+
+    const retryResponse = await requestUpload(
+      release.id,
+      session.token,
+      declaration,
+    );
+    expect(retryResponse.status).toBe(200);
+    const retry = await retryResponse.json();
+    expect(retry.artifact.id).toBe(first.artifact.id);
+    expect(retry.upload.url).toContain(
+      `games/${game.id}/releases/${release.id}/artifacts/`,
+    );
+  });
+
+  test("rejects unsafe entrypoints and non-lowercase SHA-256 values", async () => {
+    const { owner, release } = await createRelease();
+    const session = await orchestrator.createSession(owner.id);
+    const declaration = artifactDeclaration(Buffer.from("archive"));
+
+    for (const invalid of [
+      { ...declaration, sha256: declaration.sha256.toUpperCase() },
+      {
+        ...declaration,
+        manifest: { ...declaration.manifest, entrypoint: "../game.exe" },
+      },
+    ]) {
+      const response = await requestUpload(release.id, session.token, invalid);
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({
+        name: "ValidationError",
+      });
+    }
+  });
+});
+
+async function createRelease() {
+  const owner = await orchestrator.createUser();
+  await orchestrator.activateUser(owner.id);
+  const game = await orchestrator.createGame(owner.id);
+  const release = await gameRelease.createDraft({
+    game_id: game.id,
+    version: "1.0.0",
+  });
+  return { owner, game, release };
+}
+
+function artifactDeclaration(archive: Buffer) {
+  return {
+    platform: "WINDOWS",
+    architecture: "X86_64",
+    archive_format: "ZIP",
+    compressed_size_bytes: archive.byteLength.toString(),
+    installed_size_bytes: "4096",
+    sha256: createHash("sha256").update(archive).digest("hex"),
+    manifest: {
+      schema_version: "1",
+      entrypoint: "game.exe",
+      launch_arguments: [],
+      executables: ["game.exe"],
+      environment: {},
+    },
+  };
+}
+
+function requestUpload(releaseId: string, sessionToken: string, body: unknown) {
+  return fetch(
+    `${webserver.getOrigin()}/api/v1/releases/${releaseId}/artifacts/upload-url`,
+    {
+      method: "POST",
+      headers: {
+        Cookie: `session_id=${sessionToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    },
+  );
+}

--- a/tests/integration/models/game_release.test.ts
+++ b/tests/integration/models/game_release.test.ts
@@ -8,6 +8,7 @@ import {
   GamePlatform,
 } from "generated/prisma/client";
 import storage from "infra/storage";
+import { prisma } from "infra/database";
 
 beforeAll(async () => {
   await orchestrator.waitForAllServices();
@@ -137,6 +138,76 @@ describe("immutable game release distribution model", () => {
     expect(corrected.id).not.toBe(incorrect.id);
 
     deleteFile.mockRestore();
+  });
+
+  test("initiates an idempotent direct upload with declared integrity metadata", async () => {
+    const owner = await orchestrator.createUser();
+    const game = await orchestrator.createGame(owner.id);
+    const release = await gameRelease.createDraft({
+      game_id: game.id,
+      version: "1.0.0",
+    });
+    const getUploadAuthorization = jest
+      .spyOn(storage, "getArtifactUploadAuthorization")
+      .mockResolvedValue({
+        url: "https://storage.test/signed-upload",
+        expires_at: "2026-08-19T23:00:00.000Z",
+        required_headers: { "content-type": "application/zip" },
+      });
+    const declaration = {
+      platform: GamePlatform.WINDOWS,
+      architecture: GameArchitecture.X86_64,
+      archive_format: GameArchiveFormat.ZIP,
+      compressed_size_bytes: "1024",
+      installed_size_bytes: "2048",
+      sha256: "a".repeat(64),
+      manifest: {
+        schema_version: "1" as const,
+        entrypoint: "game.exe",
+        launch_arguments: [],
+        executables: ["game.exe"],
+        environment: {},
+      },
+    };
+
+    const first = await gameArtifact.initiateUpload(
+      release.id,
+      owner.id,
+      declaration,
+    );
+    const retry = await gameArtifact.initiateUpload(
+      release.id,
+      owner.id,
+      declaration,
+    );
+
+    expect(first.created).toBe(true);
+    expect(retry.created).toBe(false);
+    expect(retry.artifact.id).toBe(first.artifact.id);
+    expect(first.artifact.status).toBe("PENDING");
+    expect(first.artifact.sha256).toBe(declaration.sha256);
+    expect(first.artifact.storage_object_key).toBe(
+      `games/${game.id}/releases/${release.id}/artifacts/${first.artifact.id}.zip`,
+    );
+    expect(getUploadAuthorization).toHaveBeenCalledTimes(2);
+
+    const persisted = await prisma.gameArtifact.findUniqueOrThrow({
+      where: { id: first.artifact.id },
+    });
+    expect(persisted.created_by_user_id).toBe(owner.id);
+    expect(persisted.compressed_size_bytes).toBe(BigInt(1024));
+
+    await expect(
+      gameArtifact.initiateUpload(release.id, owner.id, {
+        ...declaration,
+        sha256: "b".repeat(64),
+      }),
+    ).rejects.toMatchObject({
+      name: "ValidationError",
+      action: expect.stringContaining("Remove the unpublished artifact"),
+    });
+
+    getUploadAuthorization.mockRestore();
   });
 
   test("published release and artifact data cannot be changed", async () => {

--- a/tests/unit/infra/storage.test.ts
+++ b/tests/unit/infra/storage.test.ts
@@ -1,0 +1,41 @@
+import storage from "infra/storage";
+
+describe("artifact upload authorization", () => {
+  test("binds checksum, content type and declared metadata as signed headers", async () => {
+    const authorization = await storage.getArtifactUploadAuthorization({
+      key: "games/game/releases/release/artifacts/artifact.zip",
+      artifactId: "11111111-1111-4111-8111-111111111111",
+      archiveFormat: "ZIP",
+      compressedSizeBytes: "1024",
+      sha256: "a".repeat(64),
+    });
+    const url = new URL(authorization.url);
+    const signedHeaders =
+      url.searchParams.get("X-Amz-SignedHeaders")?.split(";") ?? [];
+
+    expect(signedHeaders).toEqual(
+      expect.arrayContaining([
+        "content-type",
+        "host",
+        "x-amz-checksum-sha256",
+        "x-amz-meta-artifact-id",
+        "x-amz-meta-declared-size-bytes",
+        "x-amz-meta-sha256",
+      ]),
+    );
+    expect(url.searchParams.has("x-amz-checksum-sha256")).toBe(false);
+    expect(
+      [...url.searchParams.keys()].some((key) => key.startsWith("x-amz-meta-")),
+    ).toBe(false);
+    expect(authorization.required_headers).toMatchObject({
+      "content-type": "application/zip",
+      "x-amz-checksum-sha256": Buffer.from("a".repeat(64), "hex").toString(
+        "base64",
+      ),
+      "x-amz-meta-declared-size-bytes": "1024",
+    });
+    expect(new Date(authorization.expires_at).getTime()).toBeGreaterThan(
+      Date.now(),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add the API-first `POST /api/v1/releases/:release_id/artifacts/upload-url` publisher endpoint
- authenticate with the existing `session_id` cookie and enforce studio-scoped artifact permissions
- persist a retry-safe pending artifact with declared sizes, lowercase SHA-256, manifest, storage key, actor identity, and timestamps
- issue a direct signed storage PUT with checksum and metadata headers, so artifact bytes do not pass through Vercel
- reuse the same artifact for identical retries and reject conflicting declarations until the unpublished artifact is removed
- backfill the new permission for existing activated studio owners

## Why

This is the first critical-path backend issue for the Desktop Integration MVP. Publishers need a safe direct-upload path before the backend can confirm, verify, and transactionally publish the first Windows x64 ZIP.

## Impact

The publisher can initiate a Windows/X86_64/ZIP upload and send it directly to object storage. The resulting pending artifact contains the integrity and manifest declarations required by the follow-up verification workflow.

## Validation

- Prisma generation and schema validation
- ESLint on all changed TypeScript files
- 39 unit tests
- production Next.js build
- integration coverage added for authentication, authorization, validation, idempotency, conflict handling, persistence, and direct storage PUT

The integration suite was not executed locally because Docker is not installed in the current environment; CI will run it with PostgreSQL and MinIO.

Closes #212