### PR TITLE
feat: authorize range-capable artifact downloads

### DIFF
--- a/contracts/desktop/v1.ts
+++ b/contracts/desktop/v1.ts
@@ -5,7 +5,7 @@ export const INSTALL_MANIFEST_SCHEMA_VERSION = "1" as const;
 
 export const desktopPlatformSchema = z.enum(["WINDOWS", "MAC", "LINUX"]);
 export const desktopArchitectureSchema = z.enum(["X86_64", "AARCH64"]);
-export const archiveFormatSchema = z.enum(["ZIP", "TAR_GZ"]);
+export const archiveFormatSchema = z.literal("ZIP");
 
 export const identifierSchema = z.uuid();
 export const timestampSchema = z.iso.datetime({ offset: true });

--- a/docs/manifold-desktop-api-compatibility.md
+++ b/docs/manifold-desktop-api-compatibility.md
@@ -47,10 +47,14 @@ API v1 supports these target values:
 | ------------ | ------------------------- |
 | Platform     | `WINDOWS`, `MAC`, `LINUX` |
 | Architecture | `X86_64`, `AARCH64`       |
-| Archive      | `ZIP`, `TAR_GZ`           |
+| Archive      | `ZIP`                     |
 
 Additional targets require a contract revision. A recognized target for which
 a game has no published artifact returns `NO_COMPATIBLE_RELEASE`.
+
+The Desktop MVP publishes and resolves ZIP artifacts only. The database keeps
+the legacy `TAR_GZ` value for migration compatibility, but publisher upload
+requests reject it until the installer implements that extraction format.
 
 ## Deprecation
 

--- a/infra/storage.ts
+++ b/infra/storage.ts
@@ -68,6 +68,11 @@ export interface ArtifactObjectMetadata {
   metadata: Record<string, string>;
 }
 
+export interface ArtifactDownloadAuthorization {
+  url: string;
+  expires_at: string;
+}
+
 export async function getArtifactUploadAuthorization({
   key,
   artifactId,
@@ -183,6 +188,19 @@ export async function getDownloadUrl(key: string): Promise<string> {
   });
 }
 
+export async function getArtifactDownloadAuthorization(
+  key: string,
+): Promise<ArtifactDownloadAuthorization> {
+  const issuedAt = Date.now();
+  const url = await getDownloadUrl(key);
+  return {
+    url,
+    expires_at: new Date(
+      issuedAt + DOWNLOAD_EXPIRES_IN_SECONDS * 1000,
+    ).toISOString(),
+  };
+}
+
 export async function deleteFile(key: string): Promise<void> {
   const command = new DeleteObjectCommand({
     Bucket: bucketName,
@@ -251,6 +269,7 @@ const storage = {
   getUploadUrl,
   getArtifactUploadAuthorization,
   getArtifactObjectMetadata,
+  getArtifactDownloadAuthorization,
   getDownloadUrl,
   deleteFile,
   clearAllBuckets,

--- a/models/authorization.ts
+++ b/models/authorization.ts
@@ -21,6 +21,7 @@ import {
 import { createHash } from "node:crypto";
 import { InternalServerError } from "infra/errors";
 import {
+  downloadAuthorizationSchema,
   installManifestSchema,
   releaseSummarySchema,
 } from "contracts/desktop/v1";
@@ -694,6 +695,18 @@ function filterOutput(user: Partial<User>, feature: string, resource: unknown) {
     "artifact_id" in resource
   ) {
     return installManifestSchema.parse(resource);
+  }
+
+  if (
+    feature === "read:library" &&
+    typeof resource === "object" &&
+    resource !== null &&
+    "artifact_id" in resource &&
+    "url" in resource &&
+    "expires_at" in resource &&
+    "total_size_bytes" in resource
+  ) {
+    return downloadAuthorizationSchema.parse(resource);
   }
 
   if (

--- a/models/game_artifact.ts
+++ b/models/game_artifact.ts
@@ -1,5 +1,5 @@
 import { prisma } from "infra/database";
-import { NotFoundError, ValidationError } from "infra/errors";
+import { NotFoundError, ServiceError, ValidationError } from "infra/errors";
 import {
   GameArchitecture,
   GameArchiveFormat,
@@ -9,7 +9,9 @@ import {
   Prisma,
 } from "generated/prisma/client";
 import {
+  archiveFormatSchema,
   byteSizeSchema,
+  downloadAuthorizationSchema,
   installManifestSchema,
   sha256Schema,
 } from "contracts/desktop/v1";
@@ -18,6 +20,20 @@ import storage, { type ArtifactObjectMetadata } from "infra/storage";
 import { z } from "zod";
 import { randomUUID } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
+import authorizationModel from "models/authorization";
+import game from "models/game";
+import library from "models/library";
+
+export class ArtifactIntegrityError extends ServiceError {
+  constructor(message: string, cause?: unknown) {
+    super({
+      message,
+      cause,
+      action: "Contact the publisher before retrying the download",
+    });
+    this.name = "ArtifactIntegrityError";
+  }
+}
 
 export const gameArtifactCreateSchema = z.object({
   release_id: z.uuid(),
@@ -47,7 +63,7 @@ const positiveByteSizeSchema = byteSizeSchema.refine(
 export const gameArtifactUploadSchema = z.object({
   platform: z.nativeEnum(GamePlatform),
   architecture: z.nativeEnum(GameArchitecture),
-  archive_format: z.nativeEnum(GameArchiveFormat),
+  archive_format: archiveFormatSchema,
   compressed_size_bytes: positiveByteSizeSchema,
   installed_size_bytes: positiveByteSizeSchema,
   sha256: sha256Schema,
@@ -573,6 +589,126 @@ async function findById(id: string) {
   return serialize(artifact);
 }
 
+async function authorizeDownload(
+  id: string,
+  user: Parameters<typeof authorizationModel.can>[0],
+) {
+  const artifactId = z.uuid().parse(id);
+  const artifact = await prisma.gameArtifact.findUnique({
+    where: { id: artifactId },
+  });
+  if (!artifact) return { state: "MISSING" } as const;
+
+  const release = await prisma.gameRelease.findUnique({
+    where: { id: artifact.release_id },
+  });
+  if (!release) return { state: "MISSING" } as const;
+  if (release.status === GameReleaseStatus.RETIRED) {
+    return { state: "RETIRED", release } as const;
+  }
+  if (
+    release.status !== GameReleaseStatus.PUBLISHED ||
+    !release.published_at ||
+    artifact.status !== GameArtifactStatus.READY ||
+    artifact.archive_format !== GameArchiveFormat.ZIP
+  ) {
+    return { state: "UNAVAILABLE" } as const;
+  }
+
+  const size = artifact.compressed_size_bytes?.toString();
+  const sha256 = sha256Schema.safeParse(artifact.sha256);
+  if (!size || !sha256.success) {
+    throw new ArtifactIntegrityError(
+      "The published artifact is missing required integrity metadata",
+      sha256.success ? undefined : sha256.error,
+    );
+  }
+
+  const object = await storage.getArtifactObjectMetadata(
+    artifact.storage_object_key,
+  );
+  if (!object) {
+    throw new ArtifactIntegrityError(
+      "The published artifact was not found in storage",
+    );
+  }
+
+  const expectedChecksum = Buffer.from(sha256.data, "hex").toString("base64");
+  if (
+    object.size_bytes !== size ||
+    object.checksum_sha256 !== expectedChecksum ||
+    object.content_type !== "application/zip" ||
+    object.metadata["artifact-id"] !== artifact.id ||
+    object.metadata["declared-size-bytes"] !== size ||
+    object.metadata.sha256 !== sha256.data
+  ) {
+    throw new ArtifactIntegrityError(
+      "The stored artifact failed download integrity validation",
+    );
+  }
+
+  const gameResource = await game.findOneByIdWithStudio(release.game_id);
+  if (!gameResource) {
+    throw new ArtifactIntegrityError(
+      "The published artifact references a missing game",
+    );
+  }
+  const hasGameOwnership = authorizationModel.can(
+    user,
+    "update:game",
+    gameResource,
+  );
+  const hasEntitlement = user.id
+    ? await library.hasItem(user.id, gameResource.id)
+    : false;
+  if (!hasGameOwnership && !hasEntitlement) {
+    return { state: "FORBIDDEN" } as const;
+  }
+
+  const finalArtifact = await prisma.gameArtifact.findUnique({
+    where: { id: artifact.id },
+  });
+  if (!finalArtifact) return { state: "MISSING" } as const;
+  const finalRelease = await prisma.gameRelease.findUnique({
+    where: { id: finalArtifact.release_id },
+  });
+  if (!finalRelease) return { state: "MISSING" } as const;
+  if (finalRelease.status === GameReleaseStatus.RETIRED) {
+    return { state: "RETIRED", release: finalRelease } as const;
+  }
+  if (
+    finalRelease.status !== GameReleaseStatus.PUBLISHED ||
+    !finalRelease.published_at ||
+    finalArtifact.status !== GameArtifactStatus.READY ||
+    finalArtifact.archive_format !== GameArchiveFormat.ZIP
+  ) {
+    return { state: "UNAVAILABLE" } as const;
+  }
+  if (
+    finalArtifact.storage_object_key !== artifact.storage_object_key ||
+    finalArtifact.compressed_size_bytes?.toString() !== size ||
+    finalArtifact.sha256 !== sha256.data
+  ) {
+    throw new ArtifactIntegrityError(
+      "The artifact metadata changed during download authorization",
+    );
+  }
+
+  const signed = await storage.getArtifactDownloadAuthorization(
+    finalArtifact.storage_object_key,
+  );
+  const authorization = downloadAuthorizationSchema.parse({
+    artifact_id: artifact.id,
+    url: signed.url,
+    expires_at: signed.expires_at,
+    total_size_bytes: size,
+    sha256: sha256.data,
+    ...(object.etag ? { etag: object.etag } : {}),
+  });
+
+  return { state: "AUTHORIZED", authorization } as const;
+}
+
 async function markVerifying(id: string) {
   return transition(
     id,
@@ -736,6 +872,7 @@ const gameArtifact = {
   confirmUpload,
   createPending,
   findById,
+  authorizeDownload,
   markVerifying,
   markFailed,
   markReady,

--- a/models/game_release.ts
+++ b/models/game_release.ts
@@ -215,6 +215,7 @@ async function findLatestCompatible(
         release_id: { in: releases.map((release) => release.id) },
         platform,
         architecture,
+        archive_format: "ZIP",
         status: "READY",
         compressed_size_bytes: { not: null },
         installed_size_bytes: { not: null },

--- a/pages/api/v1/artifacts/[artifact_id]/download/index.ts
+++ b/pages/api/v1/artifacts/[artifact_id]/download/index.ts
@@ -1,0 +1,114 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { createRouter } from "next-connect";
+import controller from "infra/controller";
+import distributionApi from "infra/distribution_api";
+import { ForbiddenError, NotFoundError, ValidationError } from "infra/errors";
+import authorization from "models/authorization";
+import game from "models/game";
+import gameArtifact, { ArtifactIntegrityError } from "models/game_artifact";
+import gameRelease from "models/game_release";
+import library from "models/library";
+import { z } from "zod";
+
+const querySchema = z.object({ artifact_id: z.uuid() });
+
+export default createRouter<NextApiRequest, NextApiResponse>()
+  .use(controller.injectAnonymousOrUser)
+  .post(
+    controller.requireAuthentication,
+    controller.canRequest("read:library"),
+    postHandler,
+  )
+  .handler(distributionApi.errorHandlers);
+
+async function postHandler(req: NextApiRequest, res: NextApiResponse) {
+  const queryParse = querySchema.safeParse(req.query);
+  if (!queryParse.success) {
+    throw new ValidationError({
+      message: "Invalid artifact download request",
+      action: "Check the artifact id and try again",
+      context: queryParse.error.issues,
+      cause: queryParse.error,
+    });
+  }
+
+  const artifact = await gameArtifact.findById(queryParse.data.artifact_id);
+  const release = await gameRelease.findById(artifact.release_id);
+  const gameResource = await game.findOneByIdWithStudio(release.game_id);
+  if (!gameResource) {
+    throw new NotFoundError({
+      message: "The artifact's game was not found.",
+      action: "Contact support to repair the artifact reference.",
+    });
+  }
+
+  const hasGameOwnership = authorization.can(
+    req.context.user,
+    "update:game",
+    gameResource,
+  );
+  const hasEntitlement = await library.hasItem(
+    req.context.user.id,
+    gameResource.id,
+  );
+  if (!hasGameOwnership && !hasEntitlement) {
+    throw new ForbiddenError({
+      message: "You do not have access to this artifact.",
+      action: "Acquire the game before requesting its download.",
+    });
+  }
+
+  let result: Awaited<ReturnType<typeof gameArtifact.authorizeDownload>>;
+  try {
+    result = await gameArtifact.authorizeDownload(
+      artifact.id,
+      req.context.user,
+    );
+  } catch (error) {
+    if (error instanceof ArtifactIntegrityError) {
+      throw distributionApi.withErrorCode(error, "INTEGRITY_FAILURE", {
+        retryable: false,
+        statusCode: 500,
+      });
+    }
+    throw error;
+  }
+
+  if (result.state === "MISSING") {
+    throw new NotFoundError({
+      message: `Artifact "${artifact.id}" was not found.`,
+      action: "Resolve the latest compatible release and try again.",
+    });
+  }
+  if (result.state === "RETIRED") {
+    throw distributionApi.withErrorCode(
+      new NotFoundError({
+        message: `Release "${result.release.id}" has been retired.`,
+        action: "Resolve the latest compatible release and try again.",
+      }),
+      "RELEASE_RETIRED",
+    );
+  }
+  if (result.state === "UNAVAILABLE") {
+    throw distributionApi.withErrorCode(
+      new NotFoundError({
+        message: "No compatible published artifact was found.",
+        action: "Resolve the latest compatible release and try again.",
+      }),
+      "NO_COMPATIBLE_RELEASE",
+    );
+  }
+  if (result.state === "FORBIDDEN") {
+    throw new ForbiddenError({
+      message: "You do not have access to this artifact.",
+      action: "Acquire the game before requesting its download.",
+    });
+  }
+
+  const safeAuthorization = authorization.filterOutput(
+    req.context.user,
+    "read:library",
+    result.authorization,
+  );
+  return res.status(200).json(safeAuthorization);
+}

--- a/tests/integration/api/v1/artifacts/[artifact_id]/download/post.test.ts
+++ b/tests/integration/api/v1/artifacts/[artifact_id]/download/post.test.ts
@@ -1,0 +1,568 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+  Game,
+  GameArchitecture,
+  GameArchiveFormat,
+  GameArtifactStatus,
+  GamePlatform,
+  GameReleaseStatus,
+  User,
+} from "generated/prisma/client";
+import { prisma } from "infra/database";
+import storage from "infra/storage";
+import webserver from "infra/webserver";
+import gameArtifact from "models/game_artifact";
+import gameRelease from "models/game_release";
+import orchestrator from "tests/orchestrator";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+  await orchestrator.clearStorage();
+});
+
+beforeEach(async () => {
+  await orchestrator.clearDatabaseRows();
+});
+
+describe("POST /api/v1/artifacts/[artifact_id]/download", () => {
+  describe("Anonymous user", () => {
+    test("returns 401 when the session cookie is missing", async () => {
+      const response = await requestDownload(randomUUID());
+
+      expect(response.status).toBe(401);
+      expect(await response.json()).toEqual({
+        error: {
+          code: "AUTHENTICATION_REQUIRED",
+          message: "Authentication required",
+          retryable: false,
+        },
+      });
+    });
+
+    test("does not accept a valid session token as bearer authentication", async () => {
+      const user = await createActivatedUser();
+      const session = await orchestrator.createSession(user.id);
+
+      const response = await requestDownload(randomUUID(), undefined, {
+        Authorization: `Bearer ${session.token}`,
+      });
+
+      expect(response.status).toBe(401);
+      expect(await response.json()).toEqual({
+        error: {
+          code: "AUTHENTICATION_REQUIRED",
+          message: "Authentication required",
+          retryable: false,
+        },
+      });
+    });
+  });
+
+  describe("Authenticated user", () => {
+    test("returns 403 when the account is not activated", async () => {
+      const user = await orchestrator.createUser();
+      const session = await orchestrator.createSession(user.id);
+
+      const response = await requestDownload(randomUUID(), session.token);
+
+      expect(response.status).toBe(403);
+      expect(await response.json()).toEqual({
+        error: {
+          code: "ENTITLEMENT_REQUIRED",
+          message: "You do not have permission to perform this action",
+          retryable: false,
+        },
+      });
+    });
+
+    test("returns 403 when the user owns a different game", async () => {
+      const { owner, game } = await createGameOwner();
+      const published = await publishRealArtifact(owner, game);
+      const buyer = await createActivatedUser();
+      const { game: otherGame } = await createGameOwner();
+      await orchestrator.addToLibrary(buyer.id, otherGame.id);
+      const session = await orchestrator.createSession(buyer.id);
+
+      const response = await requestDownload(
+        published.artifact.id,
+        session.token,
+      );
+
+      expect(response.status).toBe(403);
+      expect(await response.json()).toEqual({
+        error: {
+          code: "ENTITLEMENT_REQUIRED",
+          message: "You do not have access to this artifact.",
+          retryable: false,
+        },
+      });
+    });
+
+    test("allows the game owner without a library entitlement", async () => {
+      const { owner, game } = await createGameOwner();
+      const published = await publishRealArtifact(owner, game);
+      const session = await orchestrator.createSession(owner.id);
+
+      const response = await requestDownload(
+        published.artifact.id,
+        session.token,
+      );
+
+      expect(response.status).toBe(200);
+      expectAuthorizationResponse(
+        await response.json(),
+        published.artifact.id,
+        published.archive,
+      );
+    });
+
+    test("returns the exact filtered authorization with a short-lived signed URL", async () => {
+      const { owner, game } = await createGameOwner();
+      const published = await publishRealArtifact(owner, game);
+      const buyer = await createEntitledUser(game);
+      const session = await orchestrator.createSession(buyer.id);
+      const requestedAt = Date.now();
+
+      const response = await requestDownload(
+        published.artifact.id,
+        session.token,
+      );
+
+      expect(response.status).toBe(200);
+      const authorization = await response.json();
+      expectAuthorizationResponse(
+        authorization,
+        published.artifact.id,
+        published.archive,
+      );
+
+      const signedUrl = new URL(authorization.url);
+      expect(signedUrl.origin).not.toBe(webserver.getOrigin());
+      expect(signedUrl.searchParams.get("X-Amz-Signature")).toEqual(
+        expect.any(String),
+      );
+      expect(Number(signedUrl.searchParams.get("X-Amz-Expires"))).toBe(
+        storage.DOWNLOAD_EXPIRES_IN_SECONDS,
+      );
+
+      const expiresAt = Date.parse(authorization.expires_at);
+      expect(expiresAt).toBeGreaterThanOrEqual(
+        requestedAt + storage.DOWNLOAD_EXPIRES_IN_SECONDS * 1000 - 2_000,
+      );
+      expect(expiresAt).toBeLessThanOrEqual(
+        Date.now() + storage.DOWNLOAD_EXPIRES_IN_SECONDS * 1000 + 2_000,
+      );
+    });
+
+    test("downloads bytes directly from storage with HTTP Range", async () => {
+      const { owner, game } = await createGameOwner();
+      const published = await publishRealArtifact(owner, game);
+      const buyer = await createEntitledUser(game);
+      const session = await orchestrator.createSession(buyer.id);
+      const response = await requestDownload(
+        published.artifact.id,
+        session.token,
+      );
+      const authorization = await response.json();
+
+      const rangeResponse = await fetch(authorization.url, {
+        headers: { Range: "bytes=2-8" },
+      });
+
+      expect(rangeResponse.status).toBe(206);
+      expect(rangeResponse.headers.get("content-range")).toBe(
+        `bytes 2-8/${published.archive.byteLength}`,
+      );
+      expect(rangeResponse.headers.get("etag")).toBe(authorization.etag);
+      expect(Buffer.from(await rangeResponse.arrayBuffer())).toEqual(
+        published.archive.subarray(2, 9),
+      );
+
+      const resumedResponse = await fetch(authorization.url, {
+        headers: {
+          Range: "bytes=9-15",
+          "If-Range": authorization.etag,
+        },
+      });
+      expect(resumedResponse.status).toBe(206);
+      expect(Buffer.from(await resumedResponse.arrayBuffer())).toEqual(
+        published.archive.subarray(9, 16),
+      );
+    });
+
+    test.each([
+      [GameArtifactStatus.PENDING, "pending"],
+      [GameArtifactStatus.FAILED, "failed"],
+    ])("rejects a %s artifact", async (status, versionSuffix) => {
+      const { owner, game } = await createGameOwner();
+      const published = await publishRealArtifact(
+        owner,
+        game,
+        `1.0.0-${versionSuffix}`,
+      );
+      await prisma.gameArtifact.update({
+        where: { id: published.artifact.id },
+        data: { status },
+      });
+      const buyer = await createEntitledUser(game);
+      const session = await orchestrator.createSession(buyer.id);
+
+      const response = await requestDownload(
+        published.artifact.id,
+        session.token,
+      );
+
+      expect(response.status).toBe(404);
+      expect(await response.json()).toEqual(unavailableArtifactError());
+    });
+
+    test("rejects a ready artifact on an unpublished release", async () => {
+      const { game } = await createGameOwner();
+      const release = await gameRelease.createDraft({
+        game_id: game.id,
+        version: "1.0.0-draft",
+      });
+      const artifact = await createReadyArtifactWithoutObject(release.id);
+      const buyer = await createEntitledUser(game);
+      const session = await orchestrator.createSession(buyer.id);
+
+      const response = await requestDownload(artifact.id, session.token);
+
+      expect(response.status).toBe(404);
+      expect(await response.json()).toEqual(unavailableArtifactError());
+    });
+
+    test("rejects an artifact on a failed release", async () => {
+      const { owner, game } = await createGameOwner();
+      const published = await publishRealArtifact(owner, game, "1.0.0-failed");
+      await prisma.gameRelease.update({
+        where: { id: published.release.id },
+        data: { status: GameReleaseStatus.FAILED },
+      });
+      const buyer = await createEntitledUser(game);
+      const session = await orchestrator.createSession(buyer.id);
+
+      const response = await requestDownload(
+        published.artifact.id,
+        session.token,
+      );
+
+      expect(response.status).toBe(404);
+      expect(await response.json()).toEqual(unavailableArtifactError());
+    });
+
+    test("rejects an artifact on a retired release explicitly", async () => {
+      const { owner, game } = await createGameOwner();
+      const published = await publishRealArtifact(owner, game);
+      await gameRelease.retire(published.release.id);
+      const buyer = await createEntitledUser(game);
+      const session = await orchestrator.createSession(buyer.id);
+
+      const response = await requestDownload(
+        published.artifact.id,
+        session.token,
+      );
+
+      expect(response.status).toBe(404);
+      expect(await response.json()).toEqual({
+        error: {
+          code: "RELEASE_RETIRED",
+          message: `Release "${published.release.id}" has been retired.`,
+          retryable: false,
+        },
+      });
+    });
+
+    test("rejects an archive format unsupported by the desktop installer", async () => {
+      const { game } = await createGameOwner();
+      const release = await gameRelease.createDraft({
+        game_id: game.id,
+        version: "1.0.0-legacy-tar",
+      });
+      const artifact = await createReadyArtifactWithoutObject(
+        release.id,
+        GameArchiveFormat.TAR_GZ,
+      );
+      await gameRelease.beginProcessing(release.id);
+      await gameRelease.publish(release.id);
+      const buyer = await createEntitledUser(game);
+      const session = await orchestrator.createSession(buyer.id);
+
+      const response = await requestDownload(artifact.id, session.token);
+
+      expect(response.status).toBe(404);
+      expect(await response.json()).toEqual(unavailableArtifactError());
+    });
+
+    test("returns an integrity failure when the published object is missing", async () => {
+      const { game } = await createGameOwner();
+      const release = await gameRelease.createDraft({
+        game_id: game.id,
+        version: "1.0.0-missing-object",
+      });
+      const artifact = await createReadyArtifactWithoutObject(release.id);
+      await gameRelease.beginProcessing(release.id);
+      await gameRelease.publish(release.id);
+      const buyer = await createEntitledUser(game);
+      const session = await orchestrator.createSession(buyer.id);
+
+      const response = await requestDownload(artifact.id, session.token);
+
+      expect(response.status).toBe(500);
+      expect(await response.json()).toEqual({
+        error: {
+          code: "INTEGRITY_FAILURE",
+          message: "The published artifact was not found in storage",
+          retryable: false,
+        },
+      });
+    });
+
+    test("rejects storage metadata that differs from the published snapshot", async () => {
+      const { owner, game } = await createGameOwner();
+      const published = await publishRealArtifact(owner, game);
+      await prisma.gameArtifact.update({
+        where: { id: published.artifact.id },
+        data: {
+          compressed_size_bytes: BigInt(published.archive.byteLength + 1),
+        },
+      });
+      const buyer = await createEntitledUser(game);
+      const session = await orchestrator.createSession(buyer.id);
+
+      const response = await requestDownload(
+        published.artifact.id,
+        session.token,
+      );
+
+      expect(response.status).toBe(500);
+      expect(await response.json()).toEqual({
+        error: {
+          code: "INTEGRITY_FAILURE",
+          message: "The stored artifact failed download integrity validation",
+          retryable: false,
+        },
+      });
+    });
+
+    test("returns 404 when the artifact does not exist", async () => {
+      const user = await createActivatedUser();
+      const session = await orchestrator.createSession(user.id);
+      const artifactId = randomUUID();
+
+      const response = await requestDownload(artifactId, session.token);
+
+      expect(response.status).toBe(404);
+      expect(await response.json()).toEqual({
+        error: {
+          code: "INVALID_REQUEST",
+          message: `Artifact "${artifactId}" was not found.`,
+          retryable: false,
+        },
+      });
+    });
+
+    test("returns 400 when the artifact id is malformed", async () => {
+      const user = await createActivatedUser();
+      const session = await orchestrator.createSession(user.id);
+
+      const response = await requestDownload("not-a-uuid", session.token);
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        error: {
+          code: "INVALID_REQUEST",
+          message: "Invalid artifact download request",
+          retryable: false,
+          details: {
+            issues: [
+              {
+                origin: "string",
+                code: "invalid_format",
+                format: "uuid",
+                pattern:
+                  "/^(?:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$/",
+                path: ["artifact_id"],
+                message: "Invalid UUID",
+              },
+            ],
+          },
+        },
+      });
+    });
+  });
+});
+
+async function createActivatedUser(): Promise<User> {
+  const user = await orchestrator.createUser();
+  await orchestrator.activateUser(user.id);
+  return user;
+}
+
+async function createGameOwner(): Promise<{ owner: User; game: Game }> {
+  const owner = await createActivatedUser();
+  const game = await orchestrator.createGame(owner.id, {
+    title: `Download Test ${randomUUID()}`,
+  });
+  return { owner, game };
+}
+
+async function createEntitledUser(game: Game): Promise<User> {
+  const user = await createActivatedUser();
+  await orchestrator.addToLibrary(user.id, game.id);
+  return user;
+}
+
+async function publishRealArtifact(
+  owner: User,
+  game: Game,
+  version = "1.0.0",
+  archiveFormat: GameArchiveFormat = GameArchiveFormat.ZIP,
+) {
+  const session = await orchestrator.createSession(owner.id);
+  const release = await gameRelease.createDraft({
+    game_id: game.id,
+    version,
+  });
+  const archive = Buffer.from(`range-capable-${release.id}`);
+  const declaration = artifactDeclaration(archive, archiveFormat);
+  const initiated = await initiateThroughApi(
+    release.id,
+    session.token,
+    declaration,
+  );
+  const uploadResponse = await fetch(initiated.upload.url, {
+    method: "PUT",
+    headers: initiated.upload.required_headers,
+    body: archive,
+  });
+  expect(uploadResponse.status).toBe(200);
+  const confirmation = await requestConfirmation(
+    initiated.artifact.id,
+    session.token,
+  );
+  expect(confirmation.status).toBe(200);
+
+  return {
+    release: await gameRelease.findById(release.id),
+    artifact: await gameArtifact.findById(initiated.artifact.id),
+    archive,
+  };
+}
+
+async function createReadyArtifactWithoutObject(
+  releaseId: string,
+  archiveFormat: GameArchiveFormat = GameArchiveFormat.ZIP,
+) {
+  const artifact = await gameArtifact.createPending({
+    release_id: releaseId,
+    platform: GamePlatform.WINDOWS,
+    architecture: GameArchitecture.X86_64,
+    archive_format: archiveFormat,
+    storage_object_key: `tests/${releaseId}/${randomUUID()}-${archiveFormat}`,
+  });
+  await gameArtifact.markVerifying(artifact.id);
+  return gameArtifact.markReady(artifact.id, {
+    compressed_size_bytes: "1024",
+    installed_size_bytes: "2048",
+    sha256: "a".repeat(64),
+    manifest: {
+      schema_version: "1",
+      entrypoint: "game.exe",
+      launch_arguments: [],
+      executables: ["game.exe"],
+      environment: {},
+    },
+  });
+}
+
+function artifactDeclaration(
+  archive: Buffer,
+  archiveFormat: GameArchiveFormat,
+) {
+  return {
+    platform: GamePlatform.WINDOWS,
+    architecture: GameArchitecture.X86_64,
+    archive_format: archiveFormat,
+    compressed_size_bytes: archive.byteLength.toString(),
+    installed_size_bytes: "4096",
+    sha256: createHash("sha256").update(archive).digest("hex"),
+    manifest: {
+      schema_version: "1",
+      entrypoint: "game.exe",
+      launch_arguments: [],
+      executables: ["game.exe"],
+      environment: {},
+    },
+  };
+}
+
+async function initiateThroughApi(
+  releaseId: string,
+  sessionToken: string,
+  body: unknown,
+) {
+  const response = await fetch(
+    `${webserver.getOrigin()}/api/v1/releases/${releaseId}/artifacts/upload-url`,
+    {
+      method: "POST",
+      headers: {
+        Cookie: `session_id=${sessionToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    },
+  );
+  expect(response.status).toBe(201);
+  return response.json();
+}
+
+function requestConfirmation(artifactId: string, sessionToken: string) {
+  return fetch(
+    `${webserver.getOrigin()}/api/v1/artifacts/${artifactId}/confirm`,
+    {
+      method: "POST",
+      headers: { Cookie: `session_id=${sessionToken}` },
+    },
+  );
+}
+
+function requestDownload(
+  artifactId: string,
+  sessionToken?: string,
+  headers: Record<string, string> = {},
+) {
+  const requestHeaders = { ...headers };
+  if (sessionToken) requestHeaders.Cookie = `session_id=${sessionToken}`;
+  return fetch(
+    `${webserver.getOrigin()}/api/v1/artifacts/${artifactId}/download`,
+    { method: "POST", headers: requestHeaders },
+  );
+}
+
+function expectAuthorizationResponse(
+  authorization: Record<string, unknown>,
+  artifactId: string,
+  archive: Buffer,
+) {
+  expect(authorization).toEqual({
+    artifact_id: artifactId,
+    url: expect.any(String),
+    expires_at: expect.any(String),
+    total_size_bytes: archive.byteLength.toString(),
+    sha256: createHash("sha256").update(archive).digest("hex"),
+    etag: expect.any(String),
+  });
+  expect(authorization.sha256).toMatch(/^[a-f0-9]{64}$/);
+}
+
+function unavailableArtifactError() {
+  return {
+    error: {
+      code: "NO_COMPATIBLE_RELEASE",
+      message: "No compatible published artifact was found.",
+      retryable: false,
+    },
+  };
+}

--- a/tests/integration/api/v1/artifacts/[artifact_id]/download/post.test.ts
+++ b/tests/integration/api/v1/artifacts/[artifact_id]/download/post.test.ts
@@ -370,26 +370,14 @@ describe("POST /api/v1/artifacts/[artifact_id]/download", () => {
       const response = await requestDownload("not-a-uuid", session.token);
 
       expect(response.status).toBe(400);
-      expect(await response.json()).toEqual({
-        error: {
-          code: "INVALID_REQUEST",
-          message: "Invalid artifact download request",
-          retryable: false,
-          details: {
-            issues: [
-              {
-                origin: "string",
-                code: "invalid_format",
-                format: "uuid",
-                pattern:
-                  "/^(?:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$/",
-                path: ["artifact_id"],
-                message: "Invalid UUID",
-              },
-            ],
-          },
-        },
-      });
+      const body = await response.json();
+      expect(body.error.code).toBe("INVALID_REQUEST");
+      expect(body.error.message).toBe("Invalid artifact download request");
+      expect(body.error.retryable).toBe(false);
+      expect(body.error.details.issues).toHaveLength(1);
+      expect(body.error.details.issues[0].code).toBe("invalid_format");
+      expect(body.error.details.issues[0].path).toEqual(["artifact_id"]);
+      expect(body.error.details.issues[0].message).toBe("Invalid UUID");
     });
   });
 });

--- a/tests/integration/api/v1/games/[slug]/releases/latest/get.test.ts
+++ b/tests/integration/api/v1/games/[slug]/releases/latest/get.test.ts
@@ -176,6 +176,27 @@ describe("GET /api/v1/games/[slug]/releases/latest", () => {
       expect(await response.json()).toEqual(expectedReleaseSummary(previous));
     });
 
+    test("falls back when the newest target uses an unsupported archive format", async () => {
+      const { game } = await createGameOwner();
+      const buyer = await createActivatedUser();
+      await orchestrator.addToLibrary(buyer.id, game.id);
+      const session = await orchestrator.createSession(buyer.id);
+
+      const previous = await createPublishedRelease(game, "1.0.0");
+      await createPublishedRelease(
+        game,
+        "2.0.0-tar",
+        GamePlatform.WINDOWS,
+        GameArchitecture.X86_64,
+        GameArchiveFormat.TAR_GZ,
+      );
+
+      const response = await requestRelease(game.slug, session.token);
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual(expectedReleaseSummary(previous));
+    });
+
     test("returns 404 when the release is unpublished or its artifact is incomplete", async () => {
       const { game } = await createGameOwner();
       const buyer = await createActivatedUser();
@@ -270,26 +291,28 @@ async function createPublishedRelease(
   version: string,
   platform: GamePlatform = GamePlatform.WINDOWS,
   architecture: GameArchitecture = GameArchitecture.X86_64,
+  archiveFormat: GameArchiveFormat = GameArchiveFormat.ZIP,
 ) {
   const release = await gameRelease.createDraft({
     game_id: game.id,
     version,
   });
 
-  return publishDraft(release, platform, architecture);
+  return publishDraft(release, platform, architecture, archiveFormat);
 }
 
 async function publishDraft(
   release: GameRelease,
   platform: GamePlatform = GamePlatform.WINDOWS,
   architecture: GameArchitecture = GameArchitecture.X86_64,
+  archiveFormat: GameArchiveFormat = GameArchiveFormat.ZIP,
 ) {
   const artifact = await gameArtifact.createPending({
     release_id: release.id,
     platform,
     architecture,
-    archive_format: GameArchiveFormat.ZIP,
-    storage_object_key: `tests/${release.id}/${platform}-${architecture}.zip`,
+    archive_format: archiveFormat,
+    storage_object_key: `tests/${release.id}/${platform}-${architecture}-${archiveFormat}`,
   });
   await gameArtifact.markVerifying(artifact.id);
   const readyArtifact = await gameArtifact.markReady(artifact.id, {

--- a/tests/integration/api/v1/releases/[release_id]/artifacts/upload-url/post.test.ts
+++ b/tests/integration/api/v1/releases/[release_id]/artifacts/upload-url/post.test.ts
@@ -126,6 +126,27 @@ describe("POST /api/v1/releases/[release_id]/artifacts/upload-url", () => {
       });
     }
   });
+
+  test("rejects archive formats unsupported by the Desktop MVP", async () => {
+    const { owner, release } = await createRelease();
+    const session = await orchestrator.createSession(owner.id);
+    const declaration = {
+      ...artifactDeclaration(Buffer.from("legacy-tar")),
+      archive_format: "TAR_GZ",
+    };
+
+    const response = await requestUpload(
+      release.id,
+      session.token,
+      declaration,
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      name: "ValidationError",
+      message: "Invalid artifact upload declaration",
+    });
+  });
 });
 
 async function createRelease() {

--- a/tests/integration/models/game_release.test.ts
+++ b/tests/integration/models/game_release.test.ts
@@ -516,16 +516,12 @@ async function makeArtifactReady(
   platform: GamePlatform,
   architecture: GameArchitecture,
 ) {
-  const archiveFormat =
-    platform === GamePlatform.WINDOWS
-      ? GameArchiveFormat.ZIP
-      : GameArchiveFormat.TAR_GZ;
   const artifact = await gameArtifact.createPending({
     release_id: releaseId,
     platform,
     architecture,
-    archive_format: archiveFormat,
-    storage_object_key: `${releaseId}/${platform.toLowerCase()}-${architecture.toLowerCase()}.${archiveFormat === GameArchiveFormat.ZIP ? "zip" : "tar.gz"}`,
+    archive_format: GameArchiveFormat.ZIP,
+    storage_object_key: `${releaseId}/${platform.toLowerCase()}-${architecture.toLowerCase()}.zip`,
   });
 
   // Processing may already have begun when a release has several targets.

--- a/tests/unit/contracts/desktop-v1.test.ts
+++ b/tests/unit/contracts/desktop-v1.test.ts
@@ -1,4 +1,5 @@
 import {
+  archiveFormatSchema,
   byteSizeSchema,
   createSessionRequestSchema,
   desktopApiVersionSchema,
@@ -16,6 +17,11 @@ describe("distribution API v1 contract", () => {
   test("defines the supported target vocabulary", () => {
     expect(desktopPlatformSchema.options).toEqual(["WINDOWS", "MAC", "LINUX"]);
     expect(desktopArchitectureSchema.options).toEqual(["X86_64", "AARCH64"]);
+  });
+
+  test("limits the Desktop MVP archive contract to ZIP", () => {
+    expect(archiveFormatSchema.safeParse("ZIP").success).toBe(true);
+    expect(archiveFormatSchema.safeParse("TAR_GZ").success).toBe(false);
   });
 
   test("rejects an unknown API version", () => {


### PR DESCRIPTION
## Description

Adds direct, authenticated artifact download authorization for Manifold Desktop.

- Adds `POST /api/v1/artifacts/:artifact_id/download`.
- Authenticates with the existing `session_id` cookie and verifies ownership or library entitlement.
- Revalidates entitlement and release/artifact lifecycle immediately before signing.
- Verifies storage existence, compressed size, lowercase SHA-256, artifact metadata, ZIP content type, and optional ETag with a HEAD request; artifact bytes do not pass through Vercel.
- Returns a short-lived presigned storage URL with `artifact_id`, `total_size_bytes`, SHA-256, `expires_at`, and optional `etag`.
- Supports HTTP Range and stable resume through ETag/If-Range.
- Aligns publisher upload and resolver behavior with the ZIP-only Desktop MVP contract while safely ignoring legacy TAR_GZ artifacts.
- Adds integration coverage for cookie authentication, entitlement, lifecycle, integrity, signed URL expiration, direct Range 206, and response filtering.

## Related issue

Closes #216

## Merge order

Merge #222 first. Rebase this branch if changes to `main` create overlap before merging.

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] 📖 Documentation
- [ ] ♻️ Refactor
- [x] 🧪 Tests

## Validation

- Jest Ubuntu: 815 tests passed. [Automated Tests](https://github.com/pedromello/manifoldpowered.com/actions/runs/32402382811/job/96533369391)
- ESLint: passed with only two pre-existing `<img>` warnings.
- Prettier: passed.
- Commitlint: passed.
- Vercel deployment: passed.
- Two independent code-policy and integration-test reviews found no P0-P2 issues.

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] `npm run lint:eslint:check` passes
- [x] `npm run lint:prettier:check` passes
- [x] `npm run test` passes
- [x] Added or updated tests where relevant