### PR TITLE
feat: add Outlet Featured curation backend

### DIFF
--- a/models/authorization.ts
+++ b/models/authorization.ts
@@ -109,6 +109,7 @@ const AVAILABLE_FEATURES = [
   "read:public_store",
   "update:store",
   "update:store:any",
+  "manage:store_featured_games",
   "manage:store_members",
   "manage:store_members:any",
   "read:store_tag_filter",
@@ -334,6 +335,7 @@ function can(user: Partial<User>, feature: string, resource?: unknown) {
 
   if (
     (feature === "update:store" ||
+      feature === "manage:store_featured_games" ||
       feature === "manage:store_members" ||
       feature === "read:store_statement") &&
     resource
@@ -346,7 +348,7 @@ function can(user: Partial<User>, feature: string, resource?: unknown) {
       "update:store": "update:store:any",
       "manage:store_members": "manage:store_members:any",
       "read:store_statement": "read:store_statement:any",
-    }[feature] as string;
+    }[feature] as string | undefined;
 
     const isOwner = user.id === storeResource.owner_id;
     const isPermittedMember = storeResource.members?.some(
@@ -354,7 +356,11 @@ function can(user: Partial<User>, feature: string, resource?: unknown) {
         member.user_id === user.id && member.permissions.includes(feature),
     );
 
-    if (isOwner || isPermittedMember || can(user, anyFeature)) {
+    if (
+      isOwner ||
+      isPermittedMember ||
+      (anyFeature !== undefined && can(user, anyFeature))
+    ) {
       authorized = true;
     }
   }

--- a/models/feature_backfill.ts
+++ b/models/feature_backfill.ts
@@ -177,13 +177,9 @@ async function reconcileStudioMembers(
   return result;
 }
 
-// Both of store.MEMBER_PERMISSIONS (update:store, manage:store_members) are
-// already plain ACTIVATED_USER_FEATURES entries, and reconcileBaseline runs
-// before this pass — so today this pass's `updated` count is always 0: any
-// gap it would have fixed is already closed by the baseline pass first. It
-// only starts doing real work if store.MEMBER_PERMISSIONS ever gains an
-// entry that isn't also a baseline feature (mirroring how studio's
-// create:game/update:game/create:game_file/delete:game_file aren't).
+// Store owners receive every delegable Outlet permission. Some are baseline
+// features, while editorial curation is intentionally only granted to Outlet
+// owners and explicitly permitted members.
 async function reconcileStoreOwners(
   eligibleUsers: EligibleUsers,
   touchedIds: Set<string>,

--- a/models/store.ts
+++ b/models/store.ts
@@ -23,6 +23,7 @@ export type StoreCreateDto = z.infer<typeof storeSchema> & {
 // provider reference, and because changing it resets verification to false.
 export const MEMBER_PERMISSIONS = [
   "update:store",
+  "manage:store_featured_games",
   "manage:store_members",
   "read:store_statement",
   "read:payout_account",

--- a/models/store_featured_game.ts
+++ b/models/store_featured_game.ts
@@ -1,0 +1,142 @@
+import { Prisma } from "generated/prisma/client";
+import { prisma } from "infra/database";
+import { ValidationError } from "infra/errors";
+import storeCuration from "models/store_curation";
+import { z } from "zod";
+
+export const MAX_FEATURED_GAMES = 3;
+
+export const featuredGameSelectionSchema = z
+  .object({
+    game_slugs: z
+      .array(z.string().trim().min(1).max(255))
+      .min(1)
+      .max(MAX_FEATURED_GAMES),
+  })
+  .superRefine(({ game_slugs }, context) => {
+    if (new Set(game_slugs).size !== game_slugs.length) {
+      context.addIssue({
+        code: "custom",
+        path: ["game_slugs"],
+        message: "Featured games must be unique.",
+      });
+    }
+  });
+
+interface EditorialGameQuery {
+  storeId: string;
+  curationWhere: Prisma.GameWhereInput;
+  priceableGameIds?: string[] | null;
+  page: number;
+  limit: number;
+}
+
+async function replaceSelection(storeId: string, gameSlugs: string[]) {
+  const curationWhere = await storeCuration.getCurationWhereClause(storeId);
+
+  return prisma.$transaction(async (transaction) => {
+    const andClauses: Prisma.GameWhereInput[] = [];
+    if (Object.keys(curationWhere).length > 0) {
+      andClauses.push(curationWhere);
+    }
+
+    const games = await transaction.game.findMany({
+      where: {
+        slug: { in: gameSlugs },
+        status: "ACTIVE",
+        ...(andClauses.length > 0 && { AND: andClauses }),
+      },
+      select: { id: true, slug: true },
+    });
+
+    const gameBySlug = new Map(games.map((game) => [game.slug, game]));
+    const ineligibleSlugs = gameSlugs.filter((slug) => !gameBySlug.has(slug));
+
+    if (ineligibleSlugs.length > 0) {
+      throw new ValidationError({
+        message: "One or more games cannot be featured by this Outlet.",
+        action:
+          "Choose active games that are currently included in the Outlet catalog.",
+        context: { game_slugs: ineligibleSlugs },
+      });
+    }
+
+    await transaction.storeFeaturedGame.deleteMany({
+      where: { store_id: storeId },
+    });
+    await transaction.storeFeaturedGame.createMany({
+      data: gameSlugs.map((slug, index) => ({
+        store_id: storeId,
+        game_id: gameBySlug.get(slug)!.id,
+        position: index + 1,
+      })),
+    });
+
+    return gameSlugs.map((game_slug, index) => ({
+      game_slug,
+      position: index + 1,
+    }));
+  });
+}
+
+async function resetSelection(storeId: string) {
+  await prisma.storeFeaturedGame.deleteMany({ where: { store_id: storeId } });
+}
+
+async function findAvailableEditorialGames({
+  storeId,
+  curationWhere,
+  priceableGameIds,
+  page,
+  limit,
+}: EditorialGameQuery) {
+  const selection = await prisma.storeFeaturedGame.findMany({
+    where: { store_id: storeId },
+    orderBy: { position: "asc" },
+  });
+
+  if (selection.length === 0) {
+    return null;
+  }
+
+  const andClauses: Prisma.GameWhereInput[] = [];
+  if (Object.keys(curationWhere).length > 0) {
+    andClauses.push(curationWhere);
+  }
+  if (priceableGameIds !== null && priceableGameIds !== undefined) {
+    andClauses.push({ id: { in: priceableGameIds } });
+  }
+
+  const games = await prisma.game.findMany({
+    where: {
+      id: { in: selection.map((entry) => entry.game_id) },
+      status: "ACTIVE",
+      ...(andClauses.length > 0 && { AND: andClauses }),
+    },
+  });
+
+  const gameById = new Map(games.map((game) => [game.id, game]));
+  const orderedGames = selection
+    .map((entry) => gameById.get(entry.game_id))
+    .filter((game) => game !== undefined);
+  const total = orderedGames.length;
+  const paginatedGames = orderedGames.slice((page - 1) * limit, page * limit);
+
+  return {
+    games: paginatedGames,
+    pagination: {
+      page,
+      limit,
+      total,
+      pages: Math.ceil(total / limit),
+    },
+  };
+}
+
+const storeFeaturedGame = {
+  replaceSelection,
+  resetSelection,
+  findAvailableEditorialGames,
+};
+
+export default storeFeaturedGame;

--- a/pages/api/v1/stores/[slug]/featured/index.ts
+++ b/pages/api/v1/stores/[slug]/featured/index.ts
@@ -5,8 +5,12 @@ import store from "models/store";
 import game from "models/game";
 import storeCuration from "models/store_curation";
 import storefrontPricing from "models/storefront_pricing";
-import { ValidationError } from "infra/errors";
+import { ForbiddenError, ValidationError } from "infra/errors";
 import { z } from "zod";
+import authorization from "models/authorization";
+import storeFeaturedGame, {
+  featuredGameSelectionSchema,
+} from "models/store_featured_game";
 
 const listQuerySchema = z.object({
   page: z.coerce.number().min(1).default(1),
@@ -16,6 +20,8 @@ const listQuerySchema = z.object({
 export default createRouter<NextApiRequest, NextApiResponse>()
   .use(controller.injectAnonymousOrUser)
   .get(controller.canRequest("read:public_game"), getHandler)
+  .put(controller.canRequest("manage:store_featured_games"), putHandler)
+  .delete(controller.canRequest("manage:store_featured_games"), deleteHandler)
   .handler(controller.errorHandlers);
 
 async function getHandler(req: NextApiRequest, res: NextApiResponse) {
@@ -39,6 +45,31 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
   const { currency, gameIds } =
     await storefrontPricing.idConstraintForRequest(req);
 
+  const editorialResult = await storeFeaturedGame.findAvailableEditorialGames({
+    storeId: foundStore.id,
+    curationWhere,
+    priceableGameIds: gameIds,
+    ...result.data,
+  });
+
+  if (editorialResult) {
+    const context = await storefrontPricing.contextFor(
+      currency,
+      editorialResult.games,
+    );
+
+    return res.status(200).json({
+      games: storefrontPricing.filterAndPrice(
+        req.context.user,
+        editorialResult.games,
+        context,
+      ),
+      pagination: editorialResult.pagination,
+      currency,
+      mode: "EDITORIAL",
+    });
+  }
+
   const { games, pagination } = await game.findAllPaginated({
     priceableGameIds: gameIds,
     ...result.data,
@@ -52,5 +83,68 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
     games: storefrontPricing.filterAndPrice(req.context.user, games, context),
     pagination,
     currency,
+    mode: "AUTOMATIC",
   });
+}
+
+async function putHandler(req: NextApiRequest, res: NextApiResponse) {
+  const result = featuredGameSelectionSchema.safeParse(req.body);
+  if (!result.success) {
+    throw new ValidationError({
+      message: "One or more fields are invalid.",
+      action: "Choose between one and three unique game slugs.",
+      context: result.error.issues,
+    });
+  }
+
+  const foundStore = await store.findOneBySlugWithMembers(
+    req.query.slug as string,
+  );
+  if (
+    !authorization.can(
+      req.context.user,
+      "manage:store_featured_games",
+      foundStore,
+    )
+  ) {
+    throw new ForbiddenError({
+      message:
+        "You do not have permission to manage this Outlet's Featured games.",
+      action:
+        "Ask the Outlet owner for the manage:store_featured_games permission.",
+    });
+  }
+
+  const selection = await storeFeaturedGame.replaceSelection(
+    foundStore.id,
+    result.data.game_slugs,
+  );
+
+  return res.status(200).json({
+    mode: "EDITORIAL",
+    game_slugs: selection.map((entry) => entry.game_slug),
+  });
+}
+
+async function deleteHandler(req: NextApiRequest, res: NextApiResponse) {
+  const foundStore = await store.findOneBySlugWithMembers(
+    req.query.slug as string,
+  );
+  if (
+    !authorization.can(
+      req.context.user,
+      "manage:store_featured_games",
+      foundStore,
+    )
+  ) {
+    throw new ForbiddenError({
+      message:
+        "You do not have permission to manage this Outlet's Featured games.",
+      action:
+        "Ask the Outlet owner for the manage:store_featured_games permission.",
+    });
+  }
+
+  await storeFeaturedGame.resetSelection(foundStore.id);
+  return res.status(204).end();
 }

--- a/prisma/migrations/20260823120000_create_store_featured_games/migration.sql
+++ b/prisma/migrations/20260823120000_create_store_featured_games/migration.sql
@@ -1,0 +1,19 @@
+-- A game's presence in an Outlet and an Outlet's editorial endorsement are
+-- deliberately separate decisions. store_game_overrides remains SHOW/HIDE;
+-- this table stores the small, ordered recommendation set.
+CREATE TABLE "store_featured_games" (
+    "id" TEXT NOT NULL,
+    "store_id" TEXT NOT NULL,
+    "game_id" TEXT NOT NULL,
+    "position" INTEGER NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "store_featured_games_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "store_featured_games_position_check" CHECK ("position" BETWEEN 1 AND 3)
+);
+
+CREATE INDEX "store_featured_games_store_id_idx" ON "store_featured_games"("store_id");
+CREATE INDEX "store_featured_games_game_id_idx" ON "store_featured_games"("game_id");
+CREATE UNIQUE INDEX "store_featured_games_store_id_game_id_key" ON "store_featured_games"("store_id", "game_id");
+CREATE UNIQUE INDEX "store_featured_games_store_id_position_key" ON "store_featured_games"("store_id", "position");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -423,6 +423,21 @@ model StoreGameOverride {
   @@map("store_game_overrides")
 }
 
+model StoreFeaturedGame {
+  id         String   @id @default(uuid())
+  store_id   String // Logical reference to Store.id
+  game_id    String // Logical reference to Game.id
+  position   Int
+  created_at DateTime @default(now())
+  updated_at DateTime @updatedAt
+
+  @@unique([store_id, game_id])
+  @@unique([store_id, position])
+  @@index([store_id])
+  @@index([game_id])
+  @@map("store_featured_games")
+}
+
 model AdminActionLog {
   id            String   @id @default(uuid())
   admin_user_id String // Logical reference to User.id (who performed the action)

--- a/tests/integration/api/v1/stores/[slug]/featured/delete.test.ts
+++ b/tests/integration/api/v1/stores/[slug]/featured/delete.test.ts
@@ -1,0 +1,66 @@
+import orchestrator from "tests/orchestrator";
+import webserver from "infra/webserver";
+import gameModel from "models/game";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+async function deleteSelection(storeSlug: string, sessionToken: string) {
+  return fetch(`${webserver.getOrigin()}/api/v1/stores/${storeSlug}/featured`, {
+    method: "DELETE",
+    headers: { Cookie: `session_id=${sessionToken}` },
+  });
+}
+
+describe("DELETE /api/v1/stores/[slug]/featured", () => {
+  test("An owner can return the Outlet to automatic mode", async () => {
+    const owner = await orchestrator.createUser();
+    await orchestrator.activateUser(owner.id);
+    const session = await orchestrator.createSession(owner.id);
+    const store = await orchestrator.createStore(owner.id);
+    const game = await orchestrator.createGame(owner.id, {
+      title: "Resettable Pick",
+    });
+    await gameModel.makePublic(game.id);
+
+    const putResponse = await fetch(
+      `${webserver.getOrigin()}/api/v1/stores/${store.slug}/featured`,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: `session_id=${session.token}`,
+        },
+        body: JSON.stringify({ game_slugs: [game.slug] }),
+      },
+    );
+    expect(putResponse.status).toBe(200);
+
+    const deleteResponse = await deleteSelection(store.slug, session.token);
+    expect(deleteResponse.status).toBe(204);
+
+    const publicResponse = await fetch(
+      `${webserver.getOrigin()}/api/v1/stores/${store.slug}/featured`,
+    );
+    const publicBody = await publicResponse.json();
+    expect(publicBody.mode).toBe("AUTOMATIC");
+  });
+
+  test("A member with only update:store cannot reset the selection", async () => {
+    const owner = await orchestrator.createUser();
+    await orchestrator.activateUser(owner.id);
+    const store = await orchestrator.createStore(owner.id);
+
+    const editor = await orchestrator.createUser();
+    await orchestrator.activateUser(editor.id);
+    const session = await orchestrator.createSession(editor.id);
+    await orchestrator.addStoreMember(store.id, editor.username, [
+      "update:store",
+    ]);
+
+    const response = await deleteSelection(store.slug, session.token);
+    expect(response.status).toBe(403);
+  });
+});

--- a/tests/integration/api/v1/stores/[slug]/featured/get.test.ts
+++ b/tests/integration/api/v1/stores/[slug]/featured/get.test.ts
@@ -46,6 +46,7 @@ describe("GET /api/v1/stores/[slug]/featured", () => {
 
       expect(response.status).toBe(200);
       const body = await response.json();
+      expect(body.mode).toBe("AUTOMATIC");
       const titles = body.games.map((g: { title: string }) => g.title);
       expect(titles).toContain("Featured Allowed");
       expect(titles).not.toContain("Featured Banned");

--- a/tests/integration/api/v1/stores/[slug]/featured/put.test.ts
+++ b/tests/integration/api/v1/stores/[slug]/featured/put.test.ts
@@ -1,0 +1,228 @@
+import orchestrator from "tests/orchestrator";
+import webserver from "infra/webserver";
+import gameModel from "models/game";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabaseRows();
+});
+
+async function createPublicGame(userId: string, title: string, tags = ["rpg"]) {
+  const game = await orchestrator.createGame(userId, { title, tags });
+  await gameModel.makePublic(game.id);
+  return game;
+}
+
+async function putSelection(
+  storeSlug: string,
+  sessionToken: string,
+  gameSlugs: string[],
+) {
+  return fetch(`${webserver.getOrigin()}/api/v1/stores/${storeSlug}/featured`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      Cookie: `session_id=${sessionToken}`,
+    },
+    body: JSON.stringify({ game_slugs: gameSlugs }),
+  });
+}
+
+describe("PUT /api/v1/stores/[slug]/featured", () => {
+  test("An owner can replace the selection and public GET preserves its order", async () => {
+    const owner = await orchestrator.createUser();
+    await orchestrator.activateUser(owner.id);
+    const session = await orchestrator.createSession(owner.id);
+    const store = await orchestrator.createStore(owner.id);
+    const first = await createPublicGame(owner.id, "Editorial First");
+    const second = await createPublicGame(owner.id, "Editorial Second");
+
+    const response = await putSelection(store.slug, session.token, [
+      second.slug,
+      first.slug,
+    ]);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      mode: "EDITORIAL",
+      game_slugs: [second.slug, first.slug],
+    });
+
+    const publicResponse = await fetch(
+      `${webserver.getOrigin()}/api/v1/stores/${store.slug}/featured`,
+    );
+    const publicBody = await publicResponse.json();
+    expect(publicBody.mode).toBe("EDITORIAL");
+    expect(publicBody.games.map((game: { slug: string }) => game.slug)).toEqual(
+      [second.slug, first.slug],
+    );
+  });
+
+  test("A member with only manage:store_featured_games can replace the selection", async () => {
+    const owner = await orchestrator.createUser();
+    await orchestrator.activateUser(owner.id);
+    const ownerSession = await orchestrator.createSession(owner.id);
+    const store = await orchestrator.createStore(owner.id);
+
+    const curator = await orchestrator.createUser();
+    await orchestrator.activateUser(curator.id);
+    const session = await orchestrator.createSession(curator.id);
+    const memberResponse = await fetch(
+      `${webserver.getOrigin()}/api/v1/stores/${store.slug}/members`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: `session_id=${ownerSession.token}`,
+        },
+        body: JSON.stringify({
+          username: curator.username,
+          permissions: ["manage:store_featured_games"],
+        }),
+      },
+    );
+    expect(memberResponse.status).toBe(201);
+
+    const game = await createPublicGame(owner.id, "Curator Pick");
+    const response = await putSelection(store.slug, session.token, [game.slug]);
+
+    expect(response.status).toBe(200);
+  });
+
+  test("A member with only update:store cannot replace the selection", async () => {
+    const owner = await orchestrator.createUser();
+    await orchestrator.activateUser(owner.id);
+    const store = await orchestrator.createStore(owner.id);
+
+    const editor = await orchestrator.createUser();
+    await orchestrator.activateUser(editor.id);
+    const session = await orchestrator.createSession(editor.id);
+    await orchestrator.addStoreMember(store.id, editor.username, [
+      "update:store",
+    ]);
+
+    const game = await createPublicGame(owner.id, "Not Editor Pick");
+    const response = await putSelection(store.slug, session.token, [game.slug]);
+
+    expect(response.status).toBe(403);
+  });
+
+  test("A curator of another Outlet cannot replace this Outlet's selection", async () => {
+    const firstOwner = await orchestrator.createUser();
+    await orchestrator.activateUser(firstOwner.id);
+    const targetStore = await orchestrator.createStore(firstOwner.id);
+
+    const secondOwner = await orchestrator.createUser();
+    await orchestrator.activateUser(secondOwner.id);
+    const otherStore = await orchestrator.createStore(secondOwner.id);
+
+    const curator = await orchestrator.createUser();
+    await orchestrator.activateUser(curator.id);
+    const session = await orchestrator.createSession(curator.id);
+    await orchestrator.addStoreMember(otherStore.id, curator.username, [
+      "manage:store_featured_games",
+    ]);
+
+    const game = await createPublicGame(firstOwner.id, "Wrong Outlet Pick");
+    const response = await putSelection(targetStore.slug, session.token, [
+      game.slug,
+    ]);
+
+    expect(response.status).toBe(403);
+  });
+
+  test("Rejects duplicate games and selections larger than three", async () => {
+    const owner = await orchestrator.createUser();
+    await orchestrator.activateUser(owner.id);
+    const session = await orchestrator.createSession(owner.id);
+    const store = await orchestrator.createStore(owner.id);
+    const games = await Promise.all(
+      ["One", "Two", "Three", "Four"].map((suffix) =>
+        createPublicGame(owner.id, `Validation ${suffix}`),
+      ),
+    );
+
+    const duplicateResponse = await putSelection(store.slug, session.token, [
+      games[0].slug,
+      games[0].slug,
+    ]);
+    expect(duplicateResponse.status).toBe(400);
+
+    const oversizedResponse = await putSelection(
+      store.slug,
+      session.token,
+      games.map((game) => game.slug),
+    );
+    expect(oversizedResponse.status).toBe(400);
+  });
+
+  test("Rejects inactive games and games outside the Outlet curation", async () => {
+    const owner = await orchestrator.createUser();
+    await orchestrator.activateUser(owner.id);
+    const session = await orchestrator.createSession(owner.id);
+    const store = await orchestrator.createStore(owner.id);
+
+    const inactive = await orchestrator.createGame(owner.id, {
+      title: "Private Pick",
+      tags: ["rpg"],
+    });
+    const inactiveResponse = await putSelection(store.slug, session.token, [
+      inactive.slug,
+    ]);
+    expect(inactiveResponse.status).toBe(400);
+
+    const excluded = await createPublicGame(owner.id, "Excluded Pick", [
+      "horror",
+    ]);
+    await orchestrator.addStoreTagFilter(store.id, "horror", "BLACKLIST");
+    const excludedResponse = await putSelection(store.slug, session.token, [
+      excluded.slug,
+    ]);
+    expect(excludedResponse.status).toBe(400);
+  });
+
+  test("An invalid replacement leaves the previous selection intact", async () => {
+    const owner = await orchestrator.createUser();
+    await orchestrator.activateUser(owner.id);
+    const session = await orchestrator.createSession(owner.id);
+    const store = await orchestrator.createStore(owner.id);
+    const valid = await createPublicGame(owner.id, "Atomic Pick");
+
+    expect(
+      (await putSelection(store.slug, session.token, [valid.slug])).status,
+    ).toBe(200);
+    expect(
+      (await putSelection(store.slug, session.token, ["missing-game"])).status,
+    ).toBe(400);
+
+    const publicResponse = await fetch(
+      `${webserver.getOrigin()}/api/v1/stores/${store.slug}/featured`,
+    );
+    const publicBody = await publicResponse.json();
+    expect(publicBody.mode).toBe("EDITORIAL");
+    expect(publicBody.games.map((game: { slug: string }) => game.slug)).toEqual(
+      [valid.slug],
+    );
+  });
+
+  test("Public GET hides a selected game that later becomes inactive without inventing an automatic recommendation", async () => {
+    const owner = await orchestrator.createUser();
+    await orchestrator.activateUser(owner.id);
+    const session = await orchestrator.createSession(owner.id);
+    const store = await orchestrator.createStore(owner.id);
+    const game = await createPublicGame(owner.id, "Unavailable Pick");
+
+    expect(
+      (await putSelection(store.slug, session.token, [game.slug])).status,
+    ).toBe(200);
+    await gameModel.setStatus(game.id, "PRIVATE");
+
+    const publicResponse = await fetch(
+      `${webserver.getOrigin()}/api/v1/stores/${store.slug}/featured`,
+    );
+    const publicBody = await publicResponse.json();
+    expect(publicBody.mode).toBe("EDITORIAL");
+    expect(publicBody.games).toEqual([]);
+    expect(publicBody.pagination.total).toBe(0);
+  });
+});

--- a/tests/integration/models/feature_backfill.test.ts
+++ b/tests/integration/models/feature_backfill.test.ts
@@ -64,6 +64,27 @@ describe("models/feature_backfill.ts reconcileAll()", () => {
     expect(report.studio_owners.skipped_ineligible).toBeGreaterThanOrEqual(1);
   });
 
+  test("Tops up an existing store owner with editorial curation without granting it to unrelated users", async () => {
+    const owner = await orchestrator.createUser();
+    await orchestrator.activateUser(owner.id);
+    await orchestrator.createStore(owner.id);
+    await user.setFeatures(owner.id, authorization.ACTIVATED_USER_FEATURES);
+
+    const unrelated = await orchestrator.createUser();
+    await orchestrator.activateUser(unrelated.id);
+
+    const report = await featureBackfill.reconcileAll();
+    expect(report.store_owners.updated).toBeGreaterThanOrEqual(1);
+
+    const updatedOwner = await orchestrator.getUserById(owner.id);
+    expect(updatedOwner.features).toContain("manage:store_featured_games");
+
+    const unchangedUnrelated = await orchestrator.getUserById(unrelated.id);
+    expect(unchangedUnrelated.features).not.toContain(
+      "manage:store_featured_games",
+    );
+  });
+
   // The admin pass decides who is an admin by asking whether they already hold
   // any ADMIN_ONLY_FEATURES entry, which is only sound while every entry in
   // that list is admin-exclusive. Putting a feature there that a studio or


### PR DESCRIPTION
## Summary

- add a dedicated ordered `store_featured_games` association and migration
- add granular `manage:store_featured_games` delegation without granting `update:store`
- support atomic PUT and reset DELETE operations on the Outlet Featured endpoint
- distinguish explicit `EDITORIAL` recommendations from the existing `AUTOMATIC` fallback
- filter manual selections against current curation, status, region, and price availability
- reconcile the new capability for existing Outlet owners

## Authorization

- Outlet owner: allowed
- member with only `manage:store_featured_games`: allowed
- member with only `update:store`: forbidden
- curator of another Outlet: forbidden
- no `manage:store_featured_games:any` escape hatch

## Tests

- `npx eslint .` (0 errors; 2 pre-existing `no-img-element` warnings)
- `npx jest --runInBand --testPathPatterns="featured|feature_backfill|authorization.test"`
  - 5 suites passed
  - 34 tests passed
- migration applied successfully to a clean local PostgreSQL database
- commitlint passed manually; the worktree path contains a space that exposes an existing quoting bug in the Husky commit-msg hook

## Stack

This PR is intentionally based on `codex/acquisition-flow` / #229 and should be reviewed and merged after #227, #228, and #229.

Closes #230
