### PR TITLE
Verify uploads and publish game releases idempotently

### DIFF
--- a/infra/storage.ts
+++ b/infra/storage.ts
@@ -1,6 +1,7 @@
 import {
   S3Client,
   PutObjectCommand,
+  HeadObjectCommand,
   GetObjectCommand,
   DeleteObjectCommand,
   CreateBucketCommand,
@@ -9,7 +10,7 @@ import {
   ListObjectsCommand,
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
-import { InternalServerError } from "./errors";
+import { InternalServerError, ServiceError } from "./errors";
 import { GameArchiveFormat } from "generated/prisma/client";
 
 const s3Client = new S3Client({
@@ -57,6 +58,14 @@ export interface ArtifactUploadAuthorization {
   url: string;
   expires_at: string;
   required_headers: Record<string, string>;
+}
+
+export interface ArtifactObjectMetadata {
+  size_bytes: string;
+  checksum_sha256: string | null;
+  content_type: string | null;
+  etag: string | null;
+  metadata: Record<string, string>;
 }
 
 export async function getArtifactUploadAuthorization({
@@ -108,6 +117,59 @@ export async function getArtifactUploadAuthorization({
     ).toISOString(),
     required_headers: requiredHeaders,
   };
+}
+
+export async function getArtifactObjectMetadata(
+  key: string,
+): Promise<ArtifactObjectMetadata | null> {
+  try {
+    const object = await s3Client.send(
+      new HeadObjectCommand({
+        Bucket: bucketName,
+        Key: key,
+        ChecksumMode: "ENABLED",
+      }),
+    );
+
+    if (object.ContentLength === undefined) {
+      throw new ServiceError({
+        message: "Storage returned artifact metadata without a content length",
+        action: "Retry upload confirmation",
+      });
+    }
+
+    return {
+      size_bytes: object.ContentLength.toString(),
+      checksum_sha256: object.ChecksumSHA256 ?? null,
+      content_type: object.ContentType ?? null,
+      etag: object.ETag ?? null,
+      metadata: object.Metadata ?? {},
+    };
+  } catch (error) {
+    if (isMissingObjectError(error)) return null;
+    if (error instanceof ServiceError) throw error;
+
+    throw new ServiceError({
+      message: "Artifact metadata could not be read from storage",
+      cause: error,
+      action: "Retry upload confirmation",
+    });
+  }
+}
+
+function isMissingObjectError(error: unknown) {
+  if (!error || typeof error !== "object") return false;
+
+  const status =
+    "$metadata" in error &&
+    error.$metadata &&
+    typeof error.$metadata === "object" &&
+    "httpStatusCode" in error.$metadata
+      ? error.$metadata.httpStatusCode
+      : undefined;
+  const name = "name" in error ? error.name : undefined;
+
+  return status === 404 || name === "NotFound" || name === "NoSuchKey";
 }
 
 export async function getDownloadUrl(key: string): Promise<string> {
@@ -188,6 +250,7 @@ export async function createBucket(
 const storage = {
   getUploadUrl,
   getArtifactUploadAuthorization,
+  getArtifactObjectMetadata,
   getDownloadUrl,
   deleteFile,
   clearAllBuckets,

--- a/models/game_artifact.ts
+++ b/models/game_artifact.ts
@@ -5,6 +5,7 @@ import {
   GameArchiveFormat,
   GameArtifactStatus,
   GamePlatform,
+  GameReleaseStatus,
   Prisma,
 } from "generated/prisma/client";
 import {
@@ -13,7 +14,7 @@ import {
   sha256Schema,
 } from "contracts/desktop/v1";
 import gameRelease from "models/game_release";
-import storage from "infra/storage";
+import storage, { type ArtifactObjectMetadata } from "infra/storage";
 import { z } from "zod";
 import { randomUUID } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
@@ -60,6 +61,11 @@ export type GameArtifactUploadDto = z.infer<typeof gameArtifactUploadSchema>;
 const archiveExtensions: Record<GameArchiveFormat, string> = {
   ZIP: "zip",
   TAR_GZ: "tar.gz",
+};
+
+const archiveContentTypes: Record<GameArchiveFormat, string> = {
+  ZIP: "application/zip",
+  TAR_GZ: "application/gzip",
 };
 
 async function initiateUpload(
@@ -176,6 +182,328 @@ async function createUploadArtifact(
     },
     { isolationLevel: "Serializable" },
   );
+}
+
+async function confirmUpload(id: string) {
+  const artifactId = z.uuid().parse(id);
+  const claimed = await claimVerification(artifactId);
+
+  if (claimed.already_published) {
+    return {
+      artifact: serialize(claimed.artifact),
+      release: claimed.release,
+      published: true,
+    };
+  }
+
+  if (claimed.needs_verification) {
+    try {
+      const object = await storage.getArtifactObjectMetadata(
+        claimed.artifact.storage_object_key,
+      );
+      validateStoredArtifact(claimed.artifact, object);
+    } catch (error) {
+      if (error instanceof ValidationError) {
+        await failVerification(artifactId);
+      }
+      throw error;
+    }
+  }
+
+  return finalizeVerificationAndPublication(artifactId);
+}
+
+async function claimVerification(id: string) {
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    try {
+      return await prisma.$transaction(
+        async (tx) => {
+          const artifact = await tx.gameArtifact.findUnique({ where: { id } });
+          if (!artifact) throw artifactNotFound(id);
+          const release = await tx.gameRelease.findUnique({
+            where: { id: artifact.release_id },
+          });
+          if (!release) {
+            throw new NotFoundError({
+              message: `Release "${artifact.release_id}" was not found.`,
+              action: "Check the artifact's release reference.",
+            });
+          }
+
+          if (
+            artifact.status === GameArtifactStatus.READY &&
+            release.status === GameReleaseStatus.PUBLISHED
+          ) {
+            return {
+              artifact,
+              release,
+              needs_verification: false,
+              already_published: true,
+            };
+          }
+
+          gameRelease.assertReleaseMutable(release);
+
+          const needsVerification =
+            artifact.status !== GameArtifactStatus.READY;
+          if (
+            artifact.status !== GameArtifactStatus.PENDING &&
+            artifact.status !== GameArtifactStatus.FAILED &&
+            artifact.status !== GameArtifactStatus.VERIFYING &&
+            artifact.status !== GameArtifactStatus.READY
+          ) {
+            throw invalidTransition(
+              artifact.id,
+              artifact.status,
+              GameArtifactStatus.READY,
+            );
+          }
+
+          const claimedArtifact =
+            artifact.status === GameArtifactStatus.PENDING ||
+            artifact.status === GameArtifactStatus.FAILED
+              ? await tx.gameArtifact.update({
+                  where: { id },
+                  data: { status: GameArtifactStatus.VERIFYING },
+                })
+              : artifact;
+
+          const processingRelease =
+            release.status === GameReleaseStatus.DRAFT ||
+            release.status === GameReleaseStatus.FAILED
+              ? await tx.gameRelease.update({
+                  where: { id: release.id },
+                  data: { status: GameReleaseStatus.PROCESSING },
+                })
+              : release;
+
+          return {
+            artifact: claimedArtifact,
+            release: processingRelease,
+            needs_verification: needsVerification,
+            already_published: false,
+          };
+        },
+        { isolationLevel: "Serializable" },
+      );
+    } catch (error) {
+      if (attempt < 3 && isRetryableTransactionError(error)) continue;
+      throw error;
+    }
+  }
+
+  throw new Error("Unreachable artifact verification claim state");
+}
+
+function validateStoredArtifact(
+  artifact: {
+    id: string;
+    release_id: string;
+    archive_format: GameArchiveFormat;
+    compressed_size_bytes: bigint | null;
+    installed_size_bytes: bigint | null;
+    sha256: string | null;
+    manifest_schema_version: string | null;
+    manifest: Prisma.JsonValue | null;
+  },
+  object: ArtifactObjectMetadata | null,
+) {
+  if (!object) {
+    throw verificationError(
+      artifact.id,
+      "The uploaded artifact was not found in storage.",
+    );
+  }
+  if (
+    !artifact.compressed_size_bytes ||
+    !artifact.installed_size_bytes ||
+    !artifact.sha256 ||
+    !artifact.manifest_schema_version
+  ) {
+    throw verificationError(
+      artifact.id,
+      "The artifact is missing required declared integrity metadata.",
+    );
+  }
+
+  const declaredSize = artifact.compressed_size_bytes.toString();
+  const expectedChecksum = Buffer.from(artifact.sha256, "hex").toString(
+    "base64",
+  );
+  const mismatches: string[] = [];
+
+  if (object.size_bytes !== declaredSize) mismatches.push("compressed size");
+  if (object.checksum_sha256 !== expectedChecksum) mismatches.push("SHA-256");
+  if (object.content_type !== archiveContentTypes[artifact.archive_format]) {
+    mismatches.push("archive content type");
+  }
+  if (object.metadata["artifact-id"] !== artifact.id) {
+    mismatches.push("artifact identity metadata");
+  }
+  if (object.metadata["declared-size-bytes"] !== declaredSize) {
+    mismatches.push("declared size metadata");
+  }
+  if (object.metadata.sha256 !== artifact.sha256) {
+    mismatches.push("SHA-256 metadata");
+  }
+
+  if (mismatches.length > 0) {
+    throw verificationError(
+      artifact.id,
+      `Storage verification failed for: ${mismatches.join(", ")}.`,
+    );
+  }
+
+  const manifest = installManifestSchema.safeParse(artifact.manifest);
+  if (
+    !manifest.success ||
+    manifest.data.release_id !== artifact.release_id ||
+    manifest.data.artifact_id !== artifact.id ||
+    manifest.data.schema_version !== artifact.manifest_schema_version
+  ) {
+    throw verificationError(
+      artifact.id,
+      "The persisted install manifest is invalid or belongs to another artifact.",
+      manifest.success ? undefined : manifest.error,
+    );
+  }
+}
+
+async function failVerification(id: string) {
+  await prisma.$transaction(
+    async (tx) => {
+      const artifact = await tx.gameArtifact.findUnique({ where: { id } });
+      if (!artifact || artifact.status !== GameArtifactStatus.VERIFYING) return;
+
+      await tx.gameArtifact.update({
+        where: { id },
+        data: { status: GameArtifactStatus.FAILED },
+      });
+      await tx.gameRelease.updateMany({
+        where: {
+          id: artifact.release_id,
+          status: GameReleaseStatus.PROCESSING,
+        },
+        data: { status: GameReleaseStatus.FAILED },
+      });
+    },
+    { isolationLevel: "Serializable" },
+  );
+}
+
+async function finalizeVerificationAndPublication(id: string) {
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    try {
+      const result = await prisma.$transaction(
+        async (tx) => {
+          const artifact = await tx.gameArtifact.findUnique({
+            where: { id },
+          });
+          if (!artifact) throw artifactNotFound(id);
+          const release = await tx.gameRelease.findUnique({
+            where: { id: artifact.release_id },
+          });
+          if (!release) {
+            throw new NotFoundError({
+              message: `Release "${artifact.release_id}" was not found.`,
+              action: "Check the artifact's release reference.",
+            });
+          }
+
+          if (
+            artifact.status === GameArtifactStatus.READY &&
+            release.status === GameReleaseStatus.PUBLISHED
+          ) {
+            return { artifact, release, published: true };
+          }
+          gameRelease.assertReleaseMutable(release);
+          if (
+            artifact.status !== GameArtifactStatus.VERIFYING &&
+            artifact.status !== GameArtifactStatus.READY
+          ) {
+            throw invalidTransition(
+              artifact.id,
+              artifact.status,
+              GameArtifactStatus.READY,
+            );
+          }
+
+          const manifest = installManifestSchema.safeParse(artifact.manifest);
+          if (
+            !manifest.success ||
+            manifest.data.release_id !== artifact.release_id ||
+            manifest.data.artifact_id !== artifact.id ||
+            manifest.data.schema_version !== artifact.manifest_schema_version
+          ) {
+            throw verificationError(
+              artifact.id,
+              "The persisted install manifest is invalid or belongs to another artifact.",
+              manifest.success ? undefined : manifest.error,
+            );
+          }
+
+          const readyArtifact =
+            artifact.status === GameArtifactStatus.READY
+              ? artifact
+              : await tx.gameArtifact.update({
+                  where: { id },
+                  data: { status: GameArtifactStatus.READY },
+                });
+          const incompleteArtifacts = await tx.gameArtifact.count({
+            where: {
+              release_id: release.id,
+              id: { not: id },
+              status: { not: GameArtifactStatus.READY },
+            },
+          });
+
+          if (incompleteArtifacts > 0) {
+            const processingRelease =
+              release.status === GameReleaseStatus.PROCESSING
+                ? release
+                : await tx.gameRelease.update({
+                    where: { id: release.id },
+                    data: { status: GameReleaseStatus.PROCESSING },
+                  });
+            return {
+              artifact: readyArtifact,
+              release: processingRelease,
+              published: false,
+            };
+          }
+
+          const publishedRelease = await tx.gameRelease.update({
+            where: { id: release.id },
+            data: {
+              status: GameReleaseStatus.PUBLISHED,
+              published_at: release.published_at ?? new Date(),
+            },
+          });
+          return {
+            artifact: readyArtifact,
+            release: publishedRelease,
+            published: true,
+          };
+        },
+        { isolationLevel: "Serializable" },
+      );
+
+      return { ...result, artifact: serialize(result.artifact) };
+    } catch (error) {
+      if (attempt < 3 && isRetryableTransactionError(error)) continue;
+      throw error;
+    }
+  }
+
+  throw new Error("Unreachable artifact confirmation state");
+}
+
+function verificationError(id: string, message: string, cause?: unknown) {
+  return new ValidationError({
+    message,
+    cause,
+    action: `Correct or replace artifact "${id}", then retry confirmation.`,
+  });
 }
 
 function isSameUploadDeclaration(
@@ -405,6 +733,7 @@ function invalidTransition(
 
 const gameArtifact = {
   initiateUpload,
+  confirmUpload,
   createPending,
   findById,
   markVerifying,

--- a/models/game_release.ts
+++ b/models/game_release.ts
@@ -121,6 +121,9 @@ async function publish(id: string) {
     async (tx) => {
       const release = await tx.gameRelease.findUnique({ where: { id } });
       if (!release) throw releaseNotFound(id);
+      if (release.status === GameReleaseStatus.PUBLISHED) {
+        return release;
+      }
       if (release.status !== GameReleaseStatus.PROCESSING) {
         throw invalidTransition(
           id,

--- a/pages/api/v1/artifacts/[artifact_id]/confirm/index.ts
+++ b/pages/api/v1/artifacts/[artifact_id]/confirm/index.ts
@@ -1,0 +1,72 @@
+import { createRouter } from "next-connect";
+import { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import controller from "infra/controller";
+import { ForbiddenError, NotFoundError, ValidationError } from "infra/errors";
+import authorization from "models/authorization";
+import game from "models/game";
+import gameArtifact from "models/game_artifact";
+import gameRelease from "models/game_release";
+
+const querySchema = z.object({ artifact_id: z.uuid() });
+
+export default createRouter<NextApiRequest, NextApiResponse>()
+  .use(controller.injectAnonymousOrUser)
+  .post(
+    controller.requireAuthentication,
+    controller.canRequest("create:game_artifact"),
+    postHandler,
+  )
+  .handler(controller.errorHandlers);
+
+async function postHandler(req: NextApiRequest, res: NextApiResponse) {
+  const query = querySchema.safeParse(req.query);
+  if (!query.success) {
+    throw new ValidationError({
+      message: "Invalid artifact id",
+      action: "Check the URL and try again",
+      cause: query.error,
+    });
+  }
+
+  const artifact = await gameArtifact.findById(query.data.artifact_id);
+  const release = await gameRelease.findById(artifact.release_id);
+  const gameResource = await game.findOneByIdWithStudio(release.game_id);
+  if (!gameResource) {
+    throw new NotFoundError({
+      message: "The artifact's game was not found",
+      action: "Check the artifact and try again",
+    });
+  }
+
+  if (
+    !authorization.can(req.context.user, "create:game_artifact", gameResource)
+  ) {
+    throw new ForbiddenError({
+      message: "You are not allowed to publish artifacts for this game",
+      action: "Use a studio owner or member with artifact upload permission",
+    });
+  }
+
+  const result = await gameArtifact.confirmUpload(artifact.id);
+  const filteredArtifact = authorization.filterOutput(
+    req.context.user,
+    "create:game_artifact",
+    result.artifact,
+  );
+
+  return res.status(200).json({
+    artifact: filteredArtifact,
+    release: {
+      id: result.release.id,
+      game_id: result.release.game_id,
+      version: result.release.version,
+      release_number: result.release.release_number,
+      status: result.release.status,
+      published_at: result.release.published_at,
+      created_at: result.release.created_at,
+      updated_at: result.release.updated_at,
+    },
+    published: result.published,
+  });
+}

--- a/tests/integration/api/v1/artifacts/[artifact_id]/confirm/post.test.ts
+++ b/tests/integration/api/v1/artifacts/[artifact_id]/confirm/post.test.ts
@@ -1,0 +1,222 @@
+import { createHash } from "node:crypto";
+import webserver from "infra/webserver";
+import gameArtifact from "models/game_artifact";
+import gameRelease from "models/game_release";
+import orchestrator from "tests/orchestrator";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+  await orchestrator.clearStorage();
+});
+
+beforeEach(async () => {
+  await orchestrator.clearDatabaseRows();
+});
+
+describe("POST /api/v1/artifacts/[artifact_id]/confirm", () => {
+  test("requires the existing session cookie", async () => {
+    const response = await fetch(
+      `${webserver.getOrigin()}/api/v1/artifacts/11111111-1111-4111-8111-111111111111/confirm`,
+      { method: "POST" },
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({
+      name: "UnauthorizedError",
+      action: "Sign in and send the session_id cookie",
+    });
+  });
+
+  test("rejects a publisher who does not control the artifact's game", async () => {
+    const { owner, release } = await createReleaseValues();
+    const ownerSession = await orchestrator.createSession(owner.id);
+    const initiated = await initiateThroughApi(
+      release.id,
+      ownerSession.token,
+      artifactDeclaration(Buffer.from("archive")),
+    );
+    const attacker = await orchestrator.createUser();
+    await orchestrator.activateUser(attacker.id);
+    await orchestrator.addFeaturesToUser(attacker.id, ["create:game_artifact"]);
+    const attackerSession = await orchestrator.createSession(attacker.id);
+
+    const response = await requestConfirmation(
+      initiated.artifact.id,
+      attackerSession.token,
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      name: "ForbiddenError",
+      message: "You are not allowed to publish artifacts for this game",
+    });
+  });
+
+  test("verifies the direct upload, publishes, and returns the same result on retry", async () => {
+    const { owner, release } = await createReleaseValues();
+    const session = await orchestrator.createSession(owner.id);
+    const archive = Buffer.from("small-windows-x64-zip-fixture");
+    const initiated = await initiateThroughApi(
+      release.id,
+      session.token,
+      artifactDeclaration(archive),
+    );
+
+    const uploadResponse = await fetch(initiated.upload.url, {
+      method: "PUT",
+      headers: initiated.upload.required_headers,
+      body: archive,
+    });
+    expect(uploadResponse.status).toBe(200);
+
+    const confirmationResponse = await requestConfirmation(
+      initiated.artifact.id,
+      session.token,
+    );
+    expect(confirmationResponse.status).toBe(200);
+    const confirmation = await confirmationResponse.json();
+    expect(confirmation).toMatchObject({
+      artifact: {
+        id: initiated.artifact.id,
+        status: "READY",
+      },
+      release: {
+        id: release.id,
+        status: "PUBLISHED",
+      },
+      published: true,
+    });
+    expect(confirmation.artifact).not.toHaveProperty("storage_object_key");
+    expect(confirmation.artifact).not.toHaveProperty("created_by_user_id");
+    expect(confirmation.release.published_at).toEqual(expect.any(String));
+
+    const retryResponse = await requestConfirmation(
+      initiated.artifact.id,
+      session.token,
+    );
+    expect(retryResponse.status).toBe(200);
+    const retry = await retryResponse.json();
+    expect(retry.artifact.id).toBe(confirmation.artifact.id);
+    expect(retry.release.published_at).toBe(confirmation.release.published_at);
+  });
+
+  test("marks a missing upload as failed without publishing", async () => {
+    const { owner, release } = await createReleaseValues();
+    const session = await orchestrator.createSession(owner.id);
+    const initiated = await initiateThroughApi(
+      release.id,
+      session.token,
+      artifactDeclaration(Buffer.from("missing")),
+    );
+
+    const response = await requestConfirmation(
+      initiated.artifact.id,
+      session.token,
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      name: "ValidationError",
+      message: expect.stringContaining("not found"),
+    });
+    await expect(
+      gameArtifact.findById(initiated.artifact.id),
+    ).resolves.toMatchObject({ status: "FAILED" });
+    await expect(gameRelease.findById(release.id)).resolves.toMatchObject({
+      status: "FAILED",
+      published_at: null,
+    });
+  });
+
+  test("rejects an uploaded object whose real size differs from its declaration", async () => {
+    const { owner, release } = await createReleaseValues();
+    const session = await orchestrator.createSession(owner.id);
+    const archive = Buffer.from("actual-object");
+    const declaration = {
+      ...artifactDeclaration(archive),
+      compressed_size_bytes: (archive.byteLength + 1).toString(),
+    };
+    const initiated = await initiateThroughApi(
+      release.id,
+      session.token,
+      declaration,
+    );
+    const uploadResponse = await fetch(initiated.upload.url, {
+      method: "PUT",
+      headers: initiated.upload.required_headers,
+      body: archive,
+    });
+    expect(uploadResponse.status).toBe(200);
+
+    const response = await requestConfirmation(
+      initiated.artifact.id,
+      session.token,
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      name: "ValidationError",
+      message: expect.stringContaining("compressed size"),
+    });
+  });
+});
+
+async function createReleaseValues() {
+  const owner = await orchestrator.createUser();
+  await orchestrator.activateUser(owner.id);
+  const game = await orchestrator.createGame(owner.id);
+  const release = await gameRelease.createDraft({
+    game_id: game.id,
+    version: "1.0.0",
+  });
+  return { owner, game, release };
+}
+
+function artifactDeclaration(archive: Buffer) {
+  return {
+    platform: "WINDOWS",
+    architecture: "X86_64",
+    archive_format: "ZIP",
+    compressed_size_bytes: archive.byteLength.toString(),
+    installed_size_bytes: "4096",
+    sha256: createHash("sha256").update(archive).digest("hex"),
+    manifest: {
+      schema_version: "1",
+      entrypoint: "game.exe",
+      launch_arguments: [],
+      executables: ["game.exe"],
+      environment: {},
+    },
+  };
+}
+
+async function initiateThroughApi(
+  releaseId: string,
+  sessionToken: string,
+  body: unknown,
+) {
+  const response = await fetch(
+    `${webserver.getOrigin()}/api/v1/releases/${releaseId}/artifacts/upload-url`,
+    {
+      method: "POST",
+      headers: {
+        Cookie: `session_id=${sessionToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    },
+  );
+  expect(response.status).toBe(201);
+  return response.json();
+}
+
+function requestConfirmation(artifactId: string, sessionToken: string) {
+  return fetch(
+    `${webserver.getOrigin()}/api/v1/artifacts/${artifactId}/confirm`,
+    {
+      method: "POST",
+      headers: { Cookie: `session_id=${sessionToken}` },
+    },
+  );
+}

--- a/tests/integration/models/game_release.test.ts
+++ b/tests/integration/models/game_release.test.ts
@@ -210,6 +210,203 @@ describe("immutable game release distribution model", () => {
     getUploadAuthorization.mockRestore();
   });
 
+  test("verifies storage metadata and publishes atomically and idempotently", async () => {
+    const owner = await orchestrator.createUser();
+    const game = await orchestrator.createGame(owner.id);
+    const release = await gameRelease.createDraft({
+      game_id: game.id,
+      version: "1.0.0",
+    });
+    jest.spyOn(storage, "getArtifactUploadAuthorization").mockResolvedValue({
+      url: "https://storage.test/signed-upload",
+      expires_at: "2026-08-19T23:00:00.000Z",
+      required_headers: {},
+    });
+    const declaration = artifactUploadDeclaration();
+    const initiated = await gameArtifact.initiateUpload(
+      release.id,
+      owner.id,
+      declaration,
+    );
+    const getMetadata = jest
+      .spyOn(storage, "getArtifactObjectMetadata")
+      .mockResolvedValue(artifactObjectMetadata(initiated.artifact.id));
+
+    const confirmed = await gameArtifact.confirmUpload(initiated.artifact.id);
+    const retry = await gameArtifact.confirmUpload(initiated.artifact.id);
+
+    expect(confirmed.artifact.status).toBe("READY");
+    expect(confirmed.release.status).toBe("PUBLISHED");
+    expect(confirmed.published).toBe(true);
+    expect(retry.artifact.id).toBe(confirmed.artifact.id);
+    expect(retry.release.published_at).toEqual(confirmed.release.published_at);
+    expect(getMetadata).toHaveBeenCalledTimes(1);
+
+    const directPublishRetry = await gameRelease.publish(release.id);
+    expect(directPublishRetry.published_at).toEqual(
+      confirmed.release.published_at,
+    );
+
+    jest.restoreAllMocks();
+  });
+
+  test("waits for every artifact before publishing the release", async () => {
+    const owner = await orchestrator.createUser();
+    const game = await orchestrator.createGame(owner.id);
+    const release = await gameRelease.createDraft({
+      game_id: game.id,
+      version: "1.0.0",
+    });
+    jest.spyOn(storage, "getArtifactUploadAuthorization").mockResolvedValue({
+      url: "https://storage.test/signed-upload",
+      expires_at: "2026-08-19T23:00:00.000Z",
+      required_headers: {},
+    });
+    const x64 = await gameArtifact.initiateUpload(
+      release.id,
+      owner.id,
+      artifactUploadDeclaration(),
+    );
+    const arm64 = await gameArtifact.initiateUpload(release.id, owner.id, {
+      ...artifactUploadDeclaration(),
+      architecture: GameArchitecture.AARCH64,
+    });
+    jest
+      .spyOn(storage, "getArtifactObjectMetadata")
+      .mockImplementation(async (key) => {
+        const artifactId = key.includes(x64.artifact.id)
+          ? x64.artifact.id
+          : arm64.artifact.id;
+        return artifactObjectMetadata(artifactId);
+      });
+
+    const first = await gameArtifact.confirmUpload(x64.artifact.id);
+    expect(first.artifact.status).toBe("READY");
+    expect(first.release.status).toBe("PROCESSING");
+    expect(first.published).toBe(false);
+
+    const second = await gameArtifact.confirmUpload(arm64.artifact.id);
+    expect(second.artifact.status).toBe("READY");
+    expect(second.release.status).toBe("PUBLISHED");
+    expect(second.published).toBe(true);
+
+    jest.restoreAllMocks();
+  });
+
+  test("marks verification failures and permits a corrected retry", async () => {
+    const owner = await orchestrator.createUser();
+    const game = await orchestrator.createGame(owner.id);
+    const release = await gameRelease.createDraft({
+      game_id: game.id,
+      version: "1.0.0",
+    });
+    jest.spyOn(storage, "getArtifactUploadAuthorization").mockResolvedValue({
+      url: "https://storage.test/signed-upload",
+      expires_at: "2026-08-19T23:00:00.000Z",
+      required_headers: {},
+    });
+    const initiated = await gameArtifact.initiateUpload(
+      release.id,
+      owner.id,
+      artifactUploadDeclaration(),
+    );
+    const getMetadata = jest
+      .spyOn(storage, "getArtifactObjectMetadata")
+      .mockResolvedValue({
+        ...artifactObjectMetadata(initiated.artifact.id),
+        size_bytes: "1023",
+      });
+
+    await expect(
+      gameArtifact.confirmUpload(initiated.artifact.id),
+    ).rejects.toMatchObject({
+      name: "ValidationError",
+      message: expect.stringContaining("compressed size"),
+    });
+    await expect(
+      gameArtifact.findById(initiated.artifact.id),
+    ).resolves.toMatchObject({ status: "FAILED" });
+    await expect(gameRelease.findById(release.id)).resolves.toMatchObject({
+      status: "FAILED",
+    });
+
+    getMetadata.mockResolvedValue({
+      ...artifactObjectMetadata(initiated.artifact.id),
+      checksum_sha256: Buffer.from("b".repeat(64), "hex").toString("base64"),
+    });
+    await expect(
+      gameArtifact.confirmUpload(initiated.artifact.id),
+    ).rejects.toMatchObject({
+      name: "ValidationError",
+      message: expect.stringContaining("SHA-256"),
+    });
+
+    getMetadata.mockResolvedValue(
+      artifactObjectMetadata(initiated.artifact.id),
+    );
+    const retried = await gameArtifact.confirmUpload(initiated.artifact.id);
+    expect(retried.artifact.status).toBe("READY");
+    expect(retried.release.status).toBe("PUBLISHED");
+
+    jest.restoreAllMocks();
+  });
+
+  test("rejects a missing object and an invalid persisted entrypoint", async () => {
+    const owner = await orchestrator.createUser();
+    const game = await orchestrator.createGame(owner.id);
+    const release = await gameRelease.createDraft({
+      game_id: game.id,
+      version: "1.0.0",
+    });
+    jest.spyOn(storage, "getArtifactUploadAuthorization").mockResolvedValue({
+      url: "https://storage.test/signed-upload",
+      expires_at: "2026-08-19T23:00:00.000Z",
+      required_headers: {},
+    });
+    const initiated = await gameArtifact.initiateUpload(
+      release.id,
+      owner.id,
+      artifactUploadDeclaration(),
+    );
+    const getMetadata = jest
+      .spyOn(storage, "getArtifactObjectMetadata")
+      .mockResolvedValue(null);
+
+    await expect(
+      gameArtifact.confirmUpload(initiated.artifact.id),
+    ).rejects.toMatchObject({
+      name: "ValidationError",
+      message: expect.stringContaining("not found"),
+    });
+
+    await prisma.gameArtifact.update({
+      where: { id: initiated.artifact.id },
+      data: {
+        manifest: {
+          schema_version: "1",
+          release_id: release.id,
+          artifact_id: initiated.artifact.id,
+          entrypoint: "../game.exe",
+          launch_arguments: [],
+          executables: [],
+          environment: {},
+        },
+      },
+    });
+    getMetadata.mockResolvedValue(
+      artifactObjectMetadata(initiated.artifact.id),
+    );
+
+    await expect(
+      gameArtifact.confirmUpload(initiated.artifact.id),
+    ).rejects.toMatchObject({
+      name: "ValidationError",
+      message: expect.stringContaining("manifest"),
+    });
+
+    jest.restoreAllMocks();
+  });
+
   test("published release and artifact data cannot be changed", async () => {
     const owner = await orchestrator.createUser();
     const game = await orchestrator.createGame(owner.id);
@@ -350,4 +547,37 @@ async function makeArtifactReady(
       environment: {},
     },
   });
+}
+
+function artifactUploadDeclaration() {
+  return {
+    platform: GamePlatform.WINDOWS,
+    architecture: GameArchitecture.X86_64,
+    archive_format: GameArchiveFormat.ZIP,
+    compressed_size_bytes: "1024",
+    installed_size_bytes: "2048",
+    sha256: "a".repeat(64),
+    manifest: {
+      schema_version: "1" as const,
+      entrypoint: "game.exe",
+      launch_arguments: [],
+      executables: ["game.exe"],
+      environment: {},
+    },
+  };
+}
+
+function artifactObjectMetadata(artifactId: string) {
+  const sha256 = "a".repeat(64);
+  return {
+    size_bytes: "1024",
+    checksum_sha256: Buffer.from(sha256, "hex").toString("base64"),
+    content_type: "application/zip",
+    etag: '"etag"',
+    metadata: {
+      "artifact-id": artifactId,
+      "declared-size-bytes": "1024",
+      sha256,
+    },
+  };
 }


### PR DESCRIPTION
## Summary

- add the API-first `POST /api/v1/artifacts/:artifact_id/confirm` publisher endpoint
- authenticate with the existing `session_id` cookie and enforce studio-scoped artifact permission
- verify uploaded objects with storage `HEAD` metadata rather than downloading archives through Vercel
- compare actual compressed size, provider-recorded SHA-256, content type, artifact identity, and signed upload metadata against the persisted declaration
- revalidate the versioned manifest and safe entrypoint path before readiness
- make failed verification retryable and publication idempotent
- atomically mark the final artifact `READY` and its release `PUBLISHED`
- keep multi-artifact releases unpublished until every artifact is ready

## Why

The desktop delivery APIs must never expose an artifact that has only been declared by a publisher. This workflow creates the integrity boundary between a direct upload and an installable immutable release without sending multi-gigabyte ZIP files through Vercel.

## Desktop impact

Once this is deployed and one Windows x64 ZIP is confirmed:

- Desktop can safely resolve only immutable, published releases in the upcoming latest-release endpoint.
- The manifest can be treated as the verified installation instruction set.
- The download endpoint can return the persisted lowercase SHA-256 and size for client-side verification.
- Desktop can download directly from storage, verify the archive, extract it, confirm the executable entrypoint, register the installation, and enable **Jogar**.
- Failed or incomplete uploads remain invisible to Desktop.

This PR establishes the publication gate; issues #214, #215, and #216 expose the published data to Desktop.

## Validation

- ESLint on all changed TypeScript files
- Prisma schema validation
- 39 unit tests
- production Next.js build
- integration coverage for cookie authentication, ownership, real direct upload, storage `HEAD`, missing objects, size/checksum mismatches, invalid manifests, multi-artifact gating, and idempotent retries

The Docker-backed PostgreSQL/MinIO integration suite could not run locally because Docker is unavailable in this environment; CI will execute it.

Closes #213