### PR TITLE
feat: expose latest compatible game release

### DIFF
--- a/infra/distribution_api.ts
+++ b/infra/distribution_api.ts
@@ -1,0 +1,105 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import {
+  desktopErrorCodeSchema,
+  desktopErrorSchema,
+} from "contracts/desktop/v1";
+import controller from "infra/controller";
+import {
+  ForbiddenError,
+  MethodNotAllowedError,
+  NotFoundError,
+  RateLimitError,
+  ServiceError,
+  UnauthorizedError,
+  ValidationError,
+} from "infra/errors";
+
+type DistributionErrorCode = z.infer<typeof desktopErrorCodeSchema>;
+type DistributionError = Error & {
+  statusCode?: number;
+  distributionErrorCode?: DistributionErrorCode;
+};
+
+function withErrorCode<T extends Error>(
+  error: T,
+  code: DistributionErrorCode,
+): T {
+  return Object.assign(error, { distributionErrorCode: code });
+}
+
+function onNoMatch(_req: NextApiRequest, res: NextApiResponse) {
+  const error = new MethodNotAllowedError();
+  return sendError(res, error.statusCode, "INVALID_REQUEST", error.message);
+}
+
+function onError(
+  error: DistributionError,
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (error instanceof UnauthorizedError) {
+    controller.clearSessionCookie(res);
+  }
+
+  const isKnownError =
+    error instanceof ValidationError ||
+    error instanceof NotFoundError ||
+    error instanceof ForbiddenError ||
+    error instanceof UnauthorizedError ||
+    error instanceof RateLimitError ||
+    error instanceof ServiceError;
+
+  if (!isKnownError || error instanceof ServiceError) {
+    controller.logServerError(error, req);
+  }
+
+  const statusCode =
+    isKnownError && typeof error.statusCode === "number"
+      ? error.statusCode
+      : 500;
+  const code = error.distributionErrorCode ?? inferErrorCode(error);
+  const message = isKnownError ? error.message : "Service unavailable";
+  const retryable =
+    error instanceof RateLimitError ||
+    error instanceof ServiceError ||
+    !isKnownError;
+  const details =
+    error instanceof ValidationError && error.context !== undefined
+      ? { issues: error.context }
+      : undefined;
+
+  return sendError(res, statusCode, code, message, retryable, details);
+}
+
+function inferErrorCode(error: DistributionError): DistributionErrorCode {
+  if (error instanceof UnauthorizedError) return "AUTHENTICATION_REQUIRED";
+  if (error instanceof ForbiddenError) return "ENTITLEMENT_REQUIRED";
+  if (error instanceof RateLimitError) return "RATE_LIMITED";
+  if (error instanceof ServiceError) return "SERVICE_UNAVAILABLE";
+  if (error instanceof ValidationError || error instanceof NotFoundError) {
+    return "INVALID_REQUEST";
+  }
+  return "SERVICE_UNAVAILABLE";
+}
+
+function sendError(
+  res: NextApiResponse,
+  statusCode: number,
+  code: DistributionErrorCode,
+  message: string,
+  retryable = false,
+  details?: Record<string, unknown>,
+) {
+  const payload = desktopErrorSchema.parse({
+    error: { code, message, retryable, details },
+  });
+  return res.status(statusCode).json(payload);
+}
+
+const distributionApi = {
+  errorHandlers: { onError, onNoMatch },
+  withErrorCode,
+};
+
+export default distributionApi;

--- a/models/authorization.ts
+++ b/models/authorization.ts
@@ -15,9 +15,12 @@ import {
   ExchangeRate,
   SupplierTerms,
   PayoutAccount,
+  GameArtifact,
+  GameRelease,
 } from "generated/prisma/client";
 import { createHash } from "node:crypto";
 import { InternalServerError } from "infra/errors";
+import { releaseSummarySchema } from "contracts/desktop/v1";
 
 type SaleWithGame = Sale & { game_title?: string; game_slug?: string | null };
 
@@ -642,6 +645,41 @@ function filterOutput(user: Partial<User>, feature: string, resource: unknown) {
       created_at: artifact.created_at,
       updated_at: artifact.updated_at,
     };
+  }
+
+  if (
+    feature === "read:library" &&
+    typeof resource === "object" &&
+    resource !== null &&
+    "release" in resource &&
+    "artifact" in resource
+  ) {
+    const result = resource as {
+      release: GameRelease;
+      artifact: Omit<
+        GameArtifact,
+        "compressed_size_bytes" | "installed_size_bytes"
+      > & {
+        compressed_size_bytes: string | bigint;
+        installed_size_bytes: string | bigint;
+      };
+    };
+
+    return releaseSummarySchema.parse({
+      id: result.release.id,
+      version: result.release.version,
+      release_number: result.release.release_number,
+      published_at: result.release.published_at?.toISOString(),
+      artifact_id: result.artifact.id,
+      target: {
+        platform: result.artifact.platform,
+        architecture: result.artifact.architecture,
+      },
+      compressed_size_bytes: result.artifact.compressed_size_bytes.toString(),
+      installed_size_bytes: result.artifact.installed_size_bytes.toString(),
+      sha256: result.artifact.sha256,
+      manifest_schema_version: result.artifact.manifest_schema_version,
+    });
   }
 
   if (

--- a/models/game_release.ts
+++ b/models/game_release.ts
@@ -188,40 +188,59 @@ async function findLatestCompatible(
   platform: GamePlatform,
   architecture: GameArchitecture,
 ) {
-  const releases = await prisma.gameRelease.findMany({
-    where: { game_id: gameId, status: GameReleaseStatus.PUBLISHED },
-    orderBy: { release_number: "desc" },
-  });
+  const batchSize = 50;
+  let beforeReleaseNumber: number | undefined;
 
-  if (releases.length === 0) return null;
+  while (true) {
+    const releases = await prisma.gameRelease.findMany({
+      where: {
+        game_id: gameId,
+        status: GameReleaseStatus.PUBLISHED,
+        published_at: { not: null },
+        release_number:
+          beforeReleaseNumber === undefined
+            ? undefined
+            : { lt: beforeReleaseNumber },
+      },
+      orderBy: { release_number: "desc" },
+      take: batchSize,
+    });
 
-  const artifacts = await prisma.gameArtifact.findMany({
-    where: {
-      release_id: { in: releases.map((release) => release.id) },
-      platform,
-      architecture,
-      status: "READY",
-    },
-  });
-  const artifactsByRelease = new Map(
-    artifacts.map((artifact) => [artifact.release_id, artifact]),
-  );
+    if (releases.length === 0) return null;
 
-  for (const release of releases) {
-    const artifact = artifactsByRelease.get(release.id);
-    if (artifact) {
-      return {
-        release,
-        artifact: {
-          ...artifact,
-          compressed_size_bytes: artifact.compressed_size_bytes!.toString(),
-          installed_size_bytes: artifact.installed_size_bytes!.toString(),
-        },
-      };
+    const artifacts = await prisma.gameArtifact.findMany({
+      where: {
+        release_id: { in: releases.map((release) => release.id) },
+        platform,
+        architecture,
+        status: "READY",
+        compressed_size_bytes: { not: null },
+        installed_size_bytes: { not: null },
+        sha256: { not: null },
+        manifest_schema_version: { not: null },
+      },
+    });
+    const artifactsByRelease = new Map(
+      artifacts.map((artifact) => [artifact.release_id, artifact]),
+    );
+
+    for (const release of releases) {
+      const artifact = artifactsByRelease.get(release.id);
+      if (artifact) {
+        return {
+          release,
+          artifact: {
+            ...artifact,
+            compressed_size_bytes: artifact.compressed_size_bytes!.toString(),
+            installed_size_bytes: artifact.installed_size_bytes!.toString(),
+          },
+        };
+      }
     }
-  }
 
-  return null;
+    if (releases.length < batchSize) return null;
+    beforeReleaseNumber = releases.at(-1)!.release_number;
+  }
 }
 
 function assertReleaseMutable(release: {

--- a/pages/api/v1/games/[slug]/releases/latest/index.ts
+++ b/pages/api/v1/games/[slug]/releases/latest/index.ts
@@ -1,0 +1,92 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { createRouter } from "next-connect";
+import {
+  desktopArchitectureSchema,
+  desktopPlatformSchema,
+} from "contracts/desktop/v1";
+import controller from "infra/controller";
+import distributionApi from "infra/distribution_api";
+import { ForbiddenError, NotFoundError, ValidationError } from "infra/errors";
+import authorization from "models/authorization";
+import game from "models/game";
+import gameRelease from "models/game_release";
+import library from "models/library";
+import { z } from "zod";
+
+const querySchema = z.object({
+  slug: z.string().min(1).max(255),
+  platform: desktopPlatformSchema,
+  architecture: desktopArchitectureSchema,
+});
+
+export default createRouter<NextApiRequest, NextApiResponse>()
+  .use(controller.injectAnonymousOrUser)
+  .get(
+    controller.requireAuthentication,
+    controller.canRequest("read:library"),
+    getHandler,
+  )
+  .handler(distributionApi.errorHandlers);
+
+async function getHandler(req: NextApiRequest, res: NextApiResponse) {
+  const queryParse = querySchema.safeParse(req.query);
+  if (!queryParse.success) {
+    throw new ValidationError({
+      message: "Invalid release target",
+      action: "Check the game slug, platform, and architecture",
+      context: queryParse.error.issues,
+      cause: queryParse.error,
+    });
+  }
+
+  const { slug, platform, architecture } = queryParse.data;
+  const gameResource = await game.findOneBySlugWithStudio(slug);
+
+  if (!gameResource) {
+    throw new NotFoundError({
+      message: `Game "${slug}" was not found.`,
+      action: "Check the game slug and try again.",
+    });
+  }
+
+  const hasGameOwnership = authorization.can(
+    req.context.user,
+    "update:game",
+    gameResource,
+  );
+  const hasEntitlement = await library.hasItem(
+    req.context.user.id,
+    gameResource.id,
+  );
+
+  if (!hasGameOwnership && !hasEntitlement) {
+    throw new ForbiddenError({
+      message: "You do not have access to this game release.",
+      action: "Acquire the game before requesting a release.",
+    });
+  }
+
+  const result = await gameRelease.findLatestCompatible(
+    gameResource.id,
+    platform,
+    architecture,
+  );
+
+  if (!result) {
+    throw distributionApi.withErrorCode(
+      new NotFoundError({
+        message: "No compatible published release was found.",
+        action: "Check the requested platform and architecture.",
+      }),
+      "NO_COMPATIBLE_RELEASE",
+    );
+  }
+
+  const safeRelease = authorization.filterOutput(
+    req.context.user,
+    "read:library",
+    result,
+  );
+
+  return res.status(200).json(safeRelease);
+}

--- a/tests/integration/api/v1/games/[slug]/releases/latest/get.test.ts
+++ b/tests/integration/api/v1/games/[slug]/releases/latest/get.test.ts
@@ -1,0 +1,376 @@
+import { randomUUID } from "node:crypto";
+import {
+  Game,
+  GameArchitecture,
+  GameArchiveFormat,
+  GameArtifactStatus,
+  GamePlatform,
+  GameRelease,
+  User,
+} from "generated/prisma/client";
+import { prisma } from "infra/database";
+import webserver from "infra/webserver";
+import gameArtifact from "models/game_artifact";
+import gameRelease from "models/game_release";
+import orchestrator from "tests/orchestrator";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+beforeEach(async () => {
+  await orchestrator.clearDatabaseRows();
+});
+
+describe("GET /api/v1/games/[slug]/releases/latest", () => {
+  describe("Anonymous user", () => {
+    test("returns 401 when the session cookie is missing", async () => {
+      const response = await requestRelease("missing-game");
+
+      expect(response.status).toBe(401);
+      expect(await response.json()).toEqual({
+        error: {
+          code: "AUTHENTICATION_REQUIRED",
+          message: "Authentication required",
+          retryable: false,
+        },
+      });
+    });
+
+    test("does not accept a bearer token instead of the session cookie", async () => {
+      const user = await createActivatedUser();
+      const session = await orchestrator.createSession(user.id);
+
+      const response = await requestRelease("missing-game", undefined, {
+        Authorization: `Bearer ${session.token}`,
+      });
+
+      expect(response.status).toBe(401);
+      expect(await response.json()).toEqual({
+        error: {
+          code: "AUTHENTICATION_REQUIRED",
+          message: "Authentication required",
+          retryable: false,
+        },
+      });
+    });
+  });
+
+  describe("Authenticated user", () => {
+    test("returns 403 when the account is not activated", async () => {
+      const user = await orchestrator.createUser();
+      const session = await orchestrator.createSession(user.id);
+
+      const response = await requestRelease("missing-game", session.token);
+
+      expect(response.status).toBe(403);
+      expect(await response.json()).toEqual({
+        error: {
+          code: "ENTITLEMENT_REQUIRED",
+          message: "You do not have permission to perform this action",
+          retryable: false,
+        },
+      });
+    });
+
+    test("returns 403 when the user has no entitlement", async () => {
+      const { game } = await createGameOwner();
+      const buyer = await createActivatedUser();
+      const session = await orchestrator.createSession(buyer.id);
+
+      const response = await requestRelease(game.slug, session.token);
+
+      expect(response.status).toBe(403);
+      expect(await response.json()).toEqual({
+        error: {
+          code: "ENTITLEMENT_REQUIRED",
+          message: "You do not have access to this game release.",
+          retryable: false,
+        },
+      });
+    });
+
+    test("allows the game owner without a library entitlement", async () => {
+      const { owner, game } = await createGameOwner();
+      const published = await createPublishedRelease(game, "1.0.0");
+      const session = await orchestrator.createSession(owner.id);
+
+      const response = await requestRelease(game.slug, session.token);
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual(expectedReleaseSummary(published));
+    });
+
+    test("uses the requested platform and architecture exactly", async () => {
+      const { game } = await createGameOwner();
+      const buyer = await createActivatedUser();
+      await orchestrator.addToLibrary(buyer.id, game.id);
+      const session = await orchestrator.createSession(buyer.id);
+
+      const macRelease = await createPublishedRelease(
+        game,
+        "1.0.0-mac",
+        GamePlatform.MAC,
+        GameArchitecture.AARCH64,
+      );
+      await createPublishedRelease(game, "2.0.0-windows");
+
+      const response = await requestRelease(
+        game.slug,
+        session.token,
+        undefined,
+        "MAC",
+        "AARCH64",
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual(expectedReleaseSummary(macRelease));
+    });
+
+    test("orders compatible releases by monotonic release number", async () => {
+      const { game } = await createGameOwner();
+      const buyer = await createActivatedUser();
+      await orchestrator.addToLibrary(buyer.id, game.id);
+      const session = await orchestrator.createSession(buyer.id);
+      const firstDraft = await gameRelease.createDraft({
+        game_id: game.id,
+        version: "99.0.0",
+      });
+      const secondDraft = await gameRelease.createDraft({
+        game_id: game.id,
+        version: "1.0.0",
+      });
+
+      const newestByNumber = await publishDraft(secondDraft);
+      await publishDraft(firstDraft);
+      const latestRelease = await prisma.gameRelease.update({
+        where: { id: newestByNumber.release.id },
+        data: { published_at: new Date("2025-01-01T00:00:00.000Z") },
+      });
+      await prisma.gameRelease.update({
+        where: { id: firstDraft.id },
+        data: { published_at: new Date("2026-01-01T00:00:00.000Z") },
+      });
+      const latest = { ...newestByNumber, release: latestRelease };
+
+      const response = await requestRelease(game.slug, session.token);
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual(expectedReleaseSummary(latest));
+    });
+
+    test("falls back when the newest compatible release is retired", async () => {
+      const { game } = await createGameOwner();
+      const buyer = await createActivatedUser();
+      await orchestrator.addToLibrary(buyer.id, game.id);
+      const session = await orchestrator.createSession(buyer.id);
+
+      const previous = await createPublishedRelease(game, "1.0.0");
+      const newest = await createPublishedRelease(game, "2.0.0");
+      await gameRelease.retire(newest.release.id);
+
+      const response = await requestRelease(game.slug, session.token);
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual(expectedReleaseSummary(previous));
+    });
+
+    test("returns 404 when the release is unpublished or its artifact is incomplete", async () => {
+      const { game } = await createGameOwner();
+      const buyer = await createActivatedUser();
+      await orchestrator.addToLibrary(buyer.id, game.id);
+      const session = await orchestrator.createSession(buyer.id);
+
+      await createReadyUnpublishedRelease(game, "1.0.0-draft");
+      const incomplete = await createPublishedRelease(game, "2.0.0");
+      await prisma.gameArtifact.update({
+        where: { id: incomplete.artifact.id },
+        data: { status: GameArtifactStatus.PENDING },
+      });
+
+      const response = await requestRelease(game.slug, session.token);
+
+      expect(response.status).toBe(404);
+      expect(await response.json()).toEqual({
+        error: {
+          code: "NO_COMPATIBLE_RELEASE",
+          message: "No compatible published release was found.",
+          retryable: false,
+        },
+      });
+    });
+
+    test("returns 400 with validation context for an unsupported target", async () => {
+      const user = await createActivatedUser();
+      const session = await orchestrator.createSession(user.id);
+
+      const response = await requestRelease(
+        "any-game",
+        session.token,
+        undefined,
+        "ANDROID",
+      );
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        error: {
+          code: "INVALID_REQUEST",
+          message: "Invalid release target",
+          retryable: false,
+          details: {
+            issues: [
+              {
+                code: "invalid_value",
+                values: ["WINDOWS", "MAC", "LINUX"],
+                path: ["platform"],
+                message:
+                  'Invalid option: expected one of "WINDOWS"|"MAC"|"LINUX"',
+              },
+            ],
+          },
+        },
+      });
+    });
+
+    test("returns 404 when the game does not exist", async () => {
+      const user = await createActivatedUser();
+      const session = await orchestrator.createSession(user.id);
+
+      const response = await requestRelease("missing-game", session.token);
+
+      expect(response.status).toBe(404);
+      expect(await response.json()).toEqual({
+        error: {
+          code: "INVALID_REQUEST",
+          message: 'Game "missing-game" was not found.',
+          retryable: false,
+        },
+      });
+    });
+  });
+});
+
+async function createActivatedUser(): Promise<User> {
+  const user = await orchestrator.createUser();
+  await orchestrator.activateUser(user.id);
+  return user;
+}
+
+async function createGameOwner(): Promise<{ owner: User; game: Game }> {
+  const owner = await createActivatedUser();
+  const game = await orchestrator.createGame(owner.id, {
+    title: `Release Test ${randomUUID()}`,
+  });
+  return { owner, game };
+}
+
+async function createPublishedRelease(
+  game: Game,
+  version: string,
+  platform: GamePlatform = GamePlatform.WINDOWS,
+  architecture: GameArchitecture = GameArchitecture.X86_64,
+) {
+  const release = await gameRelease.createDraft({
+    game_id: game.id,
+    version,
+  });
+
+  return publishDraft(release, platform, architecture);
+}
+
+async function publishDraft(
+  release: GameRelease,
+  platform: GamePlatform = GamePlatform.WINDOWS,
+  architecture: GameArchitecture = GameArchitecture.X86_64,
+) {
+  const artifact = await gameArtifact.createPending({
+    release_id: release.id,
+    platform,
+    architecture,
+    archive_format: GameArchiveFormat.ZIP,
+    storage_object_key: `tests/${release.id}/${platform}-${architecture}.zip`,
+  });
+  await gameArtifact.markVerifying(artifact.id);
+  const readyArtifact = await gameArtifact.markReady(artifact.id, {
+    compressed_size_bytes: "1024",
+    installed_size_bytes: "2048",
+    sha256: "a".repeat(64),
+    manifest: {
+      schema_version: "1",
+      entrypoint: "game.exe",
+      launch_arguments: [],
+      executables: ["game.exe"],
+      environment: {},
+    },
+  });
+  await gameRelease.beginProcessing(release.id);
+  const publishedRelease = await gameRelease.publish(release.id);
+
+  return { release: publishedRelease, artifact: readyArtifact };
+}
+
+async function createReadyUnpublishedRelease(game: Game, version: string) {
+  const release = await gameRelease.createDraft({
+    game_id: game.id,
+    version,
+  });
+  const artifact = await gameArtifact.createPending({
+    release_id: release.id,
+    platform: GamePlatform.WINDOWS,
+    architecture: GameArchitecture.X86_64,
+    archive_format: GameArchiveFormat.ZIP,
+    storage_object_key: `tests/${release.id}/unpublished.zip`,
+  });
+  await gameArtifact.markVerifying(artifact.id);
+  await gameArtifact.markReady(artifact.id, {
+    compressed_size_bytes: "1024",
+    installed_size_bytes: "2048",
+    sha256: "b".repeat(64),
+    manifest: {
+      schema_version: "1",
+      entrypoint: "game.exe",
+      launch_arguments: [],
+      executables: ["game.exe"],
+      environment: {},
+    },
+  });
+  return release;
+}
+
+function expectedReleaseSummary(
+  published: Awaited<ReturnType<typeof createPublishedRelease>>,
+) {
+  return {
+    id: published.release.id,
+    version: published.release.version,
+    release_number: published.release.release_number,
+    published_at: published.release.published_at!.toISOString(),
+    artifact_id: published.artifact.id,
+    target: {
+      platform: published.artifact.platform,
+      architecture: published.artifact.architecture,
+    },
+    compressed_size_bytes: "1024",
+    installed_size_bytes: "2048",
+    sha256: "a".repeat(64),
+    manifest_schema_version: "1",
+  };
+}
+
+function requestRelease(
+  slug: string,
+  sessionToken?: string,
+  headers: Record<string, string> = {},
+  platform: string = "WINDOWS",
+  architecture: string = "X86_64",
+) {
+  const requestHeaders = { ...headers };
+  if (sessionToken) requestHeaders.Cookie = `session_id=${sessionToken}`;
+
+  const query = new URLSearchParams({ platform, architecture });
+  return fetch(
+    `${webserver.getOrigin()}/api/v1/games/${slug}/releases/latest?${query}`,
+    { headers: requestHeaders },
+  );
+}


### PR DESCRIPTION
## Description

- Adds GET /api/v1/games/:slug/releases/latest for entitled desktop users and game owners.
- Authenticates through the existing session_id cookie and resolves the highest compatible published release by monotonic release number.
- Returns the exact release summary contract and versioned distribution error envelope.
- Rejects retired, unpublished, incompatible, and incomplete artifacts.
- Bounds historical release lookup in batches and adds integration coverage for authentication, entitlement, compatibility, ordering, retirement, incomplete metadata, and output filtering.

## Related issue

Closes #214

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📖 Documentation
- [x] ♻️ Refactor
- [x] 🧪 Tests

## Checklist

- [ ] Commits follow Conventional Commits
- [x] npm run lint:eslint:check passes
- [ ] npm run lint:prettier:check passes globally (pre-existing formatting failures; all changed files pass)
- [ ] npm run test passes (Docker/PostgreSQL unavailable locally; integration suite delegated to CI)
- [x] Added or updated tests where relevant

## Validation

- npm run build: passed
- Unit tests: 39/39 passed
- ESLint: 0 errors; 2 unrelated existing warnings
- Changed-file Prettier check: passed
- Two independent reviews completed with no remaining P0-P2 findings
