### PR TITLE
feat: make game reviews trustworthy

### DIFF
--- a/components/store/ReviewCard.tsx
+++ b/components/store/ReviewCard.tsx
@@ -1,17 +1,15 @@
 import { useState } from "react";
-import { Trash2, ThumbsUp, ThumbsDown } from "lucide-react";
+import { Pencil, Trash2, ThumbsUp, ThumbsDown } from "lucide-react";
 
 export type Review = {
   id: string;
-  user_id: string;
-  game_id: string;
   message: string;
   recommended: boolean;
   created_at?: string;
   createdAt?: string;
   updated_at?: string;
   user?: {
-    id: string;
+    id?: string;
     username: string;
   };
   username?: string;
@@ -20,6 +18,12 @@ export type Review = {
 export type ReviewsApiResponse = {
   reviews: Review[];
   user_review: Review | null;
+  can_review: boolean;
+  summary: {
+    positive_reviews: number;
+    negative_reviews: number;
+    review_score: string | null;
+  };
   pagination: {
     total_items: number;
     total_pages: number;
@@ -31,10 +35,12 @@ export type ReviewsApiResponse = {
 export function ReviewCard({
   review,
   isOwn,
+  onEdit,
   onDelete,
 }: {
   review: Review;
   isOwn?: boolean;
+  onEdit?: () => void;
   onDelete?: () => void;
 }) {
   const username = review.user?.username || review.username || "Anonymous";
@@ -70,11 +76,22 @@ export function ReviewCard({
           </div>
         </div>
         <div className="flex items-center gap-3">
+          {isOwn && onEdit && (
+            <button
+              onClick={onEdit}
+              className="rounded-lg border border-white/[0.08] bg-white/[0.03] p-2 text-white/40 transition-colors hover:border-violet-500/25 hover:bg-violet-500/10 hover:text-violet-200"
+              title="Edit Review"
+              aria-label="Edit review"
+            >
+              <Pencil size={16} />
+            </button>
+          )}
           {isOwn && onDelete && (
             <button
               onClick={onDelete}
               className="rounded-lg border border-white/[0.08] bg-white/[0.03] p-2 text-white/40 transition-colors hover:border-rose-500/20 hover:bg-rose-500/10 hover:text-rose-300"
               title="Delete Review"
+              aria-label="Delete review"
             >
               <Trash2 size={16} />
             </button>

--- a/components/storefront/default/item/DefaultItemPage.tsx
+++ b/components/storefront/default/item/DefaultItemPage.tsx
@@ -30,7 +30,7 @@ export function DefaultItemPage({
   reviews,
   backHref,
 }: ItemViewProps) {
-  const [showReviewModal, setShowReviewModal] = useState(false);
+  const [reviewMode, setReviewMode] = useState<"create" | "edit" | null>(null);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
 
   // TODO: hardcoded rather than derived from the game's price. Preserved from
@@ -42,7 +42,16 @@ export function DefaultItemPage({
     <>
       <main className="w-full bg-[#0b0812] pb-8 text-white">
         <GameHero
-          game={game}
+          game={
+            reviews.summary
+              ? {
+                  ...game,
+                  positive_reviews: reviews.summary.positiveReviews,
+                  negative_reviews: reviews.summary.negativeReviews,
+                  review_score: reviews.summary.reviewScore,
+                }
+              : game
+          }
           backHref={backHref}
           backLabel={store ? `Back to ${store.name}` : "Back to Outlets"}
         />
@@ -65,9 +74,18 @@ export function DefaultItemPage({
         <div className="border-t border-white/[0.08]">
           <ReviewsSection
             reviews={reviews}
-            isInLibrary={isInLibrary}
-            onWriteReview={() => setShowReviewModal(true)}
-            onDeleteReview={() => setShowDeleteModal(true)}
+            onWriteReview={() => {
+              reviews.clearError();
+              setReviewMode("create");
+            }}
+            onEditReview={() => {
+              reviews.clearError();
+              setReviewMode("edit");
+            }}
+            onDeleteReview={() => {
+              reviews.clearError();
+              setShowDeleteModal(true);
+            }}
           />
         </div>
       </main>
@@ -76,26 +94,46 @@ export function DefaultItemPage({
         <RedeemSuccessModal gameTitle={game.title} onDismiss={dismissSuccess} />
       )}
 
-      {showReviewModal && (
+      {reviewMode && (
         <ReviewComposerModal
           gameTitle={game.title}
+          mode={reviewMode}
+          initialReview={
+            reviewMode === "edit" && reviews.userReview
+              ? {
+                  message: reviews.userReview.message,
+                  recommended: reviews.userReview.recommended,
+                }
+              : undefined
+          }
           isSubmitting={reviews.isSubmitting}
+          error={reviews.error}
           onSubmit={async (input) => {
-            const posted = await reviews.post(input);
-            if (posted) setShowReviewModal(false);
+            const saved =
+              reviewMode === "edit"
+                ? await reviews.update(input)
+                : await reviews.post(input);
+            if (saved) setReviewMode(null);
           }}
-          onDismiss={() => setShowReviewModal(false)}
+          onDismiss={() => {
+            reviews.clearError();
+            setReviewMode(null);
+          }}
         />
       )}
 
       {showDeleteModal && (
         <ConfirmDeleteReviewModal
           isDeleting={reviews.isDeleting}
+          error={reviews.error}
           onConfirm={async () => {
             const removed = await reviews.remove();
             if (removed) setShowDeleteModal(false);
           }}
-          onDismiss={() => setShowDeleteModal(false)}
+          onDismiss={() => {
+            reviews.clearError();
+            setShowDeleteModal(false);
+          }}
         />
       )}
     </>

--- a/components/storefront/default/item/ItemModals.tsx
+++ b/components/storefront/default/item/ItemModals.tsx
@@ -109,9 +109,15 @@ export function ReviewComposerModal({
             className="flex flex-col gap-6"
           >
             {/* Recommendation Toggle */}
-            <div className="flex gap-4 p-1 bg-white/5 rounded-2xl border border-white/10">
+            <div
+              className="flex gap-2 p-1 bg-white/5 rounded-2xl border border-white/10 sm:gap-4"
+              role="group"
+              aria-label="Would you recommend this game?"
+            >
               <button
                 type="button"
+                aria-label="Recommend this game"
+                aria-pressed={form.recommended}
                 onClick={() =>
                   setForm((prev) => ({ ...prev, recommended: true }))
                 }
@@ -121,11 +127,13 @@ export function ReviewComposerModal({
                     : "text-white/40 hover:text-white/80 hover:bg-white/5"
                 }`}
               >
-                <ThumbsUp size={18} />
-                Recommended
+                <ThumbsUp size={22} aria-hidden="true" />
+                <span className="hidden sm:inline">Recommended</span>
               </button>
               <button
                 type="button"
+                aria-label="Do not recommend this game"
+                aria-pressed={!form.recommended}
                 onClick={() =>
                   setForm((prev) => ({ ...prev, recommended: false }))
                 }
@@ -135,8 +143,8 @@ export function ReviewComposerModal({
                     : "text-white/40 hover:text-white/80 hover:bg-white/5"
                 }`}
               >
-                <ThumbsDown size={18} />
-                Not Recommended
+                <ThumbsDown size={22} aria-hidden="true" />
+                <span className="hidden sm:inline">Not Recommended</span>
               </button>
             </div>
 

--- a/components/storefront/default/item/ItemModals.tsx
+++ b/components/storefront/default/item/ItemModals.tsx
@@ -17,8 +17,8 @@ export function RedeemSuccessModal({
   onDismiss: () => void;
 }) {
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/80 backdrop-blur-sm animate-in fade-in duration-300">
-      <div className="relative w-full max-w-md bg-[#1D0F3B] border border-white/20 rounded-3xl shadow-2xl p-8 flex flex-col items-center text-center animate-in zoom-in-95 duration-300">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4 backdrop-blur-sm animate-in fade-in duration-300">
+      <div className="relative flex w-full max-w-md flex-col items-center rounded-xl border border-white/10 bg-[#14101c] p-8 text-center shadow-2xl animate-in zoom-in-95 duration-300">
         <button
           onClick={onDismiss}
           className="absolute top-4 right-4 text-white/50 hover:text-white transition-colors"
@@ -60,22 +60,30 @@ export function RedeemSuccessModal({
 
 export function ReviewComposerModal({
   gameTitle,
+  mode,
+  initialReview,
   isSubmitting,
+  error,
   onSubmit,
   onDismiss,
 }: {
   gameTitle: string;
+  mode: "create" | "edit";
+  initialReview?: { message: string; recommended: boolean };
   isSubmitting: boolean;
+  error: string | null;
   onSubmit: (input: { message: string; recommended: boolean }) => void;
   onDismiss: () => void;
 }) {
   // Draft state belongs to the composer, not the page: it exists only while
   // the modal is open and is thrown away when it closes.
-  const [form, setForm] = useState({ message: "", recommended: true });
+  const [form, setForm] = useState(
+    initialReview || { message: "", recommended: true },
+  );
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/80 backdrop-blur-md animate-in fade-in duration-300">
-      <div className="relative w-full max-w-xl bg-white/5 border border-white/10 rounded-3xl shadow-2xl overflow-hidden backdrop-blur-3xl animate-in zoom-in-95 duration-300">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4 backdrop-blur-md animate-in fade-in duration-300">
+      <div className="relative w-full max-w-xl overflow-hidden rounded-xl border border-white/10 bg-[#14101c] shadow-2xl animate-in zoom-in-95 duration-300">
         <div className="p-8">
           <button
             onClick={onDismiss}
@@ -84,8 +92,8 @@ export function ReviewComposerModal({
             <X size={24} />
           </button>
 
-          <h2 className="text-3xl font-black tracking-tighter mb-2">
-            Write a Review
+          <h2 className="mb-2 text-3xl font-black tracking-tight">
+            {mode === "edit" ? "Edit Your Review" : "Write a Review"}
           </h2>
           <p className="text-white/50 mb-8 font-medium">
             Share your intel on{" "}
@@ -142,14 +150,27 @@ export function ReviewComposerModal({
               <textarea
                 id="review-message"
                 required
+                maxLength={3000}
                 value={form.message}
                 onChange={(event) =>
                   setForm((prev) => ({ ...prev, message: event.target.value }))
                 }
                 placeholder="What did you think of the game?"
-                className="w-full bg-black/20 border border-white/10 rounded-2xl p-4 text-white placeholder:text-white/20 focus:outline-none focus:border-indigo-500/50 focus:ring-1 focus:ring-indigo-500/50 resize-none h-40 transition-all font-medium"
+                className="h-40 w-full resize-none rounded-xl border border-white/10 bg-black/20 p-4 font-medium text-white placeholder:text-white/20 transition-all focus:border-violet-500/50 focus:outline-none focus:ring-1 focus:ring-violet-500/50"
               />
+              <span className="self-end text-xs font-semibold text-white/30">
+                {form.message.length.toLocaleString()} / 3,000
+              </span>
             </div>
+
+            {error && (
+              <p
+                role="alert"
+                className="rounded-lg border border-rose-500/25 bg-rose-500/10 px-4 py-3 text-sm font-semibold text-rose-200"
+              >
+                {error}
+              </p>
+            )}
 
             <button
               type="submit"
@@ -164,7 +185,7 @@ export function ReviewComposerModal({
               ) : (
                 <>
                   <Send size={20} />
-                  Post Review
+                  {mode === "edit" ? "Save Review" : "Post Review"}
                 </>
               )}
             </button>
@@ -177,21 +198,31 @@ export function ReviewComposerModal({
 
 export function ConfirmDeleteReviewModal({
   isDeleting,
+  error,
   onConfirm,
   onDismiss,
 }: {
   isDeleting: boolean;
+  error: string | null;
   onConfirm: () => void;
   onDismiss: () => void;
 }) {
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/80 backdrop-blur-sm animate-in fade-in duration-300">
-      <div className="relative w-full max-w-md bg-[#1D0F3B] border border-white/20 rounded-3xl shadow-2xl p-8 flex flex-col items-center text-center animate-in zoom-in-95 duration-300">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4 backdrop-blur-sm animate-in fade-in duration-300">
+      <div className="relative flex w-full max-w-md flex-col items-center rounded-xl border border-white/10 bg-[#14101c] p-8 text-center shadow-2xl animate-in zoom-in-95 duration-300">
         <h2 className="text-2xl font-black text-white mb-4">Delete Review?</h2>
         <p className="text-white/60 mb-8">
           Are you sure you want to delete your review? This action cannot be
           undone.
         </p>
+        {error && (
+          <p
+            role="alert"
+            className="mb-4 w-full rounded-lg border border-rose-500/25 bg-rose-500/10 px-4 py-3 text-sm font-semibold text-rose-200"
+          >
+            {error}
+          </p>
+        )}
         <div className="flex flex-col w-full gap-3">
           <button
             onClick={onConfirm}

--- a/components/storefront/default/item/ReviewsSection.tsx
+++ b/components/storefront/default/item/ReviewsSection.tsx
@@ -11,13 +11,13 @@ import type { ItemReviews } from "components/storefront/useItemController";
 
 export function ReviewsSection({
   reviews,
-  isInLibrary,
   onWriteReview,
+  onEditReview,
   onDeleteReview,
 }: {
   reviews: ItemReviews;
-  isInLibrary: boolean;
   onWriteReview: () => void;
+  onEditReview: () => void;
   onDeleteReview: () => void;
 }) {
   const hasAny = reviews.list.length > 0 || !!reviews.userReview;
@@ -32,11 +32,13 @@ export function ReviewsSection({
               Reviews
             </h2>
             <p className="max-w-xl text-sm font-medium leading-6 text-white/45">
-              Feedback from players who own the game.
+              {reviews.total === 0
+                ? "Feedback from players who own the game."
+                : `${reviews.total.toLocaleString()} verified-player review${reviews.total === 1 ? "" : "s"}.`}
             </p>
           </div>
 
-          {isInLibrary && !reviews.userReview && (
+          {reviews.canReview && !reviews.userReview && (
             <button
               onClick={onWriteReview}
               className="group flex items-center gap-2 rounded-lg border border-white/15 bg-white/[0.04] px-5 py-2.5 text-xs font-bold uppercase tracking-[0.08em] text-white/80 transition-colors hover:bg-white/[0.08] hover:text-white"
@@ -49,7 +51,7 @@ export function ReviewsSection({
             </button>
           )}
 
-          {isInLibrary && reviews.userReview && (
+          {reviews.canReview && reviews.userReview && (
             <div className="flex items-center gap-2 rounded-lg border border-white/10 bg-white/[0.03] px-5 py-2.5 text-xs font-bold uppercase tracking-[0.08em] text-white/40">
               <CheckCircle2 size={18} className="text-emerald-500/50" />
               Reviewed
@@ -68,32 +70,73 @@ export function ReviewsSection({
                 key={reviews.userReview.id}
                 review={reviews.userReview}
                 isOwn={true}
+                onEdit={onEditReview}
                 onDelete={onDeleteReview}
               />
             </div>
           </div>
         )}
 
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {reviews.error && (
+          <div className="flex flex-col items-start gap-3 rounded-xl border border-rose-500/25 bg-rose-500/[0.08] px-5 py-4 text-sm text-rose-200 sm:flex-row sm:items-center sm:justify-between">
+            <span>{reviews.error}</span>
+            <button
+              type="button"
+              onClick={reviews.retry}
+              className="shrink-0 rounded-lg border border-rose-300/20 px-3 py-2 text-xs font-bold uppercase tracking-wider hover:bg-rose-300/10"
+            >
+              Try again
+            </button>
+          </div>
+        )}
+
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
           {reviews.isLoading && (
             <div className="col-span-full py-12 flex items-center justify-center">
               <Loader2 size={32} className="animate-spin text-white/50" />
             </div>
           )}
 
-          {hasAny ? (
+          {!reviews.error && !reviews.isLoading && hasAny ? (
             reviews.list.map((review) => (
               <ReviewCard key={review.id} review={review} />
             ))
-          ) : (
+          ) : !reviews.error && !reviews.isLoading ? (
             <div className="col-span-full flex flex-col items-center gap-4 rounded-xl border border-white/[0.08] bg-white/[0.025] px-6 py-14 text-center text-white/40">
               <MessageSquare size={48} strokeWidth={1} />
               <p className="font-semibold">
                 No reviews yet. Be the first player to share one.
               </p>
             </div>
-          )}
+          ) : null}
         </div>
+
+        {reviews.totalPages > 1 && !reviews.error && (
+          <nav
+            className="flex items-center justify-center gap-3"
+            aria-label="Review pages"
+          >
+            <button
+              type="button"
+              onClick={() => reviews.setPage(reviews.page - 1)}
+              disabled={reviews.page <= 1 || reviews.isLoading}
+              className="rounded-lg border border-white/10 px-4 py-2 text-xs font-bold text-white/60 transition hover:bg-white/[0.05] hover:text-white disabled:cursor-not-allowed disabled:opacity-30"
+            >
+              Previous
+            </button>
+            <span className="text-xs font-semibold text-white/35">
+              Page {reviews.page} of {reviews.totalPages}
+            </span>
+            <button
+              type="button"
+              onClick={() => reviews.setPage(reviews.page + 1)}
+              disabled={reviews.page >= reviews.totalPages || reviews.isLoading}
+              className="rounded-lg border border-white/10 px-4 py-2 text-xs font-bold text-white/60 transition hover:bg-white/[0.05] hover:text-white disabled:cursor-not-allowed disabled:opacity-30"
+            >
+              Next
+            </button>
+          </nav>
+        )}
       </div>
     </div>
   );

--- a/components/storefront/useItemController.ts
+++ b/components/storefront/useItemController.ts
@@ -22,13 +22,29 @@ export type ItemReviews = {
   /** Everyone else's reviews. The viewer's own is separated out below. */
   list: Review[];
   userReview: Review | null;
+  canReview: boolean;
+  summary: {
+    positiveReviews: number;
+    negativeReviews: number;
+    reviewScore: string | null;
+  } | null;
   total: number;
+  page: number;
+  totalPages: number;
   /** True only on the first load, so the list does not flash on revalidation. */
   isLoading: boolean;
   isSubmitting: boolean;
   isDeleting: boolean;
+  error: string | null;
   post: (input: { message: string; recommended: boolean }) => Promise<boolean>;
+  update: (input: {
+    message: string;
+    recommended: boolean;
+  }) => Promise<boolean>;
   remove: () => Promise<boolean>;
+  setPage: (page: number) => void;
+  retry: () => void;
+  clearError: () => void;
 };
 
 export type ItemControllerResult = {
@@ -44,9 +60,12 @@ export type ItemControllerResult = {
   backHref: string;
 };
 
-const okJson = (res: Response) => {
-  if (!res.ok) throw new Error(`Request failed: ${res.status}`);
-  return res.json();
+const okJson = async (res: Response) => {
+  const body = await res.json().catch(() => null);
+  if (!res.ok) {
+    throw new Error(body?.message || `Request failed: ${res.status}`);
+  }
+  return body;
 };
 
 /**
@@ -63,6 +82,7 @@ export function useItemController({
   storeSlug,
 }: ItemControllerOptions): ItemControllerResult {
   const router = useRouter();
+  const [reviewPage, setReviewPage] = useState(1);
 
   const {
     data: libraryData,
@@ -72,11 +92,12 @@ export function useItemController({
 
   const {
     data: reviewsData,
+    error: reviewsError,
     mutate: mutateReviews,
     isValidating: isReviewsLoading,
   } = useSWR<ReviewsApiResponse>(
-    `/api/v1/reviews?slug=${gameSlug}&page=1&limit=10`,
-    (url) => fetch(url).then((res) => res.json()),
+    `/api/v1/reviews?slug=${gameSlug}&page=${reviewPage}&limit=10`,
+    (url) => fetch(url).then(okJson),
   );
 
   const { data: wishlistData, mutate: mutateWishlist } = useSWR(
@@ -96,6 +117,9 @@ export function useItemController({
   const [showSuccessModal, setShowSuccessModal] = useState(false);
   const [isSubmittingReview, setIsSubmittingReview] = useState(false);
   const [isDeletingReview, setIsDeletingReview] = useState(false);
+  const [reviewActionError, setReviewActionError] = useState<string | null>(
+    null,
+  );
   const [isToggling, setIsToggling] = useState(false);
 
   const redeem = async () => {
@@ -135,6 +159,7 @@ export function useItemController({
   }) => {
     if (!input.message.trim()) return false;
 
+    setReviewActionError(null);
     setIsSubmittingReview(true);
     try {
       const res = await fetch("/api/v1/reviews", {
@@ -143,13 +168,52 @@ export function useItemController({
         body: JSON.stringify({ slug: gameSlug, ...input }),
       });
 
-      if (!res.ok) throw new Error("Failed to post review");
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.message || "Failed to post review");
+      }
+
+      setReviewPage(1);
+      await mutateReviews();
+      return true;
+    } catch (error) {
+      console.error(error);
+      setReviewActionError(
+        error instanceof Error ? error.message : "Failed to submit review.",
+      );
+      return false;
+    } finally {
+      setIsSubmittingReview(false);
+    }
+  };
+
+  const updateReview = async (input: {
+    message: string;
+    recommended: boolean;
+  }) => {
+    if (!input.message.trim()) return false;
+
+    setReviewActionError(null);
+    setIsSubmittingReview(true);
+    try {
+      const res = await fetch("/api/v1/reviews", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ slug: gameSlug, ...input }),
+      });
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.message || "Failed to update review");
+      }
 
       await mutateReviews();
       return true;
     } catch (error) {
       console.error(error);
-      alert("Failed to submit review.");
+      setReviewActionError(
+        error instanceof Error ? error.message : "Failed to update review.",
+      );
       return false;
     } finally {
       setIsSubmittingReview(false);
@@ -157,6 +221,7 @@ export function useItemController({
   };
 
   const removeReview = async () => {
+    setReviewActionError(null);
     setIsDeletingReview(true);
     try {
       const res = await fetch("/api/v1/reviews", {
@@ -165,13 +230,19 @@ export function useItemController({
         body: JSON.stringify({ slug: gameSlug }),
       });
 
-      if (!res.ok) throw new Error("Failed to delete review");
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.message || "Failed to delete review");
+      }
 
+      setReviewPage(1);
       await mutateReviews();
       return true;
     } catch (error) {
       console.error(error);
-      alert("Failed to delete review.");
+      setReviewActionError(
+        error instanceof Error ? error.message : "Failed to delete review.",
+      );
       return false;
     } finally {
       setIsDeletingReview(false);
@@ -236,12 +307,29 @@ export function useItemController({
         (review) => review.id !== reviewsData?.user_review?.id,
       ),
       userReview: reviewsData?.user_review ?? null,
+      canReview: reviewsData?.can_review ?? false,
+      summary: reviewsData?.summary
+        ? {
+            positiveReviews: reviewsData.summary.positive_reviews,
+            negativeReviews: reviewsData.summary.negative_reviews,
+            reviewScore: reviewsData.summary.review_score,
+          }
+        : null,
       total: reviewsData?.pagination?.total_items ?? 0,
+      page: reviewsData?.pagination?.current_page ?? reviewPage,
+      totalPages: reviewsData?.pagination?.total_pages ?? 0,
       isLoading: !reviewsData && isReviewsLoading,
       isSubmitting: isSubmittingReview,
       isDeleting: isDeletingReview,
+      error:
+        reviewActionError ||
+        (reviewsError instanceof Error ? reviewsError.message : null),
       post: postReview,
+      update: updateReview,
       remove: removeReview,
+      setPage: (page) => setReviewPage(Math.max(1, page)),
+      retry: () => void mutateReviews(),
+      clearError: () => setReviewActionError(null),
     },
 
     backHref: storeSlug ? `/store/${storeSlug}` : "/store",

--- a/models/authorization.ts
+++ b/models/authorization.ts
@@ -585,8 +585,6 @@ function filterOutput(user: Partial<User>, feature: string, resource: unknown) {
     const reviewOutput = resource as Review & { user: { username: string } };
     return {
       id: reviewOutput.id,
-      game_id: reviewOutput.game_id,
-      user_id: reviewOutput.user_id,
       message: reviewOutput.message,
       recommended: reviewOutput.recommended,
       created_at: reviewOutput.created_at,

--- a/models/game.ts
+++ b/models/game.ts
@@ -406,7 +406,12 @@ function deepMerge(target: any, source: any) {
 }
 
 async function findOnePublicBySlug(slug: string) {
-  return await findOneBySlug(slug);
+  return await prisma.game.findFirst({
+    where: {
+      slug,
+      status: "ACTIVE",
+    },
+  });
 }
 
 async function findOneBySlug(slug: string) {

--- a/models/game.ts
+++ b/models/game.ts
@@ -406,12 +406,7 @@ function deepMerge(target: any, source: any) {
 }
 
 async function findOnePublicBySlug(slug: string) {
-  return await prisma.game.findFirst({
-    where: {
-      slug,
-      status: "ACTIVE",
-    },
-  });
+  return await findOneBySlug(slug);
 }
 
 async function findOneBySlug(slug: string) {

--- a/models/review.ts
+++ b/models/review.ts
@@ -1,6 +1,7 @@
 import { prisma } from "infra/database";
 import gameModel from "models/game";
-import { NotFoundError, ValidationError } from "infra/errors";
+import library from "models/library";
+import { ForbiddenError, NotFoundError, ValidationError } from "infra/errors";
 import { Prisma } from "generated/prisma/client";
 
 async function add(
@@ -15,6 +16,13 @@ async function add(
     throw new NotFoundError({
       message: `The game with slug "${slug}" was not found.`,
       action: "Check if the slug is correct.",
+    });
+  }
+
+  if (!(await library.hasItem(userId, game.id))) {
+    throw new ForbiddenError({
+      message: "Only players who own this game can review it.",
+      action: "Add the game to your library before posting a review.",
     });
   }
 
@@ -64,6 +72,77 @@ async function add(
     }
     throw error;
   }
+}
+
+async function update(
+  userId: string,
+  slug: string,
+  message: string,
+  recommended: boolean,
+) {
+  const game = await gameModel.findOnePublicBySlug(slug);
+
+  if (!game) {
+    throw new NotFoundError({
+      message: `The game with slug "${slug}" was not found.`,
+      action: "Check if the slug is correct.",
+    });
+  }
+
+  if (!(await library.hasItem(userId, game.id))) {
+    throw new ForbiddenError({
+      message: "Only players who own this game can review it.",
+      action: "Add the game to your library before updating a review.",
+    });
+  }
+
+  const existingReview = await prisma.review.findUnique({
+    where: {
+      user_id_game_id: {
+        user_id: userId,
+        game_id: game.id,
+      },
+    },
+  });
+
+  if (!existingReview) {
+    throw new NotFoundError({
+      message: "Review not found.",
+      action: "Post a review before trying to update it.",
+    });
+  }
+
+  await prisma.$transaction(async (tx) => {
+    await tx.review.update({
+      where: { id: existingReview.id },
+      data: { message, recommended },
+    });
+
+    if (existingReview.recommended === recommended) return;
+
+    const updatedGame = await tx.game.update({
+      where: { id: game.id },
+      data: recommended
+        ? {
+            positive_reviews: { increment: 1 },
+            negative_reviews: { decrement: 1 },
+          }
+        : {
+            positive_reviews: { decrement: 1 },
+            negative_reviews: { increment: 1 },
+          },
+    });
+
+    await tx.game.update({
+      where: { id: game.id },
+      data: {
+        review_score: gameModel.calculateReviewScore(
+          updatedGame.positive_reviews,
+          updatedGame.negative_reviews,
+        ),
+      },
+    });
+  });
 }
 
 async function remove(userId: string, slug: string) {
@@ -173,20 +252,43 @@ async function getPaginatedReviewsBySlug(
   }));
 
   let userReview = null;
+  let canReview = false;
   if (userId) {
-    userReview = await prisma.review.findUnique({
-      where: {
-        user_id_game_id: {
-          user_id: userId,
-          game_id: game.id,
+    const [ownReview, ownUser, ownsGame] = await Promise.all([
+      prisma.review.findUnique({
+        where: {
+          user_id_game_id: {
+            user_id: userId,
+            game_id: game.id,
+          },
         },
-      },
-    });
+      }),
+      prisma.user.findUnique({
+        where: { id: userId },
+        select: { id: true, username: true },
+      }),
+      library.hasItem(userId, game.id),
+    ]);
+
+    canReview = ownsGame;
+
+    userReview = ownReview
+      ? {
+          ...ownReview,
+          user: ownUser || { id: userId, username: "Unknown" },
+        }
+      : null;
   }
 
   return {
     reviews: reviewsWithUser,
     user_review: userReview,
+    can_review: canReview,
+    summary: {
+      positive_reviews: game.positive_reviews,
+      negative_reviews: game.negative_reviews,
+      review_score: game.review_score,
+    },
     pagination: {
       total_items: totalCount,
       total_pages: Math.ceil(totalCount / limit),
@@ -198,6 +300,7 @@ async function getPaginatedReviewsBySlug(
 
 const review = {
   add,
+  update,
   remove,
   getPaginatedReviewsBySlug,
 };

--- a/models/review.ts
+++ b/models/review.ts
@@ -4,13 +4,19 @@ import library from "models/library";
 import { ForbiddenError, NotFoundError, ValidationError } from "infra/errors";
 import { Prisma } from "generated/prisma/client";
 
+async function findReviewableGame(slug: string) {
+  const game = await gameModel.findOneBySlug(slug);
+
+  return game?.status === "ACTIVE" ? game : null;
+}
+
 async function add(
   userId: string,
   slug: string,
   message: string,
   recommended: boolean,
 ) {
-  const game = await gameModel.findOnePublicBySlug(slug);
+  const game = await findReviewableGame(slug);
 
   if (!game) {
     throw new NotFoundError({
@@ -80,7 +86,7 @@ async function update(
   message: string,
   recommended: boolean,
 ) {
-  const game = await gameModel.findOnePublicBySlug(slug);
+  const game = await findReviewableGame(slug);
 
   if (!game) {
     throw new NotFoundError({
@@ -146,7 +152,7 @@ async function update(
 }
 
 async function remove(userId: string, slug: string) {
-  const game = await gameModel.findOnePublicBySlug(slug);
+  const game = await findReviewableGame(slug);
 
   if (!game) {
     throw new NotFoundError({
@@ -209,7 +215,7 @@ async function getPaginatedReviewsBySlug(
   limit: number,
   userId?: string,
 ) {
-  const game = await gameModel.findOnePublicBySlug(slug);
+  const game = await findReviewableGame(slug);
 
   if (!game) {
     throw new NotFoundError({

--- a/pages/api/v1/reviews/index.ts
+++ b/pages/api/v1/reviews/index.ts
@@ -18,7 +18,7 @@ const bodySchema = z.object({
 
 const postBodySchema = z.object({
   slug: z.string().min(1),
-  message: z.string().min(1).max(3000),
+  message: z.string().trim().min(1).max(3000),
   recommended: z.boolean(),
 });
 
@@ -26,6 +26,7 @@ export default createRouter<NextApiRequest, NextApiResponse>()
   .use(controller.injectAnonymousOrUser)
   .get(controller.canRequest("read:review"), getHandler)
   .post(controller.canRequest("create:review"), postHandler)
+  .patch(controller.canRequest("create:review"), patchHandler)
   .delete(controller.canRequest("delete:review"), deleteHandler)
   .handler(controller.errorHandlers);
 
@@ -64,6 +65,8 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
   return res.status(200).json({
     reviews: filteredReviews,
     user_review: filteredUserReview,
+    can_review: result.can_review,
+    summary: result.summary,
     pagination: result.pagination,
   });
 }
@@ -120,4 +123,31 @@ async function deleteHandler(req: NextApiRequest, res: NextApiResponse) {
   await review.remove(userTryingToReview.id, slug);
 
   return res.status(200).json({ message: "Review deleted successfully" });
+}
+
+async function patchHandler(req: NextApiRequest, res: NextApiResponse) {
+  const userTryingToReview = req.context?.user;
+
+  if (!userTryingToReview?.id) {
+    throw new ValidationError({
+      message: "User ID is missing.",
+      action: "You must be logged in to update a review.",
+    });
+  }
+
+  const parsedBody = postBodySchema.safeParse(req.body);
+
+  if (!parsedBody.success) {
+    throw new ValidationError({
+      message: "Request body validation failed.",
+      action: "Provide slug, message, and recommended boolean.",
+      cause: parsedBody.error,
+    });
+  }
+
+  const { slug, message, recommended } = parsedBody.data;
+
+  await review.update(userTryingToReview.id, slug, message, recommended);
+
+  return res.status(200).json({ message: "Review updated successfully" });
 }

--- a/tests/integration/api/v1/reviews/delete.test.ts
+++ b/tests/integration/api/v1/reviews/delete.test.ts
@@ -26,6 +26,10 @@ describe("DELETE /api/v1/reviews", () => {
       await orchestrator.activateUser(user.id);
       const session = await orchestrator.createSession(user.id);
       const game = await orchestrator.createGame(user.id);
+      await prisma.game.update({
+        where: { id: game.id },
+        data: { status: "ACTIVE" },
+      });
 
       await prisma.review.create({
         data: {
@@ -68,6 +72,10 @@ describe("DELETE /api/v1/reviews", () => {
       await orchestrator.activateUser(user.id);
       const session = await orchestrator.createSession(user.id);
       const game = await orchestrator.createGame(user.id);
+      await prisma.game.update({
+        where: { id: game.id },
+        data: { status: "ACTIVE" },
+      });
 
       const response = await fetch(`${webserver.getOrigin()}/api/v1/reviews`, {
         method: "DELETE",

--- a/tests/integration/api/v1/reviews/get.test.ts
+++ b/tests/integration/api/v1/reviews/get.test.ts
@@ -12,6 +12,10 @@ describe("GET /api/v1/reviews", () => {
     test("With valid slug should return paginated reviews", async () => {
       const gameCreator = await orchestrator.createUser();
       const game = await orchestrator.createGame(gameCreator.id);
+      await prisma.game.update({
+        where: { id: game.id },
+        data: { status: "ACTIVE" },
+      });
 
       const user1 = await orchestrator.createUser({
         username: "reviewer1",
@@ -57,6 +61,14 @@ describe("GET /api/v1/reviews", () => {
       expect(responseBody.reviews[0].message).toBeDefined();
       expect(responseBody.reviews[0].user.username).toBeDefined();
       expect(responseBody.reviews[0].user.email).toBeUndefined();
+      expect(responseBody.reviews[0].user_id).toBeUndefined();
+      expect(responseBody.reviews[0].game_id).toBeUndefined();
+      expect(responseBody.can_review).toBe(false);
+      expect(responseBody.summary).toMatchObject({
+        positive_reviews: 0,
+        negative_reviews: 0,
+        review_score: "MIXED",
+      });
     });
 
     test("With invalid slug should return 404", async () => {
@@ -68,6 +80,50 @@ describe("GET /api/v1/reviews", () => {
       );
 
       expect(response.status).toBe(404);
+    });
+
+    test("With a private game should return 404", async () => {
+      const gameCreator = await orchestrator.createUser();
+      const game = await orchestrator.createGame(gameCreator.id);
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/reviews?slug=${game.slug}`,
+      );
+
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("Authenticated user", () => {
+    test("Should include the owner identity and review eligibility", async () => {
+      const user = await orchestrator.createUser({ username: "reviewowner" });
+      await orchestrator.activateUser(user.id);
+      const session = await orchestrator.createSession(user.id);
+      const game = await orchestrator.createGame(user.id);
+      await prisma.game.update({
+        where: { id: game.id },
+        data: { status: "ACTIVE" },
+      });
+      await orchestrator.addToLibrary(user.id, game.id);
+      await prisma.review.create({
+        data: {
+          user_id: user.id,
+          game_id: game.id,
+          message: "My own review",
+          recommended: true,
+        },
+      });
+
+      const response = await fetch(
+        `${webserver.getOrigin()}/api/v1/reviews?slug=${game.slug}`,
+        { headers: { Cookie: `session_id=${session.token}` } },
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.can_review).toBe(true);
+      expect(body.user_review.user.username).toBe("reviewowner");
+      expect(body.user_review.user.email).toBeUndefined();
     });
   });
 });

--- a/tests/integration/api/v1/reviews/patch.test.ts
+++ b/tests/integration/api/v1/reviews/patch.test.ts
@@ -1,0 +1,157 @@
+import orchestrator from "tests/orchestrator";
+import webserver from "infra/webserver";
+import { prisma } from "infra/database";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+describe("PATCH /api/v1/reviews", () => {
+  test("Anonymous user should return 403", async () => {
+    const response = await fetch(`${webserver.getOrigin()}/api/v1/reviews`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        slug: "some-game",
+        message: "Updated review",
+        recommended: true,
+      }),
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  test("Owner can update the message and recommendation", async () => {
+    const user = await orchestrator.createUser();
+    await orchestrator.activateUser(user.id);
+    const session = await orchestrator.createSession(user.id);
+    const game = await orchestrator.createGame(user.id);
+    await prisma.game.update({
+      where: { id: game.id },
+      data: {
+        status: "ACTIVE",
+        positive_reviews: 1,
+        negative_reviews: 0,
+        review_score: "POSITIVE",
+      },
+    });
+    await orchestrator.addToLibrary(user.id, game.id);
+    await prisma.review.create({
+      data: {
+        user_id: user.id,
+        game_id: game.id,
+        message: "It was good.",
+        recommended: true,
+      },
+    });
+
+    const response = await fetch(`${webserver.getOrigin()}/api/v1/reviews`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `session_id=${session.token}`,
+      },
+      body: JSON.stringify({
+        slug: game.slug,
+        message: "I changed my mind.",
+        recommended: false,
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).message).toBe("Review updated successfully");
+
+    const updatedReview = await prisma.review.findUnique({
+      where: { user_id_game_id: { user_id: user.id, game_id: game.id } },
+    });
+    const updatedGame = await prisma.game.findUnique({
+      where: { id: game.id },
+    });
+
+    expect(updatedReview?.message).toBe("I changed my mind.");
+    expect(updatedReview?.recommended).toBe(false);
+    expect(updatedGame?.positive_reviews).toBe(0);
+    expect(updatedGame?.negative_reviews).toBe(1);
+    expect(updatedGame?.review_score).toBe("NEGATIVE");
+  });
+
+  test("Updating text without changing recommendation keeps counters stable", async () => {
+    const user = await orchestrator.createUser();
+    await orchestrator.activateUser(user.id);
+    const session = await orchestrator.createSession(user.id);
+    const game = await orchestrator.createGame(user.id);
+    await prisma.game.update({
+      where: { id: game.id },
+      data: {
+        status: "ACTIVE",
+        positive_reviews: 1,
+        review_score: "POSITIVE",
+      },
+    });
+    await orchestrator.addToLibrary(user.id, game.id);
+    await prisma.review.create({
+      data: {
+        user_id: user.id,
+        game_id: game.id,
+        message: "Original",
+        recommended: true,
+      },
+    });
+
+    const response = await fetch(`${webserver.getOrigin()}/api/v1/reviews`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `session_id=${session.token}`,
+      },
+      body: JSON.stringify({
+        slug: game.slug,
+        message: "Edited text only",
+        recommended: true,
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const updatedGame = await prisma.game.findUnique({
+      where: { id: game.id },
+    });
+    expect(updatedGame?.positive_reviews).toBe(1);
+    expect(updatedGame?.negative_reviews).toBe(0);
+  });
+
+  test("Non-owner cannot update a review", async () => {
+    const gameCreator = await orchestrator.createUser();
+    const reviewer = await orchestrator.createUser();
+    await orchestrator.activateUser(reviewer.id);
+    const session = await orchestrator.createSession(reviewer.id);
+    const game = await orchestrator.createGame(gameCreator.id);
+    await prisma.game.update({
+      where: { id: game.id },
+      data: { status: "ACTIVE" },
+    });
+    await prisma.review.create({
+      data: {
+        user_id: reviewer.id,
+        game_id: game.id,
+        message: "Legacy review without entitlement",
+        recommended: true,
+      },
+    });
+
+    const response = await fetch(`${webserver.getOrigin()}/api/v1/reviews`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `session_id=${session.token}`,
+      },
+      body: JSON.stringify({
+        slug: game.slug,
+        message: "Trying to update",
+        recommended: false,
+      }),
+    });
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/tests/integration/api/v1/reviews/post.test.ts
+++ b/tests/integration/api/v1/reviews/post.test.ts
@@ -30,6 +30,11 @@ describe("POST /api/v1/reviews", () => {
       await orchestrator.activateUser(user.id);
       const session = await orchestrator.createSession(user.id);
       const game = await orchestrator.createGame(user.id);
+      await prisma.game.update({
+        where: { id: game.id },
+        data: { status: "ACTIVE" },
+      });
+      await orchestrator.addToLibrary(user.id, game.id);
 
       const response = await fetch(`${webserver.getOrigin()}/api/v1/reviews`, {
         method: "POST",
@@ -67,6 +72,11 @@ describe("POST /api/v1/reviews", () => {
       await orchestrator.activateUser(user.id);
       const session = await orchestrator.createSession(user.id);
       const game = await orchestrator.createGame(user.id);
+      await prisma.game.update({
+        where: { id: game.id },
+        data: { status: "ACTIVE" },
+      });
+      await orchestrator.addToLibrary(user.id, game.id);
 
       await fetch(`${webserver.getOrigin()}/api/v1/reviews`, {
         method: "POST",
@@ -117,6 +127,57 @@ describe("POST /api/v1/reviews", () => {
           Cookie: `session_id=${session.token}`,
         },
         body: JSON.stringify({}),
+      });
+
+      expect(response.status).toBe(400);
+    });
+
+    test("Without owning the game should return 403", async () => {
+      const gameCreator = await orchestrator.createUser();
+      const reviewer = await orchestrator.createUser();
+      await orchestrator.activateUser(reviewer.id);
+      const session = await orchestrator.createSession(reviewer.id);
+      const game = await orchestrator.createGame(gameCreator.id);
+      await prisma.game.update({
+        where: { id: game.id },
+        data: { status: "ACTIVE" },
+      });
+
+      const response = await fetch(`${webserver.getOrigin()}/api/v1/reviews`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: `session_id=${session.token}`,
+        },
+        body: JSON.stringify({
+          slug: game.slug,
+          message: "I do not own this game.",
+          recommended: true,
+        }),
+      });
+
+      expect(response.status).toBe(403);
+      expect((await response.json()).message).toBe(
+        "Only players who own this game can review it.",
+      );
+    });
+
+    test("With a whitespace-only message should return 400", async () => {
+      const user = await orchestrator.createUser();
+      await orchestrator.activateUser(user.id);
+      const session = await orchestrator.createSession(user.id);
+
+      const response = await fetch(`${webserver.getOrigin()}/api/v1/reviews`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: `session_id=${session.token}`,
+        },
+        body: JSON.stringify({
+          slug: "some-game",
+          message: "   ",
+          recommended: true,
+        }),
       });
 
       expect(response.status).toBe(400);


### PR DESCRIPTION
## What changed

- require game ownership before creating or editing a review
- add review editing with transactional score updates
- fix the current user's author identity
- add review pagination, inline errors and a 3,000-character counter
- update aggregate review scores without reloading the page
- hide internal user and game IDs from public review responses
- prevent public review access for private or inactive games
- expand integration coverage for ownership, visibility and PATCH behavior

## Validation

- production build passed
- ESLint passed with only the two existing image warnings
- local integration services could not start because Docker Desktop was not running; GitHub CI will run the full suite

## Dependency

This is a stacked PR based on codex/storefront-ui-system so its diff remains separate from PR #227. After #227 merges, this PR can be retargeted to main.