### PR TITLE
feat: allow publishers to create draft releases

### DIFF
--- a/docs/manifold-desktop-backend-plan.md
+++ b/docs/manifold-desktop-backend-plan.md
@@ -174,6 +174,20 @@ Tauri HTTP client and cookie jar.
 
 ## Phase 4 — Implement a transactional publication workflow
 
+### Publisher API surface
+
+- `POST /api/v1/games/:slug/releases` creates the next immutable draft release
+  for a game controlled by the authenticated studio owner or permitted member.
+- `POST /api/v1/releases/:release_id/artifacts/upload-url` declares an artifact
+  and returns its signed direct-upload authorization.
+- `POST /api/v1/artifacts/:artifact_id/confirm` verifies storage metadata and
+  publishes the ready release idempotently.
+
+Deployment must run the idempotent feature reconciliation after introducing
+`create:game_release`. This grants the new coarse route feature to eligible
+existing studio owners and only to members whose stored permissions explicitly
+include release creation.
+
 ### Workflow
 
 1. Create a draft release.

--- a/models/authorization.ts
+++ b/models/authorization.ts
@@ -97,6 +97,7 @@ const AVAILABLE_FEATURES = [
   "delete:game_file",
 
   // Immutable release artifacts
+  "create:game_release",
   "create:game_artifact",
 
   // Library
@@ -294,6 +295,7 @@ function can(user: Partial<User>, feature: string, resource?: unknown) {
     (feature === "update:game" ||
       feature === "create:game_file" ||
       feature === "delete:game_file" ||
+      feature === "create:game_release" ||
       feature === "create:game_artifact" ||
       feature === "read:game_price" ||
       feature === "update:game_price") &&
@@ -616,6 +618,21 @@ function filterOutput(user: Partial<User>, feature: string, resource: unknown) {
       version: fileOutput.version,
       created_at: fileOutput.created_at,
       updated_at: fileOutput.updated_at,
+    };
+  }
+
+  if (feature === "create:game_release") {
+    const release = resource as GameRelease;
+    return {
+      id: release.id,
+      game_id: release.game_id,
+      version: release.version,
+      release_number: release.release_number,
+      status: release.status,
+      release_notes: release.release_notes,
+      published_at: release.published_at,
+      created_at: release.created_at,
+      updated_at: release.updated_at,
     };
   }
 

--- a/models/studio.ts
+++ b/models/studio.ts
@@ -22,6 +22,7 @@ export const MEMBER_PERMISSIONS = [
   "update:game",
   "create:game_file",
   "delete:game_file",
+  "create:game_release",
   "create:game_artifact",
   "read:game_price",
   "update:game_price",

--- a/pages/api/v1/games/[slug]/releases/index.ts
+++ b/pages/api/v1/games/[slug]/releases/index.ts
@@ -1,0 +1,74 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { createRouter } from "next-connect";
+import { z } from "zod";
+import controller from "infra/controller";
+import { ForbiddenError, NotFoundError, ValidationError } from "infra/errors";
+import authorization from "models/authorization";
+import game from "models/game";
+import gameRelease, { gameReleaseCreateSchema } from "models/game_release";
+
+const querySchema = z.object({
+  slug: z.string().trim().min(1).max(255),
+});
+
+const bodySchema = gameReleaseCreateSchema.omit({ game_id: true }).strict();
+
+export default createRouter<NextApiRequest, NextApiResponse>()
+  .use(controller.injectAnonymousOrUser)
+  .post(
+    controller.requireAuthentication,
+    controller.canRequest("create:game_release"),
+    postHandler,
+  )
+  .handler(controller.errorHandlers);
+
+async function postHandler(req: NextApiRequest, res: NextApiResponse) {
+  const query = querySchema.safeParse(req.query);
+  if (!query.success) {
+    throw new ValidationError({
+      message: "Invalid game release request",
+      action: "Check the game slug and try again",
+      context: query.error.issues,
+      cause: query.error,
+    });
+  }
+
+  const body = bodySchema.safeParse(req.body);
+  if (!body.success) {
+    throw new ValidationError({
+      message: "Invalid game release declaration",
+      action: "Check the version and release notes",
+      context: body.error.issues,
+      cause: body.error,
+    });
+  }
+
+  const gameResource = await game.findOneBySlugWithStudio(query.data.slug);
+  if (!gameResource) {
+    throw new NotFoundError({
+      message: `Game "${query.data.slug}" was not found.`,
+      action: "Check the game slug and try again.",
+    });
+  }
+
+  if (
+    !authorization.can(req.context.user, "create:game_release", gameResource)
+  ) {
+    throw new ForbiddenError({
+      message: "You are not allowed to create releases for this game",
+      action: "Use a studio owner or member with release creation permission",
+    });
+  }
+
+  const release = await gameRelease.createDraft({
+    game_id: gameResource.id,
+    ...body.data,
+  });
+  const safeRelease = authorization.filterOutput(
+    req.context.user,
+    "create:game_release",
+    release,
+  );
+
+  return res.status(201).json(safeRelease);
+}

--- a/tests/integration/api/v1/games/[slug]/releases/post.test.ts
+++ b/tests/integration/api/v1/games/[slug]/releases/post.test.ts
@@ -1,0 +1,289 @@
+import { prisma } from "infra/database";
+import webserver from "infra/webserver";
+import orchestrator from "tests/orchestrator";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+beforeEach(async () => {
+  await orchestrator.clearDatabaseRows();
+});
+
+describe("POST /api/v1/games/[slug]/releases", () => {
+  describe("Anonymous user", () => {
+    test("requires the existing session cookie", async () => {
+      const response = await requestRelease("missing-game", {
+        version: "1.0.0",
+      });
+
+      expect(response.status).toBe(401);
+      expect(await response.json()).toEqual({
+        name: "UnauthorizedError",
+        message: "Authentication required",
+        action: "Sign in and send the session_id cookie",
+        status_code: 401,
+      });
+    });
+
+    test("does not accept a valid session token as bearer authentication", async () => {
+      const user = await activatedUser();
+      const session = await orchestrator.createSession(user.id);
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/games/missing-game/releases`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${session.token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ version: "1.0.0" }),
+        },
+      );
+
+      expect(response.status).toBe(401);
+      expect(await response.json()).toEqual({
+        name: "UnauthorizedError",
+        message: "Authentication required",
+        action: "Sign in and send the session_id cookie",
+        status_code: 401,
+      });
+    });
+  });
+
+  describe("Authenticated user", () => {
+    test("allows the studio owner to create a filtered draft release", async () => {
+      const owner = await activatedUser();
+      const game = await orchestrator.createGame(owner.id);
+      const session = await orchestrator.createSession(owner.id);
+
+      const response = await requestRelease(
+        game.slug,
+        {
+          version: "1.0.0",
+          release_notes: "First Windows release",
+        },
+        session.token,
+      );
+
+      expect(response.status).toBe(201);
+      const body = await response.json();
+      expect(body).toEqual({
+        id: expect.any(String),
+        game_id: game.id,
+        version: "1.0.0",
+        release_number: 1,
+        status: "DRAFT",
+        release_notes: "First Windows release",
+        published_at: null,
+        created_at: expect.any(String),
+        updated_at: expect.any(String),
+      });
+      expect(body).not.toHaveProperty("artifacts");
+    });
+
+    test("assigns monotonically increasing release numbers", async () => {
+      const owner = await activatedUser();
+      const game = await orchestrator.createGame(owner.id);
+      const session = await orchestrator.createSession(owner.id);
+
+      const [first, second] = await Promise.all([
+        requestRelease(game.slug, { version: "1.0.0" }, session.token),
+        requestRelease(game.slug, { version: "1.1.0" }, session.token),
+      ]);
+
+      expect(first.status).toBe(201);
+      expect(second.status).toBe(201);
+      const releases = [await first.json(), await second.json()];
+      expect(new Set(releases.map((release) => release.id)).size).toBe(2);
+      expect(
+        releases
+          .map((release) => release.release_number)
+          .sort((left, right) => left - right),
+      ).toEqual([1, 2]);
+    });
+
+    test("allows a studio member with release creation permission", async () => {
+      const owner = await activatedUser();
+      const studio = await orchestrator.createStudio(owner.id);
+      const game = await orchestrator.createGame(owner.id, {
+        studio_id: studio.id,
+      });
+      const member = await activatedUser();
+      await orchestrator.addStudioMember(studio.id, member.username, [
+        "create:game_release",
+      ]);
+      const session = await orchestrator.createSession(member.id);
+
+      const response = await requestRelease(
+        game.slug,
+        { version: "2.0.0" },
+        session.token,
+      );
+
+      expect(response.status).toBe(201);
+      expect(await response.json()).toEqual({
+        id: expect.any(String),
+        game_id: game.id,
+        version: "2.0.0",
+        release_number: 1,
+        status: "DRAFT",
+        release_notes: null,
+        published_at: null,
+        created_at: expect.any(String),
+        updated_at: expect.any(String),
+      });
+    });
+
+    test("rejects a studio member without release creation permission", async () => {
+      const owner = await activatedUser();
+      const studio = await orchestrator.createStudio(owner.id);
+      const game = await orchestrator.createGame(owner.id, {
+        studio_id: studio.id,
+      });
+      const member = await activatedUser();
+      await orchestrator.addStudioMember(studio.id, member.username, [
+        "update:game",
+      ]);
+      await orchestrator.addFeaturesToUser(member.id, ["create:game_release"]);
+      const session = await orchestrator.createSession(member.id);
+
+      const response = await requestRelease(
+        game.slug,
+        { version: "1.0.0" },
+        session.token,
+      );
+
+      expect(response.status).toBe(403);
+      expect(await response.json()).toEqual({
+        name: "ForbiddenError",
+        message: "You are not allowed to create releases for this game",
+        action: "Use a studio owner or member with release creation permission",
+        status_code: 403,
+      });
+      await expect(
+        prisma.gameRelease.count({ where: { game_id: game.id } }),
+      ).resolves.toBe(0);
+    });
+
+    test("rejects a user who holds the feature but does not control the game", async () => {
+      const owner = await activatedUser();
+      const game = await orchestrator.createGame(owner.id);
+      const attacker = await activatedUser();
+      await orchestrator.addFeaturesToUser(attacker.id, [
+        "create:game_release",
+      ]);
+      const session = await orchestrator.createSession(attacker.id);
+
+      const response = await requestRelease(
+        game.slug,
+        { version: "1.0.0" },
+        session.token,
+      );
+
+      expect(response.status).toBe(403);
+      expect(await response.json()).toEqual({
+        name: "ForbiddenError",
+        message: "You are not allowed to create releases for this game",
+        action: "Use a studio owner or member with release creation permission",
+        status_code: 403,
+      });
+    });
+
+    test("returns 404 when the game does not exist", async () => {
+      const owner = await activatedUser();
+      await orchestrator.createStudio(owner.id);
+      const session = await orchestrator.createSession(owner.id);
+
+      const response = await requestRelease(
+        "missing-game",
+        { version: "1.0.0" },
+        session.token,
+      );
+
+      expect(response.status).toBe(404);
+      expect(await response.json()).toEqual({
+        name: "NotFoundError",
+        message: 'Game "missing-game" was not found.',
+        action: "Check the game slug and try again.",
+        status_code: 404,
+      });
+    });
+
+    test("rejects invalid release fields", async () => {
+      const owner = await activatedUser();
+      const game = await orchestrator.createGame(owner.id);
+      const session = await orchestrator.createSession(owner.id);
+
+      const response = await requestRelease(
+        game.slug,
+        { version: " ", release_notes: "a".repeat(100_001) },
+        session.token,
+      );
+
+      expect(response.status).toBe(400);
+      const body = await response.json();
+      expect(body.name).toBe("ValidationError");
+      expect(body.message).toBe("Invalid game release declaration");
+      expect(body.action).toBe("Check the version and release notes");
+      expect(body.status_code).toBe(400);
+      expect(body.context).toHaveLength(2);
+      expect(body.context[0].path).toEqual(["version"]);
+      expect(body.context[1].path).toEqual(["release_notes"]);
+    });
+
+    test("rejects server-controlled release fields", async () => {
+      const owner = await activatedUser();
+      const game = await orchestrator.createGame(owner.id);
+      const session = await orchestrator.createSession(owner.id);
+
+      const response = await requestRelease(
+        game.slug,
+        {
+          version: "1.0.0",
+          game_id: "11111111-1111-4111-8111-111111111111",
+          status: "PUBLISHED",
+          release_number: 999,
+        },
+        session.token,
+      );
+
+      expect(response.status).toBe(400);
+      const body = await response.json();
+      expect(body.name).toBe("ValidationError");
+      expect(body.message).toBe("Invalid game release declaration");
+      expect(body.context).toHaveLength(1);
+      expect(body.context[0].code).toBe("unrecognized_keys");
+      expect(body.context[0].keys).toEqual([
+        "game_id",
+        "status",
+        "release_number",
+      ]);
+    });
+  });
+});
+
+async function activatedUser() {
+  const user = await orchestrator.createUser();
+  await orchestrator.activateUser(user.id);
+  return user;
+}
+
+function requestRelease(
+  slug: string,
+  body: Record<string, unknown>,
+  sessionToken?: string,
+) {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (sessionToken) headers.Cookie = `session_id=${sessionToken}`;
+
+  return fetch(`${webserver.getOrigin()}/api/v1/games/${slug}/releases`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}


### PR DESCRIPTION
## Description

Adds the missing publisher entry point for creating immutable draft game releases.

- Adds `POST /api/v1/games/:slug/releases`.
- Authenticates exclusively through the existing `session_id` cookie.
- Allows only the game's studio owner or a member with `create:game_release`.
- Rejects client-controlled `game_id`, `status`, and `release_number`.
- Creates monotonic release numbers through the existing serializable model transaction.
- Filters every response through the authorization layer.
- Adds the new permission to studio membership and feature reconciliation.
- Documents the complete publisher API surface and required post-deploy feature backfill.
- Adds integration coverage for cookie-only authentication, owner/member authorization, resource-scoped denial, validation, output filtering, and concurrent release creation.

## Related issue

Supports #217

## Deployment requirement

After production deploys this change, run the idempotent Feature Backfill workflow and verify the studio-owner pass. Existing members receive `create:game_release` only when their stored studio permissions explicitly include it.

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] 📖 Documentation
- [ ] ♻️ Refactor
- [x] 🧪 Tests

## Validation

- Jest Ubuntu: passed. [Automated Tests](https://github.com/pedromello/manifoldpowered.com/actions/runs/32415706844/job/96576242412)
- ESLint: passed with only two pre-existing `<img>` warnings.
- Prettier: passed.
- Commitlint: passed.
- Vercel deployment: passed.
- Local `next build`: passed, including TypeScript and route generation.
- Local unit tests: 40 passed.
- Two independent code-policy and integration-test reviews found no remaining P0-P2 issues.

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] `npm run lint:eslint:check` passes
- [x] `npm run lint:prettier:check` passes
- [x] `npm run test` passes
- [x] Added or updated tests where relevant