### PR TITLE
fix: restore game acquisition flow

### DIFF
--- a/components/storefront/default/item/DefaultItemPage.tsx
+++ b/components/storefront/default/item/DefaultItemPage.tsx
@@ -10,6 +10,7 @@ import {
   ConfirmDeleteReviewModal,
 } from "components/storefront/default/item/ItemModals";
 import type { ItemViewProps } from "components/storefront/types";
+import { isFree } from "lib/price";
 
 /**
  * Manifold's own product page, and the fallback for any outlet without a
@@ -22,8 +23,10 @@ export function DefaultItemPage({
   game,
   store,
   isInLibrary,
+  isCheckingLibrary,
   isRedeeming,
   redeem,
+  acquisitionError,
   showSuccessModal,
   dismissSuccess,
   wishlist,
@@ -33,10 +36,7 @@ export function DefaultItemPage({
   const [reviewMode, setReviewMode] = useState<"create" | "edit" | null>(null);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
 
-  // TODO: hardcoded rather than derived from the game's price. Preserved from
-  // the previous implementation because changing it changes what every
-  // customer is charged, which needs its own decision.
-  const isDemo = true;
+  const isFreeGame = isFree(game);
 
   return (
     <>
@@ -62,9 +62,11 @@ export function DefaultItemPage({
           <aside className="flex flex-col gap-8 lg:col-span-4">
             <PurchaseCard
               game={game}
-              isDemo={isDemo}
+              isFreeGame={isFreeGame}
               isInLibrary={isInLibrary}
+              isCheckingLibrary={isCheckingLibrary}
               isRedeeming={isRedeeming}
+              acquisitionError={acquisitionError}
               onRedeem={redeem}
               wishlist={wishlist}
             />

--- a/components/storefront/default/item/DefaultItemPage.tsx
+++ b/components/storefront/default/item/DefaultItemPage.tsx
@@ -93,7 +93,11 @@ export function DefaultItemPage({
       </main>
 
       {showSuccessModal && (
-        <RedeemSuccessModal gameTitle={game.title} onDismiss={dismissSuccess} />
+        <RedeemSuccessModal
+          gameTitle={game.title}
+          continueHref={backHref}
+          onDismiss={dismissSuccess}
+        />
       )}
 
       {reviewMode && (

--- a/components/storefront/default/item/ItemModals.tsx
+++ b/components/storefront/default/item/ItemModals.tsx
@@ -30,7 +30,9 @@ export function RedeemSuccessModal({
           <CheckCircle2 size={48} className="text-emerald-400" />
         </div>
 
-        <h2 className="text-2xl font-black text-white mb-4">Game Redeemed!</h2>
+        <h2 className="text-2xl font-black text-white mb-4">
+          Added to your library
+        </h2>
 
         <p className="text-white/60 mb-8">
           Successfully added{" "}

--- a/components/storefront/default/item/ItemModals.tsx
+++ b/components/storefront/default/item/ItemModals.tsx
@@ -11,16 +11,24 @@ import {
 
 export function RedeemSuccessModal({
   gameTitle,
+  continueHref,
   onDismiss,
 }: {
   gameTitle: string;
+  continueHref: string;
   onDismiss: () => void;
 }) {
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4 backdrop-blur-sm animate-in fade-in duration-300">
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4 backdrop-blur-sm animate-in fade-in duration-300"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="acquisition-success-title"
+    >
       <div className="relative flex w-full max-w-md flex-col items-center rounded-xl border border-white/10 bg-[#14101c] p-8 text-center shadow-2xl animate-in zoom-in-95 duration-300">
         <button
           onClick={onDismiss}
+          aria-label="Close success message"
           className="absolute top-4 right-4 text-white/50 hover:text-white transition-colors"
         >
           <X size={24} />
@@ -30,7 +38,10 @@ export function RedeemSuccessModal({
           <CheckCircle2 size={48} className="text-emerald-400" />
         </div>
 
-        <h2 className="text-2xl font-black text-white mb-4">
+        <h2
+          id="acquisition-success-title"
+          className="text-2xl font-black text-white mb-4"
+        >
           Added to your library
         </h2>
 
@@ -46,14 +57,14 @@ export function RedeemSuccessModal({
             href="/library"
             className="w-full py-4 rounded-xl bg-white text-black font-black uppercase tracking-wider hover:scale-[1.02] transition-transform"
           >
-            Go to Library
+            View in Library
           </Link>
-          <button
-            onClick={onDismiss}
+          <Link
+            href={continueHref}
             className="w-full py-4 rounded-xl border border-white/10 text-white font-bold uppercase hover:bg-white/5 transition-colors"
           >
-            Continue Browsing
-          </button>
+            Continue Shopping
+          </Link>
         </div>
       </div>
     </div>

--- a/components/storefront/default/item/PurchaseCard.tsx
+++ b/components/storefront/default/item/PurchaseCard.tsx
@@ -20,16 +20,20 @@ import type { ItemWishlist } from "components/storefront/useItemController";
 
 export function PurchaseCard({
   game,
-  isDemo,
+  isFreeGame,
   isInLibrary,
+  isCheckingLibrary,
   isRedeeming,
+  acquisitionError,
   onRedeem,
   wishlist,
 }: {
   game: GameDetailApi;
-  isDemo: boolean;
+  isFreeGame: boolean;
   isInLibrary: boolean;
+  isCheckingLibrary: boolean;
   isRedeeming: boolean;
+  acquisitionError: string | null;
   onRedeem: () => void;
   wishlist: ItemWishlist;
 }) {
@@ -40,7 +44,7 @@ export function PurchaseCard({
       <div className="flex flex-col gap-6">
         <div className="flex items-center justify-between">
           <div className="flex flex-col">
-            {!isDemo && formatBasePrice(game) && (
+            {!isFreeGame && formatBasePrice(game) && (
               <span className="text-sm font-semibold text-white/35 line-through">
                 {formatBasePrice(game)}
               </span>
@@ -49,10 +53,10 @@ export function PurchaseCard({
               className="text-3xl font-black uppercase tracking-tight"
               style={{ color: discountBadgeColor }}
             >
-              {isDemo ? "Free" : formatPrice(game)}
+              {isFreeGame ? "Free" : formatPrice(game)}
             </span>
           </div>
-          {!isDemo && game.discount_label && (
+          {!isFreeGame && game.discount_label && (
             <DiscountBadge label={game.discount_label} />
           )}
         </div>
@@ -67,11 +71,28 @@ export function PurchaseCard({
         ) : (
           <button
             onClick={onRedeem}
-            disabled={isRedeeming}
+            disabled={isCheckingLibrary || isRedeeming}
             className="w-full rounded-lg bg-gradient-to-r from-violet-600 to-fuchsia-500 px-5 py-3.5 text-sm font-black uppercase tracking-[0.08em] text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
           >
-            {isRedeeming ? "Redeeming..." : isDemo ? "Redeem Demo" : "Redeem"}
+            {isCheckingLibrary
+              ? "Checking library..."
+              : isRedeeming
+                ? isFreeGame
+                  ? "Adding..."
+                  : "Processing..."
+                : isFreeGame
+                  ? "Add to Library"
+                  : `Buy now · ${formatPrice(game)}`}
           </button>
+        )}
+
+        {acquisitionError && (
+          <p
+            role="alert"
+            className="rounded-lg border border-rose-500/25 bg-rose-500/10 px-4 py-3 text-sm font-semibold leading-5 text-rose-200"
+          >
+            {acquisitionError}
+          </p>
         )}
 
         {game.social_links.steam_page ? (

--- a/components/storefront/useItemController.ts
+++ b/components/storefront/useItemController.ts
@@ -50,8 +50,10 @@ export type ItemReviews = {
 export type ItemControllerResult = {
   isLoggedOut: boolean;
   isInLibrary: boolean;
+  isCheckingLibrary: boolean;
   isRedeeming: boolean;
   redeem: () => void;
+  acquisitionError: string | null;
   showSuccessModal: boolean;
   dismissSuccess: () => void;
   wishlist: ItemWishlist;
@@ -60,13 +62,28 @@ export type ItemControllerResult = {
   backHref: string;
 };
 
+class ApiRequestError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "ApiRequestError";
+    this.status = status;
+  }
+}
+
 const okJson = async (res: Response) => {
   const body = await res.json().catch(() => null);
   if (!res.ok) {
-    throw new Error(body?.message || `Request failed: ${res.status}`);
+    throw new ApiRequestError(
+      body?.message || `Request failed: ${res.status}`,
+      res.status,
+    );
   }
   return body;
 };
+
+const fetchJson = (url: string) => fetch(url).then(okJson);
 
 /**
  * Everything the product page does beyond rendering: ownership, wishlist and
@@ -88,7 +105,13 @@ export function useItemController({
     data: libraryData,
     error: libraryError,
     mutate: mutateLibrary,
-  } = useSWR("/api/v1/library", okJson, { shouldRetryOnError: false });
+  } = useSWR(
+    `/api/v1/library?slug=${encodeURIComponent(gameSlug)}`,
+    fetchJson,
+    {
+      shouldRetryOnError: false,
+    },
+  );
 
   const {
     data: reviewsData,
@@ -97,7 +120,7 @@ export function useItemController({
     isValidating: isReviewsLoading,
   } = useSWR<ReviewsApiResponse>(
     `/api/v1/reviews?slug=${gameSlug}&page=${reviewPage}&limit=10`,
-    (url) => fetch(url).then(okJson),
+    fetchJson,
   );
 
   const { data: wishlistData, mutate: mutateWishlist } = useSWR(
@@ -105,15 +128,23 @@ export function useItemController({
     (url) => fetch(url).then((res) => res.json()),
   );
 
-  // A failing /api/v1/library is how the page learns there is no session; the
-  // endpoint 401s for an anonymous visitor.
-  const isLoggedOut = !!libraryError;
+  // Anonymous access is forbidden, while a server-side failure is a real
+  // library error and must not be disguised as a login redirect.
+  const isLoggedOut =
+    libraryError instanceof ApiRequestError &&
+    (libraryError.status === 401 || libraryError.status === 403);
+  const isCheckingLibrary = !libraryData && !libraryError;
+  const [hasJustAcquired, setHasJustAcquired] = useState(false);
   const isInLibrary =
+    hasJustAcquired ||
+    libraryData?.is_owned ||
     libraryData?.games?.some(
       (item: { game: { slug: string } }) => item.game.slug === gameSlug,
-    ) || false;
+    ) ||
+    false;
 
   const [isRedeeming, setIsRedeeming] = useState(false);
+  const [acquisitionError, setAcquisitionError] = useState<string | null>(null);
   const [showSuccessModal, setShowSuccessModal] = useState(false);
   const [isSubmittingReview, setIsSubmittingReview] = useState(false);
   const [isDeletingReview, setIsDeletingReview] = useState(false);
@@ -123,6 +154,8 @@ export function useItemController({
   const [isToggling, setIsToggling] = useState(false);
 
   const redeem = async () => {
+    setAcquisitionError(null);
+
     if (isLoggedOut) {
       router.push(
         `/login?callbackUrl=${encodeURIComponent(
@@ -132,7 +165,7 @@ export function useItemController({
       return;
     }
 
-    if (isInLibrary || isRedeeming) return;
+    if (isCheckingLibrary || isInLibrary || isRedeeming) return;
 
     setIsRedeeming(true);
     try {
@@ -142,12 +175,23 @@ export function useItemController({
         body: JSON.stringify({ slug: gameSlug, store_slug: storeSlug }),
       });
 
-      if (!res.ok) throw new Error("Failed to redeem");
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(
+          body?.message || "We could not add this game to your library.",
+        );
+      }
 
-      mutateLibrary();
+      setHasJustAcquired(true);
+      void mutateLibrary();
       setShowSuccessModal(true);
     } catch (error) {
       console.error(error);
+      setAcquisitionError(
+        error instanceof Error
+          ? error.message
+          : "We could not add this game to your library.",
+      );
     } finally {
       setIsRedeeming(false);
     }
@@ -288,8 +332,14 @@ export function useItemController({
   return {
     isLoggedOut,
     isInLibrary,
+    isCheckingLibrary,
     isRedeeming,
     redeem,
+    acquisitionError:
+      acquisitionError ||
+      (!isLoggedOut && libraryError instanceof Error
+        ? libraryError.message
+        : null),
     showSuccessModal,
     dismissSuccess: () => setShowSuccessModal(false),
 

--- a/models/library.ts
+++ b/models/library.ts
@@ -39,8 +39,13 @@ async function acquireGame(
   );
 
   const affiliate = await resolveAffiliateLeniently(storeSlug);
-  const supplierCostRate =
-    await commercialTerms.supplierCostRateFor(existingGame);
+  // A free acquisition still gets a Sale row so attribution and acquisition
+  // history stay intact, but it moves no money. Looking up commercial terms or
+  // writing a zero-value ledger set would be both unnecessary and invalid: the
+  // ledger deliberately rejects entries whose amount is zero.
+  const supplierCostRate = resolvedPrice.amount.isZero()
+    ? null
+    : await commercialTerms.supplierCostRateFor(existingGame);
 
   return await prisma.$transaction(async (tx) => {
     // The entitlement is idempotent; the Sale deliberately is not. A Sale
@@ -78,14 +83,16 @@ async function acquireGame(
       },
     });
 
-    await recordSaleEntries(tx, {
-      sale_id: sale.id,
-      gross: resolvedPrice.amount,
-      currency: resolvedPrice.currency,
-      exchange_rate: resolvedPrice.exchange_rate,
-      supplier_cost_rate: supplierCostRate,
-      affiliate,
-    });
+    if (!resolvedPrice.amount.isZero() && supplierCostRate) {
+      await recordSaleEntries(tx, {
+        sale_id: sale.id,
+        gross: resolvedPrice.amount,
+        currency: resolvedPrice.currency,
+        exchange_rate: resolvedPrice.exchange_rate,
+        supplier_cost_rate: supplierCostRate,
+        affiliate,
+      });
+    }
 
     return libraryItem;
   });
@@ -304,9 +311,16 @@ async function hasItem(
   return !!item;
 }
 
+async function hasGameBySlug(userId: string, gameSlug: string) {
+  const existingGame = await game.findOneBySlug(gameSlug);
+
+  return existingGame ? hasItem(userId, existingGame.id, "GAME") : false;
+}
+
 const library = {
   add,
   hasItem,
+  hasGameBySlug,
   findAllPaginatedGamesByUserId,
   acquireGame,
 };

--- a/pages/api/v1/library/index.ts
+++ b/pages/api/v1/library/index.ts
@@ -10,6 +10,7 @@ import { ValidationError } from "infra/errors";
 const querySchema = z.object({
   page: z.coerce.number().min(1).default(1),
   limit: z.coerce.number().min(1).max(100).default(20),
+  slug: z.string().min(1).max(255).optional(),
 });
 
 export default createRouter<NextApiRequest, NextApiResponse>()
@@ -29,13 +30,12 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
     });
   }
 
-  const { page, limit } = parsedQuery.data;
+  const { page, limit, slug } = parsedQuery.data;
 
-  const result = await library.findAllPaginatedGamesByUserId(
-    req.context.user.id!,
-    page,
-    limit,
-  );
+  const [result, isOwned] = await Promise.all([
+    library.findAllPaginatedGamesByUserId(req.context.user.id!, page, limit),
+    slug ? library.hasGameBySlug(req.context.user.id!, slug) : false,
+  ]);
 
   const filteredGames = result.games.map((item) => {
     return authorization.filterOutput(req.context.user, "read:library", item);
@@ -43,6 +43,7 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
 
   return res.status(200).json({
     games: filteredGames,
+    ...(slug ? { is_owned: isOwned } : {}),
     pagination: result.pagination,
   });
 }

--- a/tests/integration/api/v1/library/get.test.ts
+++ b/tests/integration/api/v1/library/get.test.ts
@@ -214,6 +214,18 @@ describe("GET /api/v1/library", () => {
       });
       // Should be Game 1
       expect(body2.games[0].item_id).toBe(game1.id);
+
+      const ownershipResponse = await fetch(
+        `${webserver.getOrigin()}/api/v1/library?page=1&limit=1&slug=${game1.slug}`,
+        {
+          headers: { Cookie: `session_id=${session.token}` },
+        },
+      );
+      expect(ownershipResponse.status).toBe(200);
+      const ownershipBody = await ownershipResponse.json();
+      expect(ownershipBody.games).toHaveLength(1);
+      expect(ownershipBody.games[0].item_id).not.toBe(game1.id);
+      expect(ownershipBody.is_owned).toBe(true);
     });
   });
 });

--- a/tests/integration/api/v1/library/post.test.ts
+++ b/tests/integration/api/v1/library/post.test.ts
@@ -123,6 +123,48 @@ describe("POST /api/v1/library", () => {
       expect(Date.parse(responseBody.acquired_at)).not.toBeNaN();
     });
 
+    test("With a free game should add it to a new user's library without ledger entries", async () => {
+      const creator = await orchestrator.createUser();
+      await orchestrator.activateUser(creator.id);
+      const game = await orchestrator.createGame(creator.id, { price: 0 });
+
+      const buyer = await orchestrator.createUser();
+      await orchestrator.activateUser(buyer.id);
+      const buyerSession = await orchestrator.createSession(buyer.id);
+
+      const response = await fetch(`${webserver.getOrigin()}/api/v1/library`, {
+        method: "POST",
+        headers: {
+          Cookie: `session_id=${buyerSession.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ slug: game.slug }),
+      });
+
+      expect(response.status).toBe(201);
+
+      const libraryItem = await prisma.libraryItem.findUnique({
+        where: {
+          user_id_item_id_item_type: {
+            user_id: buyer.id,
+            item_id: game.id,
+            item_type: "GAME",
+          },
+        },
+      });
+      expect(libraryItem).not.toBeNull();
+
+      const sale = await prisma.sale.findFirstOrThrow({
+        where: { user_id: buyer.id, game_id: game.id },
+      });
+      expect(sale.price_at_sale.isZero()).toBe(true);
+      expect(
+        await prisma.ledgerEntry.count({
+          where: { source_type: "SALE", source_id: sale.id },
+        }),
+      ).toBe(0);
+    });
+
     test("Without store_slug should record a Sale with a null store_id", async () => {
       const creator = await orchestrator.createUser();
       await orchestrator.activateUser(creator.id);

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -181,7 +181,7 @@ const createGame = async (userId, gameData = {}) => {
     detailed_description:
       gameData.detailed_description || faker.lorem.paragraph(),
     launch_date: gameData.launch_date || faker.date.past(),
-    price: gameData.price || faker.number.float(),
+    price: gameData.price === undefined ? faker.number.float() : gameData.price,
     tags: gameData.tags || [faker.lorem.word()],
     meta_tags: gameData.meta_tags || {},
     media: gameData.media || { screenshots: [], videos: [] },


### PR DESCRIPTION
## What changed

- fixes the library SWR fetcher that treated a URL string as a Response and caused the login redirect loop
- allows zero-price games to be acquired without invalid zero-value ledger entries
- derives Free/price and the acquisition CTA from real pricing data instead of labeling every game as a demo
- surfaces acquisition errors inline instead of logging them only to the console
- checks exact ownership by slug, even when the game is outside the first library page
- keeps successful acquisition state stable while the library revalidates

## Validation

- production build passes
- focused ESLint and Prettier checks pass
- browser QA confirms the paid MMO98 page shows its localized discounted price and preserves the login callback
- adds integration coverage for a newly activated user acquiring a free game with a zero-price Sale and no ledger entries
- adds ownership coverage for games outside the current library page

## Stack

This PR is intentionally based on #228 so the merge order is #227, #228, then this PR.