### PR TITLE
feat: expose published install manifests

### DIFF
--- a/docs/openapi/manifold-desktop-v1.yaml
+++ b/docs/openapi/manifold-desktop-v1.yaml
@@ -169,6 +169,12 @@ paths:
           required: true
           schema:
             const: "1"
+        - name: artifact_id
+          in: query
+          required: false
+          description: Selects the manifest for a specific release artifact. Required when the release has more than one ready artifact.
+          schema:
+            $ref: "#/components/schemas/Identifier"
       responses:
         "200":
           description: Versioned install manifest.

--- a/infra/distribution_api.ts
+++ b/infra/distribution_api.ts
@@ -19,13 +19,19 @@ type DistributionErrorCode = z.infer<typeof desktopErrorCodeSchema>;
 type DistributionError = Error & {
   statusCode?: number;
   distributionErrorCode?: DistributionErrorCode;
+  distributionRetryable?: boolean;
 };
 
 function withErrorCode<T extends Error>(
   error: T,
   code: DistributionErrorCode,
+  options: { retryable?: boolean; statusCode?: number } = {},
 ): T {
-  return Object.assign(error, { distributionErrorCode: code });
+  return Object.assign(error, {
+    distributionErrorCode: code,
+    distributionRetryable: options.retryable,
+    statusCode: options.statusCode ?? (error as DistributionError).statusCode,
+  });
 }
 
 function onNoMatch(_req: NextApiRequest, res: NextApiResponse) {
@@ -61,9 +67,10 @@ function onError(
   const code = error.distributionErrorCode ?? inferErrorCode(error);
   const message = isKnownError ? error.message : "Service unavailable";
   const retryable =
-    error instanceof RateLimitError ||
-    error instanceof ServiceError ||
-    !isKnownError;
+    error.distributionRetryable ??
+    (error instanceof RateLimitError ||
+      error instanceof ServiceError ||
+      !isKnownError);
   const details =
     error instanceof ValidationError && error.context !== undefined
       ? { issues: error.context }

--- a/models/authorization.ts
+++ b/models/authorization.ts
@@ -20,7 +20,10 @@ import {
 } from "generated/prisma/client";
 import { createHash } from "node:crypto";
 import { InternalServerError } from "infra/errors";
-import { releaseSummarySchema } from "contracts/desktop/v1";
+import {
+  installManifestSchema,
+  releaseSummarySchema,
+} from "contracts/desktop/v1";
 
 type SaleWithGame = Sale & { game_title?: string; game_slug?: string | null };
 
@@ -680,6 +683,17 @@ function filterOutput(user: Partial<User>, feature: string, resource: unknown) {
       sha256: result.artifact.sha256,
       manifest_schema_version: result.artifact.manifest_schema_version,
     });
+  }
+
+  if (
+    feature === "read:library" &&
+    typeof resource === "object" &&
+    resource !== null &&
+    "schema_version" in resource &&
+    "release_id" in resource &&
+    "artifact_id" in resource
+  ) {
+    return installManifestSchema.parse(resource);
   }
 
   if (

--- a/models/game_release.ts
+++ b/models/game_release.ts
@@ -1,11 +1,13 @@
 import { prisma } from "infra/database";
-import { NotFoundError, ValidationError } from "infra/errors";
+import { NotFoundError, ServiceError, ValidationError } from "infra/errors";
 import {
   GameArchitecture,
   GamePlatform,
   GameReleaseStatus,
+  Prisma,
 } from "generated/prisma/client";
 import { z } from "zod";
+import { installManifestSchema } from "contracts/desktop/v1";
 
 export const gameReleaseCreateSchema = z.object({
   game_id: z.uuid(),
@@ -243,6 +245,64 @@ async function findLatestCompatible(
   }
 }
 
+async function findPublishedManifest(
+  id: string,
+  schemaVersion: string,
+  artifactId?: string,
+) {
+  const release = await prisma.gameRelease.findUnique({
+    where: { id },
+    select: { id: true, status: true, published_at: true },
+  });
+  if (release?.status === GameReleaseStatus.RETIRED) {
+    return { state: "RETIRED" } as const;
+  }
+  if (
+    !release ||
+    release.status !== GameReleaseStatus.PUBLISHED ||
+    !release.published_at
+  ) {
+    return { state: "UNAVAILABLE" } as const;
+  }
+
+  const artifacts = await prisma.gameArtifact.findMany({
+    where: {
+      ...(artifactId ? { id: artifactId } : {}),
+      release_id: id,
+      status: "READY",
+      manifest_schema_version: schemaVersion,
+      manifest: { not: Prisma.DbNull },
+    },
+    orderBy: { created_at: "asc" },
+    take: 2,
+  });
+  const [artifact] = artifacts;
+  if (!artifact) return { state: "UNAVAILABLE" } as const;
+  if (artifacts.length > 1) {
+    throw new ValidationError({
+      message:
+        "Artifact id is required when a release has multiple ready artifacts",
+      action: "Provide the artifact id selected by the latest release response",
+    });
+  }
+
+  const manifest = installManifestSchema.safeParse(artifact.manifest);
+  if (
+    !manifest.success ||
+    manifest.data.release_id !== release.id ||
+    manifest.data.artifact_id !== artifact.id ||
+    manifest.data.schema_version !== artifact.manifest_schema_version
+  ) {
+    throw new ServiceError({
+      message: "The published install manifest failed integrity validation",
+      action: "Contact the publisher before retrying the installation",
+      cause: manifest.success ? undefined : manifest.error,
+    });
+  }
+
+  return { state: "FOUND", manifest: manifest.data } as const;
+}
+
 function assertReleaseMutable(release: {
   id: string;
   status: GameReleaseStatus;
@@ -286,6 +346,7 @@ const gameRelease = {
   publish,
   retire,
   findLatestCompatible,
+  findPublishedManifest,
   assertReleaseMutable,
 };
 

--- a/pages/api/v1/games/[slug]/releases/latest/index.ts
+++ b/pages/api/v1/games/[slug]/releases/latest/index.ts
@@ -16,7 +16,7 @@ import { z } from "zod";
 const querySchema = z.object({
   slug: z.string().min(1).max(255),
   platform: desktopPlatformSchema,
-  architecture: desktopArchitectureSchema,
+  arch: desktopArchitectureSchema,
 });
 
 export default createRouter<NextApiRequest, NextApiResponse>()
@@ -39,7 +39,7 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
     });
   }
 
-  const { slug, platform, architecture } = queryParse.data;
+  const { slug, platform, arch } = queryParse.data;
   const gameResource = await game.findOneBySlugWithStudio(slug);
 
   if (!gameResource) {
@@ -69,7 +69,7 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
   const result = await gameRelease.findLatestCompatible(
     gameResource.id,
     platform,
-    architecture,
+    arch,
   );
 
   if (!result) {

--- a/pages/api/v1/releases/[release_id]/manifest/index.ts
+++ b/pages/api/v1/releases/[release_id]/manifest/index.ts
@@ -1,0 +1,151 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { createRouter } from "next-connect";
+import { manifestSchemaVersionSchema } from "contracts/desktop/v1";
+import controller from "infra/controller";
+import distributionApi from "infra/distribution_api";
+import {
+  ForbiddenError,
+  NotFoundError,
+  ServiceError,
+  ValidationError,
+} from "infra/errors";
+import authorization from "models/authorization";
+import game from "models/game";
+import gameRelease from "models/game_release";
+import library from "models/library";
+import { z } from "zod";
+
+const querySchema = z.object({
+  release_id: z.uuid(),
+  schema_version: manifestSchemaVersionSchema,
+  artifact_id: z.uuid().optional(),
+});
+
+export default createRouter<NextApiRequest, NextApiResponse>()
+  .use(controller.injectAnonymousOrUser)
+  .get(
+    controller.requireAuthentication,
+    controller.canRequest("read:library"),
+    getHandler,
+  )
+  .handler(distributionApi.errorHandlers);
+
+async function getHandler(req: NextApiRequest, res: NextApiResponse) {
+  if (
+    typeof req.query.schema_version === "string" &&
+    req.query.schema_version !== "1"
+  ) {
+    throw distributionApi.withErrorCode(
+      new ValidationError({
+        message: `Manifest schema version "${req.query.schema_version}" is not supported`,
+        action: "Request manifest schema version 1",
+      }),
+      "UNSUPPORTED_MANIFEST_VERSION",
+    );
+  }
+
+  const queryParse = querySchema.safeParse(req.query);
+  if (!queryParse.success) {
+    throw new ValidationError({
+      message: "Invalid manifest request",
+      action: "Check the release id, artifact id, and schema version",
+      context: queryParse.error.issues,
+      cause: queryParse.error,
+    });
+  }
+
+  const {
+    release_id: releaseId,
+    schema_version: schemaVersion,
+    artifact_id: artifactId,
+  } = queryParse.data;
+  const release = await gameRelease.findById(releaseId);
+  const gameResource = await game.findOneByIdWithStudio(release.game_id);
+
+  if (!gameResource) {
+    throw new NotFoundError({
+      message: `Game "${release.game_id}" was not found.`,
+      action: "Contact support to repair the release reference.",
+    });
+  }
+
+  const hasGameOwnership = authorization.can(
+    req.context.user,
+    "update:game",
+    gameResource,
+  );
+  const hasEntitlement = await library.hasItem(
+    req.context.user.id,
+    gameResource.id,
+  );
+  if (!hasGameOwnership && !hasEntitlement) {
+    throw new ForbiddenError({
+      message: "You do not have access to this install manifest.",
+      action: "Acquire the game before requesting its manifest.",
+    });
+  }
+
+  if (release.status === "RETIRED") {
+    throw distributionApi.withErrorCode(
+      new NotFoundError({
+        message: `Release "${release.id}" has been retired.`,
+        action: "Resolve the latest compatible release and try again.",
+      }),
+      "RELEASE_RETIRED",
+    );
+  }
+
+  if (release.status !== "PUBLISHED") {
+    throw distributionApi.withErrorCode(
+      new NotFoundError({
+        message: "No published install manifest was found.",
+        action: "Resolve the latest compatible release and try again.",
+      }),
+      "NO_COMPATIBLE_RELEASE",
+    );
+  }
+
+  let result: Awaited<ReturnType<typeof gameRelease.findPublishedManifest>>;
+  try {
+    result = await gameRelease.findPublishedManifest(
+      release.id,
+      schemaVersion,
+      artifactId,
+    );
+  } catch (error) {
+    if (error instanceof ServiceError) {
+      throw distributionApi.withErrorCode(error, "INTEGRITY_FAILURE", {
+        retryable: false,
+        statusCode: 500,
+      });
+    }
+    throw error;
+  }
+
+  if (result.state === "RETIRED") {
+    throw distributionApi.withErrorCode(
+      new NotFoundError({
+        message: `Release "${release.id}" has been retired.`,
+        action: "Resolve the latest compatible release and try again.",
+      }),
+      "RELEASE_RETIRED",
+    );
+  }
+
+  if (result.state === "UNAVAILABLE") {
+    throw distributionApi.withErrorCode(
+      new NotFoundError({
+        message: "No published install manifest was found.",
+        action: "Resolve the latest compatible release and try again.",
+      }),
+      "NO_COMPATIBLE_RELEASE",
+    );
+  }
+
+  const safeManifest = authorization.filterOutput(
+    req.context.user,
+    "read:library",
+    result.manifest,
+  );
+  return res.status(200).json(safeManifest);
+}

--- a/tests/integration/api/v1/games/[slug]/releases/latest/get.test.ts
+++ b/tests/integration/api/v1/games/[slug]/releases/latest/get.test.ts
@@ -368,7 +368,7 @@ function requestRelease(
   const requestHeaders = { ...headers };
   if (sessionToken) requestHeaders.Cookie = `session_id=${sessionToken}`;
 
-  const query = new URLSearchParams({ platform, architecture });
+  const query = new URLSearchParams({ platform, arch: architecture });
   return fetch(
     `${webserver.getOrigin()}/api/v1/games/${slug}/releases/latest?${query}`,
     { headers: requestHeaders },

--- a/tests/integration/api/v1/releases/[release_id]/manifest/get.test.ts
+++ b/tests/integration/api/v1/releases/[release_id]/manifest/get.test.ts
@@ -467,26 +467,14 @@ describe("GET /api/v1/releases/[release_id]/manifest", () => {
       const response = await requestManifest("not-a-uuid", session.token);
 
       expect(response.status).toBe(400);
-      expect(await response.json()).toEqual({
-        error: {
-          code: "INVALID_REQUEST",
-          message: "Invalid manifest request",
-          retryable: false,
-          details: {
-            issues: [
-              {
-                origin: "string",
-                code: "invalid_format",
-                format: "uuid",
-                pattern:
-                  "/^(?:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$/",
-                path: ["release_id"],
-                message: "Invalid UUID",
-              },
-            ],
-          },
-        },
-      });
+      const body = await response.json();
+      expect(body.error.code).toBe("INVALID_REQUEST");
+      expect(body.error.message).toBe("Invalid manifest request");
+      expect(body.error.retryable).toBe(false);
+      expect(body.error.details.issues).toHaveLength(1);
+      expect(body.error.details.issues[0].code).toBe("invalid_format");
+      expect(body.error.details.issues[0].path).toEqual(["release_id"]);
+      expect(body.error.details.issues[0].message).toBe("Invalid UUID");
     });
   });
 });

--- a/tests/integration/api/v1/releases/[release_id]/manifest/get.test.ts
+++ b/tests/integration/api/v1/releases/[release_id]/manifest/get.test.ts
@@ -1,0 +1,600 @@
+import { randomUUID } from "node:crypto";
+import {
+  Game,
+  GameArchitecture,
+  GameArchiveFormat,
+  GameArtifactStatus,
+  GamePlatform,
+  GameRelease,
+  User,
+} from "generated/prisma/client";
+import { prisma } from "infra/database";
+import webserver from "infra/webserver";
+import gameArtifact from "models/game_artifact";
+import gameRelease from "models/game_release";
+import orchestrator from "tests/orchestrator";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+beforeEach(async () => {
+  await orchestrator.clearDatabaseRows();
+});
+
+describe("GET /api/v1/releases/[release_id]/manifest", () => {
+  describe("Anonymous user", () => {
+    test("returns 401 when the session cookie is missing", async () => {
+      const response = await requestManifest(randomUUID());
+
+      expect(response.status).toBe(401);
+      expect(await response.json()).toEqual({
+        error: {
+          code: "AUTHENTICATION_REQUIRED",
+          message: "Authentication required",
+          retryable: false,
+        },
+      });
+    });
+
+    test("does not accept a valid session token as bearer authentication", async () => {
+      const user = await createActivatedUser();
+      const session = await orchestrator.createSession(user.id);
+
+      const response = await requestManifest(randomUUID(), undefined, "1", {
+        Authorization: `Bearer ${session.token}`,
+      });
+
+      expect(response.status).toBe(401);
+      expect(await response.json()).toEqual({
+        error: {
+          code: "AUTHENTICATION_REQUIRED",
+          message: "Authentication required",
+          retryable: false,
+        },
+      });
+    });
+  });
+
+  describe("Authenticated user", () => {
+    test("returns 403 when the account is not activated", async () => {
+      const user = await orchestrator.createUser();
+      const session = await orchestrator.createSession(user.id);
+
+      const response = await requestManifest(randomUUID(), session.token);
+
+      expect(response.status).toBe(403);
+      expect(await response.json()).toEqual({
+        error: {
+          code: "ENTITLEMENT_REQUIRED",
+          message: "You do not have permission to perform this action",
+          retryable: false,
+        },
+      });
+    });
+
+    test("returns 403 when the user has no game entitlement", async () => {
+      const { game } = await createGameOwner();
+      const published = await createPublishedRelease(game, "1.0.0");
+      const buyer = await createActivatedUser();
+      const { game: otherGame } = await createGameOwner();
+      await orchestrator.addToLibrary(buyer.id, otherGame.id);
+      const session = await orchestrator.createSession(buyer.id);
+
+      const response = await requestManifest(
+        published.release.id,
+        session.token,
+      );
+
+      expect(response.status).toBe(403);
+      expect(await response.json()).toEqual({
+        error: {
+          code: "ENTITLEMENT_REQUIRED",
+          message: "You do not have access to this install manifest.",
+          retryable: false,
+        },
+      });
+    });
+
+    test("allows the game owner without a library entitlement", async () => {
+      const { owner, game } = await createGameOwner();
+      const published = await createPublishedRelease(game, "1.0.0");
+      const session = await orchestrator.createSession(owner.id);
+
+      const response = await requestManifest(
+        published.release.id,
+        session.token,
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual(expectedManifest(published));
+    });
+
+    test("returns the exact immutable manifest to an entitled user", async () => {
+      const { game } = await createGameOwner();
+      const published = await createPublishedRelease(game, "1.0.0");
+      const buyer = await createActivatedUser();
+      await orchestrator.addToLibrary(buyer.id, game.id);
+      const session = await orchestrator.createSession(buyer.id);
+
+      const response = await requestManifest(
+        published.release.id,
+        session.token,
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual(expectedManifest(published));
+    });
+
+    test("selects the requested artifact manifest on a multi-target release", async () => {
+      const { game } = await createGameOwner();
+      const release = await gameRelease.createDraft({
+        game_id: game.id,
+        version: "1.0.0",
+      });
+      await createReadyArtifact(release, GamePlatform.WINDOWS);
+      const macArtifact = await createReadyArtifact(
+        release,
+        GamePlatform.MAC,
+        GameArchitecture.AARCH64,
+      );
+      await gameRelease.beginProcessing(release.id);
+      const publishedRelease = await gameRelease.publish(release.id);
+      const buyer = await createEntitledUser(game);
+      const session = await orchestrator.createSession(buyer.id);
+
+      const response = await requestManifest(
+        release.id,
+        session.token,
+        "1",
+        {},
+        macArtifact.id,
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual(
+        expectedManifest({ release: publishedRelease, artifact: macArtifact }),
+      );
+    });
+
+    test("rejects an ambiguous multi-target manifest request", async () => {
+      const { game } = await createGameOwner();
+      const release = await gameRelease.createDraft({
+        game_id: game.id,
+        version: "1.0.0",
+      });
+      await createReadyArtifact(release, GamePlatform.WINDOWS);
+      await createReadyArtifact(
+        release,
+        GamePlatform.MAC,
+        GameArchitecture.AARCH64,
+      );
+      await gameRelease.beginProcessing(release.id);
+      await gameRelease.publish(release.id);
+      const buyer = await createEntitledUser(game);
+      const session = await orchestrator.createSession(buyer.id);
+
+      const response = await requestManifest(release.id, session.token);
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        error: {
+          code: "INVALID_REQUEST",
+          message:
+            "Artifact id is required when a release has multiple ready artifacts",
+          retryable: false,
+        },
+      });
+    });
+
+    test("does not resolve an artifact belonging to another release", async () => {
+      const { game } = await createGameOwner();
+      const first = await createPublishedRelease(game, "1.0.0");
+      const second = await createPublishedRelease(game, "1.1.0");
+      const buyer = await createEntitledUser(game);
+      const session = await orchestrator.createSession(buyer.id);
+
+      const response = await requestManifest(
+        first.release.id,
+        session.token,
+        "1",
+        {},
+        second.artifact.id,
+      );
+
+      expect(response.status).toBe(404);
+      expect(await response.json()).toEqual(noPublishedManifestError());
+    });
+
+    test("rejects a draft release", async () => {
+      const { game } = await createGameOwner();
+      const draft = await gameRelease.createDraft({
+        game_id: game.id,
+        version: "1.0.0-draft",
+      });
+      const buyer = await createEntitledUser(game);
+      const session = await orchestrator.createSession(buyer.id);
+
+      const response = await requestManifest(draft.id, session.token);
+
+      expect(response.status).toBe(404);
+      expect(await response.json()).toEqual(noPublishedManifestError());
+    });
+
+    test("rejects a failed release", async () => {
+      const { game } = await createGameOwner();
+      const failed = await gameRelease.createDraft({
+        game_id: game.id,
+        version: "1.0.0-failed",
+      });
+      await gameRelease.beginProcessing(failed.id);
+      await gameRelease.markFailed(failed.id);
+      const buyer = await createEntitledUser(game);
+      const session = await orchestrator.createSession(buyer.id);
+
+      const response = await requestManifest(failed.id, session.token);
+
+      expect(response.status).toBe(404);
+      expect(await response.json()).toEqual(noPublishedManifestError());
+    });
+
+    test("rejects a retired release explicitly", async () => {
+      const { game } = await createGameOwner();
+      const published = await createPublishedRelease(game, "1.0.0");
+      await gameRelease.retire(published.release.id);
+      const buyer = await createEntitledUser(game);
+      const session = await orchestrator.createSession(buyer.id);
+
+      const response = await requestManifest(
+        published.release.id,
+        session.token,
+      );
+
+      expect(response.status).toBe(404);
+      expect(await response.json()).toEqual({
+        error: {
+          code: "RELEASE_RETIRED",
+          message: `Release "${published.release.id}" has been retired.`,
+          retryable: false,
+        },
+      });
+    });
+
+    test("rejects a published release whose artifact is no longer ready", async () => {
+      const { game } = await createGameOwner();
+      const published = await createPublishedRelease(game, "1.0.0");
+      await prisma.gameArtifact.update({
+        where: { id: published.artifact.id },
+        data: { status: GameArtifactStatus.PENDING },
+      });
+      const buyer = await createEntitledUser(game);
+      const session = await orchestrator.createSession(buyer.id);
+
+      const response = await requestManifest(
+        published.release.id,
+        session.token,
+      );
+
+      expect(response.status).toBe(404);
+      expect(await response.json()).toEqual(noPublishedManifestError());
+    });
+
+    test("rejects a corrupted persisted manifest", async () => {
+      const { game } = await createGameOwner();
+      const published = await createPublishedRelease(game, "1.0.0");
+      await prisma.gameArtifact.update({
+        where: { id: published.artifact.id },
+        data: {
+          manifest: {
+            schema_version: "1",
+            release_id: published.release.id,
+            artifact_id: published.artifact.id,
+            entrypoint: "../game.exe",
+            launch_arguments: [],
+            executables: [],
+            environment: {},
+          },
+        },
+      });
+      const buyer = await createEntitledUser(game);
+      const session = await orchestrator.createSession(buyer.id);
+
+      const response = await requestManifest(
+        published.release.id,
+        session.token,
+      );
+
+      expect(response.status).toBe(500);
+      expect(await response.json()).toEqual({
+        error: {
+          code: "INTEGRITY_FAILURE",
+          message: "The published install manifest failed integrity validation",
+          retryable: false,
+        },
+      });
+    });
+
+    test("rejects a manifest bound to a different artifact id", async () => {
+      const { game } = await createGameOwner();
+      const published = await createPublishedRelease(game, "1.0.0");
+      await prisma.gameArtifact.update({
+        where: { id: published.artifact.id },
+        data: {
+          manifest: {
+            ...expectedManifest(published),
+            artifact_id: randomUUID(),
+          },
+        },
+      });
+      const buyer = await createEntitledUser(game);
+      const session = await orchestrator.createSession(buyer.id);
+
+      const response = await requestManifest(
+        published.release.id,
+        session.token,
+      );
+
+      expect(response.status).toBe(500);
+      expect(await response.json()).toEqual({
+        error: {
+          code: "INTEGRITY_FAILURE",
+          message: "The published install manifest failed integrity validation",
+          retryable: false,
+        },
+      });
+    });
+
+    test("rejects a manifest bound to a different release id", async () => {
+      const { game } = await createGameOwner();
+      const published = await createPublishedRelease(game, "1.0.0");
+      await prisma.gameArtifact.update({
+        where: { id: published.artifact.id },
+        data: {
+          manifest: {
+            ...expectedManifest(published),
+            release_id: randomUUID(),
+          },
+        },
+      });
+      const buyer = await createEntitledUser(game);
+      const session = await orchestrator.createSession(buyer.id);
+
+      const response = await requestManifest(
+        published.release.id,
+        session.token,
+      );
+
+      expect(response.status).toBe(500);
+      expect(await response.json()).toEqual({
+        error: {
+          code: "INTEGRITY_FAILURE",
+          message: "The published install manifest failed integrity validation",
+          retryable: false,
+        },
+      });
+    });
+
+    test("filters unexpected publisher metadata from a stored manifest", async () => {
+      const { game } = await createGameOwner();
+      const published = await createPublishedRelease(game, "1.0.0");
+      await prisma.gameArtifact.update({
+        where: { id: published.artifact.id },
+        data: {
+          manifest: {
+            ...expectedManifest(published),
+            storage_object_key: "publishers/private/game.zip",
+            created_by_user_id: randomUUID(),
+            editorial_notes: "private",
+          },
+        },
+      });
+      const buyer = await createEntitledUser(game);
+      const session = await orchestrator.createSession(buyer.id);
+
+      const response = await requestManifest(
+        published.release.id,
+        session.token,
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual(expectedManifest(published));
+    });
+
+    test("rejects an unsupported manifest schema version", async () => {
+      const user = await createActivatedUser();
+      const session = await orchestrator.createSession(user.id);
+
+      const response = await requestManifest(randomUUID(), session.token, "2");
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        error: {
+          code: "UNSUPPORTED_MANIFEST_VERSION",
+          message: 'Manifest schema version "2" is not supported',
+          retryable: false,
+        },
+      });
+    });
+
+    test("returns 404 when the release does not exist", async () => {
+      const user = await createActivatedUser();
+      const session = await orchestrator.createSession(user.id);
+      const releaseId = randomUUID();
+
+      const response = await requestManifest(releaseId, session.token);
+
+      expect(response.status).toBe(404);
+      expect(await response.json()).toEqual({
+        error: {
+          code: "INVALID_REQUEST",
+          message: `Release "${releaseId}" was not found.`,
+          retryable: false,
+        },
+      });
+    });
+
+    test("returns 400 when schema_version is missing", async () => {
+      const user = await createActivatedUser();
+      const session = await orchestrator.createSession(user.id);
+
+      const response = await requestManifest(randomUUID(), session.token, null);
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        error: {
+          code: "INVALID_REQUEST",
+          message: "Invalid manifest request",
+          retryable: false,
+          details: {
+            issues: [
+              {
+                code: "invalid_value",
+                values: ["1"],
+                path: ["schema_version"],
+                message: 'Invalid input: expected "1"',
+              },
+            ],
+          },
+        },
+      });
+    });
+
+    test("returns 400 when the release id is malformed", async () => {
+      const user = await createActivatedUser();
+      const session = await orchestrator.createSession(user.id);
+
+      const response = await requestManifest("not-a-uuid", session.token);
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        error: {
+          code: "INVALID_REQUEST",
+          message: "Invalid manifest request",
+          retryable: false,
+          details: {
+            issues: [
+              {
+                origin: "string",
+                code: "invalid_format",
+                format: "uuid",
+                pattern:
+                  "/^(?:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$/",
+                path: ["release_id"],
+                message: "Invalid UUID",
+              },
+            ],
+          },
+        },
+      });
+    });
+  });
+});
+
+async function createActivatedUser(): Promise<User> {
+  const user = await orchestrator.createUser();
+  await orchestrator.activateUser(user.id);
+  return user;
+}
+
+async function createGameOwner(): Promise<{ owner: User; game: Game }> {
+  const owner = await createActivatedUser();
+  const game = await orchestrator.createGame(owner.id, {
+    title: `Manifest Test ${randomUUID()}`,
+  });
+  return { owner, game };
+}
+
+async function createEntitledUser(game: Game): Promise<User> {
+  const user = await createActivatedUser();
+  await orchestrator.addToLibrary(user.id, game.id);
+  return user;
+}
+
+async function createPublishedRelease(game: Game, version: string) {
+  const release = await gameRelease.createDraft({
+    game_id: game.id,
+    version,
+  });
+  return publishDraft(release);
+}
+
+async function publishDraft(release: GameRelease) {
+  const readyArtifact = await createReadyArtifact(release);
+  await gameRelease.beginProcessing(release.id);
+  const publishedRelease = await gameRelease.publish(release.id);
+  return { release: publishedRelease, artifact: readyArtifact };
+}
+
+async function createReadyArtifact(
+  release: GameRelease,
+  platform: GamePlatform = GamePlatform.WINDOWS,
+  architecture: GameArchitecture = GameArchitecture.X86_64,
+) {
+  const artifact = await gameArtifact.createPending({
+    release_id: release.id,
+    platform,
+    architecture,
+    archive_format: GameArchiveFormat.ZIP,
+    storage_object_key: `tests/${release.id}/${platform}-${architecture}.zip`,
+  });
+  await gameArtifact.markVerifying(artifact.id);
+  const readyArtifact = await gameArtifact.markReady(artifact.id, {
+    compressed_size_bytes: "1024",
+    installed_size_bytes: "2048",
+    sha256: "a".repeat(64),
+    manifest: {
+      schema_version: "1",
+      entrypoint: "bin/game.exe",
+      launch_arguments: ["--manifold"],
+      working_directory: "bin",
+      executables: ["bin/game.exe"],
+      environment: { MANIFOLD_RELEASE: "1" },
+    },
+  });
+  return readyArtifact;
+}
+
+function expectedManifest(
+  published: Awaited<ReturnType<typeof createPublishedRelease>>,
+) {
+  return {
+    schema_version: "1",
+    release_id: published.release.id,
+    artifact_id: published.artifact.id,
+    entrypoint: "bin/game.exe",
+    launch_arguments: ["--manifold"],
+    working_directory: "bin",
+    executables: ["bin/game.exe"],
+    environment: { MANIFOLD_RELEASE: "1" },
+  };
+}
+
+function noPublishedManifestError() {
+  return {
+    error: {
+      code: "NO_COMPATIBLE_RELEASE",
+      message: "No published install manifest was found.",
+      retryable: false,
+    },
+  };
+}
+
+function requestManifest(
+  releaseId: string,
+  sessionToken?: string,
+  schemaVersion: string | null = "1",
+  headers: Record<string, string> = {},
+  artifactId?: string,
+) {
+  const requestHeaders = { ...headers };
+  if (sessionToken) requestHeaders.Cookie = `session_id=${sessionToken}`;
+  const query = new URLSearchParams();
+  if (schemaVersion) query.set("schema_version", schemaVersion);
+  if (artifactId) query.set("artifact_id", artifactId);
+
+  return fetch(
+    `${webserver.getOrigin()}/api/v1/releases/${releaseId}/manifest?${query}`,
+    { headers: requestHeaders },
+  );
+}


### PR DESCRIPTION
## Description

Adds the authenticated install-manifest delivery endpoint required by Manifold Desktop.

- Adds `GET /api/v1/releases/:release_id/manifest`.
- Authenticates with the existing `session_id` cookie.
- Verifies game ownership or library entitlement.
- Rejects unpublished, retired, unavailable, and corrupted release data.
- Validates immutable manifest bindings to the release and artifact.
- Supports explicit `artifact_id` selection for multi-target releases while preserving the single-artifact v1 flow.
- Filters response data through the existing authorization layer.
- Aligns the latest-release query parameter with the Tauri/OpenAPI `arch` contract.
- Adds integration coverage for authentication, entitlement, lifecycle, versioning, multi-target selection, integrity, and response filtering.

## Related issue

Closes #215

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] 📖 Documentation
- [ ] ♻️ Refactor
- [x] 🧪 Tests

## Validation

- Jest Ubuntu: passed. [Automated Tests](https://github.com/pedromello/manifoldpowered.com/actions/runs/32403200470/job/96536042694)
- ESLint: passed with only two pre-existing `<img>` warnings.
- Prettier: passed.
- Commitlint: passed.
- Vercel deployment: passed.
- Two independent code-policy and integration-test reviews found no P0-P2 issues.

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] `npm run lint:eslint:check` passes
- [x] `npm run lint:prettier:check` passes
- [x] `npm run test` passes
- [x] Added or updated tests where relevant