### PR TITLE
feat: add reasons to Outlet Featured picks

### DIFF
--- a/components/store/GameAutocomplete.tsx
+++ b/components/store/GameAutocomplete.tsx
@@ -8,17 +8,17 @@ const fetcher = (url: string) => fetch(url).then((res) => res.json());
 export function GameAutocomplete({
   onSelect,
   placeholder = "Search games...",
+  endpoint = "/api/v1/games",
 }: {
   onSelect: (game: GameApi) => void;
   placeholder?: string;
+  endpoint?: string;
 }) {
   const [query, setQuery] = useState("");
   const [isFocused, setIsFocused] = useState(false);
 
   const { data, isLoading } = useSWR<{ games: GameApi[] }>(
-    query.trim()
-      ? `/api/v1/games?q=${encodeURIComponent(query)}&limit=5`
-      : null,
+    query.trim() ? `${endpoint}?q=${encodeURIComponent(query)}&limit=5` : null,
     fetcher,
   );
 

--- a/components/store/types.ts
+++ b/components/store/types.ts
@@ -33,6 +33,8 @@ export type GameApi = {
   positive_reviews?: number;
   negative_reviews?: number;
   review_score?: string | null;
+  /** Outlet-authored editorial copy; present only in editorial Featured feeds. */
+  recommendation_reason?: string | null;
 };
 
 /**

--- a/components/store/types.ts
+++ b/components/store/types.ts
@@ -35,6 +35,8 @@ export type GameApi = {
   review_score?: string | null;
   /** Outlet-authored editorial copy; present only in editorial Featured feeds. */
   recommendation_reason?: string | null;
+  /** Distinguishes Outlet picks from automatic carousel fillers. */
+  featured_source?: "EDITORIAL" | "AUTOMATIC";
 };
 
 /**

--- a/components/storefront/default/DefaultStorefront.tsx
+++ b/components/storefront/default/DefaultStorefront.tsx
@@ -26,6 +26,7 @@ export function DefaultStorefront(props: DefaultStorefrontViewProps) {
   const {
     store,
     featured,
+    featuredMode,
     isFeaturedLoading,
     games,
     isLoading,
@@ -56,7 +57,12 @@ export function DefaultStorefront(props: DefaultStorefrontViewProps) {
                 <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-white"></div>
               </div>
             ) : (
-              <HeroBento featured={featured.slice(0, 3)} itemHref={itemHref} />
+              <HeroBento
+                featured={featured.slice(0, 3)}
+                itemHref={itemHref}
+                mode={featuredMode}
+                storeName={store?.name}
+              />
             )}
           </div>
         </section>

--- a/components/storefront/default/HeroBento.tsx
+++ b/components/storefront/default/HeroBento.tsx
@@ -15,9 +15,13 @@ import { PricedItem, formatBasePrice, formatPrice, isFree } from "lib/price";
 export function HeroBento({
   featured,
   itemHref,
+  mode,
+  storeName,
 }: {
   featured: GameApi[];
   itemHref: (slug: string) => string;
+  mode: "EDITORIAL" | "AUTOMATIC";
+  storeName?: string;
 }) {
   if (!featured || featured.length === 0) return null;
   const [main, ...rest] = featured;
@@ -34,6 +38,9 @@ export function HeroBento({
   const isDemo = (item: PricedItem) => isFree(item);
   const defaultGradient =
     "linear-gradient(135deg, var(--color-purple-dark) 0%, rgba(53,34,89,0.7) 100%)";
+  const editorialLabel = storeName
+    ? `Recommended by ${storeName}`
+    : "Outlet recommendation";
 
   return (
     <section className="grid grid-cols-1 md:grid-cols-3 gap-4 md:gap-6 w-full max-w-7xl mx-auto auto-rows-[200px] md:auto-rows-[240px]">
@@ -64,11 +71,16 @@ export function HeroBento({
 
         <div className="absolute inset-x-4 bottom-4 md:inset-x-10 md:bottom-10 text-white flex flex-col items-start min-w-0 max-w-full">
           <span className="bg-white/10 backdrop-blur-md px-3 py-1.5 rounded-full text-[10px] md:text-xs font-bold tracking-widest uppercase mb-3 text-white/80 border border-white/5">
-            Featured Match
+            {mode === "EDITORIAL" ? editorialLabel : "Featured Match"}
           </span>
           <h2 className="w-full text-xl md:text-3xl lg:text-5xl font-black leading-none mb-2 tracking-tight transform group-hover:scale-105 transition-transform duration-500 origin-bottom-left text-white drop-shadow-2xl truncate">
             {main.title}
           </h2>
+          {mode === "EDITORIAL" && main.recommendation_reason && (
+            <p className="mb-2 max-w-2xl text-xs font-semibold leading-relaxed text-white/85 line-clamp-2 drop-shadow-md md:text-base">
+              {main.recommendation_reason}
+            </p>
+          )}
           <div className="flex items-center gap-4 mt-2">
             <div className="flex items-center gap-3">
               <span
@@ -136,9 +148,19 @@ export function HeroBento({
             )}
 
           <div className="absolute inset-x-4 bottom-4 text-white min-w-0 max-w-full">
+            {mode === "EDITORIAL" && (
+              <span className="mb-2 inline-flex max-w-full rounded-full border border-white/10 bg-black/40 px-2.5 py-1 text-[9px] font-black uppercase tracking-wider text-white/75 backdrop-blur-md">
+                Outlet pick
+              </span>
+            )}
             <h3 className="w-full text-xl md:text-3xl font-black leading-tight mb-2 motion-safe:group-hover:translate-x-2 transition-transform duration-300 text-white drop-shadow-md truncate">
               {game.title}
             </h3>
+            {mode === "EDITORIAL" && game.recommendation_reason && (
+              <p className="mb-2 text-xs font-semibold leading-snug text-white/85 line-clamp-2 drop-shadow-md">
+                {game.recommendation_reason}
+              </p>
+            )}
             <div className="flex items-center gap-3">
               <span
                 className={`text-xl md:text-2xl font-bold bg-black/60 backdrop-blur-md px-3 py-1 rounded-lg border shadow-lg uppercase ${!isDemo(game) && formatBasePrice(game) !== null ? "" : "text-white border-white/20"}`}

--- a/components/storefront/default/HeroBento.tsx
+++ b/components/storefront/default/HeroBento.tsx
@@ -1,16 +1,28 @@
+import { useEffect, useState } from "react";
 import Link from "next/link";
+import { ChevronLeft, ChevronRight, Pause, Play } from "lucide-react";
 
 import { DiscountBadge } from "components/store/DiscountBadge";
 import { discountBadgeColor } from "components/store/constants";
 import { type GameApi } from "components/store/types";
 import { PricedItem, formatBasePrice, formatPrice, isFree } from "lib/price";
 
+const AUTO_ADVANCE_MS = 7000;
+
+function isEditorial(
+  game: GameApi,
+  mode: "EDITORIAL" | "HYBRID" | "AUTOMATIC",
+) {
+  return game.featured_source
+    ? game.featured_source === "EDITORIAL"
+    : mode === "EDITORIAL";
+}
+
 /**
- * The default storefront's hero: one large tile plus two stacked ones.
- *
- * Renders whatever it is given rather than bailing out below three entries —
- * it used to return null, which left a brand-new outlet with two curated games
- * showing an empty band and no explanation. The grid spans adapt instead.
+ * The default storefront hero presents up to three Featured games as one
+ * focused carousel. Outlet picks keep their order and automatic games fill
+ * any empty slots server-side; `featured_source` prevents those fillers from
+ * being presented as personal recommendations.
  */
 export function HeroBento({
   featured,
@@ -20,75 +32,104 @@ export function HeroBento({
 }: {
   featured: GameApi[];
   itemHref: (slug: string) => string;
-  mode: "EDITORIAL" | "AUTOMATIC";
+  mode: "EDITORIAL" | "HYBRID" | "AUTOMATIC";
   storeName?: string;
 }) {
-  if (!featured || featured.length === 0) return null;
-  const [main, ...rest] = featured;
-  const sides = rest.slice(0, 2);
+  const slides = featured.slice(0, 3);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [isUserPaused, setIsUserPaused] = useState(false);
+  const [isInteracting, setIsInteracting] = useState(false);
 
-  // With no side tiles the main one has nothing to sit beside, so it takes the
-  // full width instead of leaving a dead column.
-  const mainSpan =
-    sides.length > 0
-      ? "md:col-span-2 md:row-span-2"
-      : "md:col-span-3 md:row-span-2";
+  useEffect(() => {
+    if (slides.length < 2 || isUserPaused || isInteracting) return;
+    const interval = window.setInterval(() => {
+      setActiveIndex((current) => (current + 1) % slides.length);
+    }, AUTO_ADVANCE_MS);
+    return () => window.clearInterval(interval);
+  }, [slides.length, isUserPaused, isInteracting]);
 
-  // Kept as a local alias so the many call sites below read the same as before.
+  if (slides.length === 0) return null;
+
+  const displayedIndex = Math.min(activeIndex, slides.length - 1);
+  const activeGame = slides[displayedIndex];
+  const activeIsEditorial = isEditorial(activeGame, mode);
   const isDemo = (item: PricedItem) => isFree(item);
   const defaultGradient =
     "linear-gradient(135deg, var(--color-purple-dark) 0%, rgba(53,34,89,0.7) 100%)";
   const editorialLabel = storeName
     ? `Recommended by ${storeName}`
     : "Outlet recommendation";
+  const automaticLabel = storeName
+    ? `Featured in ${storeName}`
+    : "Featured on Manifold";
+
+  function showPrevious() {
+    setActiveIndex((current) => (current - 1 + slides.length) % slides.length);
+  }
+
+  function showNext() {
+    setActiveIndex((current) => (current + 1) % slides.length);
+  }
 
   return (
-    <section className="grid grid-cols-1 md:grid-cols-3 gap-4 md:gap-6 w-full max-w-7xl mx-auto auto-rows-[200px] md:auto-rows-[240px]">
-      {/* Main Massive Tile */}
-      <Link
-        href={itemHref(main.slug)}
-        className={`${mainSpan} rounded-[2rem] border border-white/10 overflow-hidden relative group cursor-pointer shadow-2xl`}
-      >
-        {/* Background Layer */}
-        <div
-          className="absolute inset-0 transition-transform duration-700 ease-out group-hover:scale-110"
-          style={{
-            background: main.media?.banner
-              ? `url(${main.media.banner}) center/cover no-repeat`
-              : defaultGradient,
-          }}
-        />
+    <section
+      className="w-full max-w-7xl mx-auto"
+      aria-label="Featured games"
+      onMouseEnter={() => setIsInteracting(true)}
+      onMouseLeave={() => setIsInteracting(false)}
+      onFocusCapture={() => setIsInteracting(true)}
+      onBlurCapture={() => setIsInteracting(false)}
+    >
+      <div className="group relative h-[25rem] overflow-hidden rounded-[2rem] border border-white/10 bg-[#1D0F3B] shadow-2xl md:h-[32rem]">
+        <Link
+          key={activeGame.id}
+          href={itemHref(activeGame.slug)}
+          className="absolute inset-0"
+          aria-label={`View ${activeGame.title}`}
+        >
+          <div
+            className="absolute inset-0 animate-[fadeIn_350ms_ease-out] transition-transform duration-1000 ease-out group-hover:scale-[1.025]"
+            style={{
+              background: activeGame.media?.banner
+                ? `url(${activeGame.media.banner}) center/cover no-repeat`
+                : defaultGradient,
+            }}
+          />
+          <div className="absolute inset-0 bg-gradient-to-r from-[#120923]/95 via-[#1D0F3B]/50 to-transparent" />
+          <div className="absolute inset-0 bg-gradient-to-t from-[#120923] via-transparent to-black/20" />
 
-        <div className="absolute inset-0 bg-gradient-to-t from-[#1D0F3B]/90 via-[#1D0F3B]/20 to-transparent opacity-90 transition-opacity group-hover:opacity-100" />
+          {!isDemo(activeGame) &&
+            formatBasePrice(activeGame) !== null &&
+            activeGame.discount_label && (
+              <div className="absolute right-5 top-5 z-10 md:right-8 md:top-8 md:scale-110">
+                <DiscountBadge label={activeGame.discount_label} />
+              </div>
+            )}
 
-        {!isDemo(main) &&
-          formatBasePrice(main) !== null &&
-          main.discount_label && (
-            <div className="absolute top-5 right-5 z-10 md:top-8 md:right-8 md:scale-120 origin-top-right">
-              <DiscountBadge label={main.discount_label} />
-            </div>
-          )}
+          <div className="absolute inset-x-6 bottom-8 flex max-w-3xl flex-col items-start text-white md:inset-x-12 md:bottom-12">
+            <span className="mb-4 max-w-full truncate rounded-full border border-white/10 bg-black/35 px-3 py-1.5 text-[10px] font-black uppercase tracking-[0.16em] text-white/85 backdrop-blur-md md:text-xs">
+              {activeIsEditorial ? editorialLabel : automaticLabel}
+            </span>
+            <h2 className="max-w-full text-3xl font-black leading-[0.95] tracking-tight text-white drop-shadow-2xl sm:text-5xl md:text-7xl">
+              {activeGame.title}
+            </h2>
+            {activeIsEditorial && activeGame.recommendation_reason && (
+              <p className="mt-4 max-w-2xl text-sm font-semibold leading-relaxed text-white/85 line-clamp-3 drop-shadow-md md:text-lg">
+                {activeGame.recommendation_reason}
+              </p>
+            )}
 
-        <div className="absolute inset-x-4 bottom-4 md:inset-x-10 md:bottom-10 text-white flex flex-col items-start min-w-0 max-w-full">
-          <span className="bg-white/10 backdrop-blur-md px-3 py-1.5 rounded-full text-[10px] md:text-xs font-bold tracking-widest uppercase mb-3 text-white/80 border border-white/5">
-            {mode === "EDITORIAL" ? editorialLabel : "Featured Match"}
-          </span>
-          <h2 className="w-full text-xl md:text-3xl lg:text-5xl font-black leading-none mb-2 tracking-tight transform group-hover:scale-105 transition-transform duration-500 origin-bottom-left text-white drop-shadow-2xl truncate">
-            {main.title}
-          </h2>
-          {mode === "EDITORIAL" && main.recommendation_reason && (
-            <p className="mb-2 max-w-2xl text-xs font-semibold leading-relaxed text-white/85 line-clamp-2 drop-shadow-md md:text-base">
-              {main.recommendation_reason}
-            </p>
-          )}
-          <div className="flex items-center gap-4 mt-2">
-            <div className="flex items-center gap-3">
+            <div className="mt-5 flex flex-wrap items-center gap-3">
               <span
-                className={`text-xl md:text-3xl font-black bg-black/60 backdrop-blur-md px-3 py-1 md:px-4 md:py-1.5 rounded-xl shadow-2xl border uppercase ${!isDemo(main) && formatBasePrice(main) !== null ? "" : "text-white border-white/20"}`}
+                className={`rounded-xl border bg-black/60 px-4 py-2 text-lg font-black uppercase shadow-2xl backdrop-blur-md md:text-2xl ${
+                  !isDemo(activeGame) && formatBasePrice(activeGame) !== null
+                    ? ""
+                    : "border-white/20 text-white"
+                }`}
                 style={
-                  !isDemo(main) &&
-                  main.base_price &&
-                  formatBasePrice(main) !== null
+                  !isDemo(activeGame) &&
+                  activeGame.base_price &&
+                  formatBasePrice(activeGame) !== null
                     ? {
                         color: discountBadgeColor,
                         borderColor: discountBadgeColor,
@@ -96,98 +137,109 @@ export function HeroBento({
                     : {}
                 }
               >
-                {isDemo(main) ? "Free Demo" : formatPrice(main)}
+                {isDemo(activeGame) ? "Free Demo" : formatPrice(activeGame)}
               </span>
-              {!isDemo(main) &&
-                main.base_price &&
-                formatBasePrice(main) !== null && (
-                  <span className="text-sm md:text-lg text-white/40 line-through font-bold">
-                    {formatBasePrice(main)}
+              {!isDemo(activeGame) &&
+                activeGame.base_price &&
+                formatBasePrice(activeGame) !== null && (
+                  <span className="text-base font-bold text-white/45 line-through md:text-lg">
+                    {formatBasePrice(activeGame)}
                   </span>
                 )}
-            </div>
-            <div className="flex gap-2 self-end mb-1">
-              {(main.tags || []).slice(0, 3).map((tag) => (
+              {(activeGame.tags || []).slice(0, 3).map((tag) => (
                 <span
                   key={tag}
-                  className="hidden md:inline-flex px-3 py-1.5 rounded-xl bg-white/5 backdrop-blur-md text-base font-bold border border-white/10 text-white/80"
+                  className="hidden rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 text-sm font-bold text-white/75 backdrop-blur-md md:inline-flex"
                 >
                   {tag}
                 </span>
               ))}
             </div>
           </div>
-        </div>
-      </Link>
-
-      {/* Secondary Vertical Tiles */}
-      {sides.map((game) => (
-        <Link
-          key={game.id}
-          href={itemHref(game.slug)}
-          className="rounded-[2rem] border border-white/10 overflow-hidden relative group cursor-pointer shadow-xl"
-        >
-          {/* Background Layer */}
-          <div
-            className="absolute inset-0 transition-transform duration-700 ease-out group-hover:scale-110"
-            style={{
-              background: game.media?.banner
-                ? `url(${game.media.banner}) center/cover no-repeat`
-                : defaultGradient,
-            }}
-          />
-
-          <div className="absolute inset-0 bg-gradient-to-t from-[#1D0F3B]/80 via-[#1D0F3B]/20 to-transparent opacity-80" />
-
-          {!isDemo(game) &&
-            formatBasePrice(game) !== null &&
-            game.discount_label && (
-              <div className="absolute top-5 right-5 z-10">
-                <DiscountBadge label={game.discount_label} />
-              </div>
-            )}
-
-          <div className="absolute inset-x-4 bottom-4 text-white min-w-0 max-w-full">
-            {mode === "EDITORIAL" && (
-              <span className="mb-2 inline-flex max-w-full rounded-full border border-white/10 bg-black/40 px-2.5 py-1 text-[9px] font-black uppercase tracking-wider text-white/75 backdrop-blur-md">
-                Outlet pick
-              </span>
-            )}
-            <h3 className="w-full text-xl md:text-3xl font-black leading-tight mb-2 motion-safe:group-hover:translate-x-2 transition-transform duration-300 text-white drop-shadow-md truncate">
-              {game.title}
-            </h3>
-            {mode === "EDITORIAL" && game.recommendation_reason && (
-              <p className="mb-2 text-xs font-semibold leading-snug text-white/85 line-clamp-2 drop-shadow-md">
-                {game.recommendation_reason}
-              </p>
-            )}
-            <div className="flex items-center gap-3">
-              <span
-                className={`text-xl md:text-2xl font-bold bg-black/60 backdrop-blur-md px-3 py-1 rounded-lg border shadow-lg uppercase ${!isDemo(game) && formatBasePrice(game) !== null ? "" : "text-white border-white/20"}`}
-                style={
-                  !isDemo(game) &&
-                  game.base_price &&
-                  formatBasePrice(game) !== null
-                    ? {
-                        color: discountBadgeColor,
-                        borderColor: discountBadgeColor,
-                      }
-                    : {}
-                }
-              >
-                {isDemo(game) ? "Free Demo" : formatPrice(game)}
-              </span>
-              {!isDemo(game) &&
-                game.base_price &&
-                formatBasePrice(game) !== null && (
-                  <span className="text-sm md:text-base text-white/40 line-through font-bold">
-                    ${game.base_price}
-                  </span>
-                )}
-            </div>
-          </div>
         </Link>
-      ))}
+
+        {slides.length > 1 && (
+          <>
+            <button
+              type="button"
+              onClick={showPrevious}
+              className="absolute left-3 top-1/2 z-20 -translate-y-1/2 rounded-full border border-white/10 bg-black/35 p-2.5 text-white/75 backdrop-blur-md transition hover:bg-black/60 hover:text-white md:left-5 md:p-3"
+              aria-label="Previous Featured game"
+            >
+              <ChevronLeft size={22} />
+            </button>
+            <button
+              type="button"
+              onClick={showNext}
+              className="absolute right-3 top-1/2 z-20 -translate-y-1/2 rounded-full border border-white/10 bg-black/35 p-2.5 text-white/75 backdrop-blur-md transition hover:bg-black/60 hover:text-white md:right-5 md:p-3"
+              aria-label="Next Featured game"
+            >
+              <ChevronRight size={22} />
+            </button>
+            <button
+              type="button"
+              onClick={() => setIsUserPaused((paused) => !paused)}
+              className="absolute right-4 top-4 z-20 rounded-full border border-white/10 bg-black/35 p-2.5 text-white/75 backdrop-blur-md transition hover:bg-black/60 hover:text-white md:right-7 md:top-7"
+              aria-label={
+                isUserPaused
+                  ? "Resume Featured carousel"
+                  : "Pause Featured carousel"
+              }
+            >
+              {isUserPaused ? <Play size={15} /> : <Pause size={15} />}
+            </button>
+          </>
+        )}
+      </div>
+
+      <div
+        className="mt-4 grid grid-cols-1 gap-2 sm:grid-cols-3"
+        role="tablist"
+        aria-label="Choose a Featured game"
+      >
+        {slides.map((game, index) => {
+          const editorial = isEditorial(game, mode);
+          const active = index === displayedIndex;
+          return (
+            <button
+              key={game.id}
+              type="button"
+              role="tab"
+              aria-selected={active}
+              onClick={() => setActiveIndex(index)}
+              className={`group/option flex min-w-0 items-center gap-3 rounded-2xl border p-2 text-left transition md:p-3 ${
+                active
+                  ? "border-violet-400/60 bg-violet-400/10"
+                  : "border-white/10 bg-white/[0.03] hover:border-white/20 hover:bg-white/[0.06]"
+              }`}
+            >
+              <div
+                className="h-14 w-24 shrink-0 rounded-xl bg-[#21152f] sm:h-12 sm:w-20 lg:h-16 lg:w-28"
+                style={{
+                  background: game.media?.banner
+                    ? `url(${game.media.banner}) center/cover no-repeat`
+                    : defaultGradient,
+                }}
+              />
+              <div className="min-w-0 flex-1">
+                <span className="block truncate text-sm font-black text-white lg:text-base">
+                  {game.title}
+                </span>
+                <span
+                  className={`mt-0.5 block truncate text-[10px] font-black uppercase tracking-wider ${
+                    editorial ? "text-violet-300" : "text-white/35"
+                  }`}
+                >
+                  {editorial ? "Outlet pick" : "Automatic pick"}
+                </span>
+              </div>
+              <span className="shrink-0 pr-1 text-xs font-black text-white/30">
+                0{index + 1}
+              </span>
+            </button>
+          );
+        })}
+      </div>
     </section>
   );
 }

--- a/components/storefront/default/PlatformStorefrontHome.tsx
+++ b/components/storefront/default/PlatformStorefrontHome.tsx
@@ -37,6 +37,14 @@ function Price({ game, large = false }: { game: GameApi; large?: boolean }) {
   );
 }
 
+function commercialLabel(game: GameApi) {
+  if (isFree(game)) return "Free Demo";
+  if (game.discount_label && formatBasePrice(game)) {
+    return game.discount_label;
+  }
+  return formatPrice(game);
+}
+
 function HeroSkeleton() {
   return (
     <div className="grid min-h-[340px] animate-pulse overflow-hidden rounded-xl border border-white/[0.08] bg-white/[0.035] md:grid-cols-[minmax(0,1.65fr)_minmax(280px,0.75fr)]">
@@ -225,7 +233,7 @@ function SpotlightCarousel({
                     {game.title}
                   </span>
                   <span className="mt-1 block text-[10px] font-bold uppercase tracking-[0.15em] text-white/35">
-                    Featured 0{index + 1}
+                    {commercialLabel(game)}
                   </span>
                 </button>
               );

--- a/components/storefront/default/PlatformStorefrontHome.tsx
+++ b/components/storefront/default/PlatformStorefrontHome.tsx
@@ -1,7 +1,17 @@
 import Form from "next/form";
 import Link from "next/link";
-import { useMemo, useState } from "react";
-import { ArrowRight, Check, ChevronDown, Search, X } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import {
+  ArrowRight,
+  Check,
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  Pause,
+  Play,
+  Search,
+  X,
+} from "lucide-react";
 
 import { DiscoverOutlets } from "components/store/DiscoverOutlets";
 import type { GameApi } from "components/store/types";
@@ -106,6 +116,154 @@ function Spotlight({ game, itemHref }: { game: GameApi; itemHref: string }) {
   );
 }
 
+function SpotlightCarousel({
+  games,
+  itemHref,
+}: {
+  games: GameApi[];
+  itemHref: (slug: string) => string;
+}) {
+  const slides = games.slice(0, 3);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [isUserPaused, setIsUserPaused] = useState(false);
+  const [isInteracting, setIsInteracting] = useState(false);
+
+  useEffect(() => {
+    if (slides.length < 2 || isUserPaused || isInteracting) return;
+    const interval = window.setInterval(() => {
+      setActiveIndex((current) => (current + 1) % slides.length);
+    }, 7000);
+    return () => window.clearInterval(interval);
+  }, [slides.length, isUserPaused, isInteracting]);
+
+  if (slides.length === 0) return null;
+
+  const displayedIndex = Math.min(activeIndex, slides.length - 1);
+  const activeGame = slides[displayedIndex];
+
+  return (
+    <div
+      aria-label="Featured games on Manifold"
+      onMouseEnter={() => setIsInteracting(true)}
+      onMouseLeave={() => setIsInteracting(false)}
+      onFocusCapture={() => setIsInteracting(true)}
+      onBlurCapture={() => setIsInteracting(false)}
+    >
+      <Spotlight game={activeGame} itemHref={itemHref(activeGame.slug)} />
+
+      {slides.length > 1 && (
+        <>
+          <div className="mt-3 flex items-center justify-between gap-3 rounded-xl border border-white/[0.08] bg-white/[0.025] p-2 sm:hidden">
+            <button
+              type="button"
+              onClick={() =>
+                setActiveIndex(
+                  (current) => (current - 1 + slides.length) % slides.length,
+                )
+              }
+              className="rounded-lg border border-white/10 p-2.5 text-white/60 hover:bg-white/10 hover:text-white"
+              aria-label="Previous Featured game"
+            >
+              <ChevronLeft size={18} />
+            </button>
+            <span className="text-xs font-black uppercase tracking-[0.18em] text-white/45">
+              {displayedIndex + 1} of {slides.length}
+            </span>
+            <button
+              type="button"
+              onClick={() => setIsUserPaused((currentPaused) => !currentPaused)}
+              className="rounded-lg border border-white/10 p-2.5 text-white/60 hover:bg-white/10 hover:text-white"
+              aria-label={
+                isUserPaused
+                  ? "Resume Featured carousel"
+                  : "Pause Featured carousel"
+              }
+            >
+              {isUserPaused ? <Play size={16} /> : <Pause size={16} />}
+            </button>
+            <button
+              type="button"
+              onClick={() =>
+                setActiveIndex((current) => (current + 1) % slides.length)
+              }
+              className="rounded-lg border border-white/10 p-2.5 text-white/60 hover:bg-white/10 hover:text-white"
+              aria-label="Next Featured game"
+            >
+              <ChevronRight size={18} />
+            </button>
+          </div>
+
+          <div className="mt-3 hidden grid-cols-[auto_repeat(3,minmax(0,1fr))_auto] gap-2 sm:grid">
+            <button
+              type="button"
+              onClick={() =>
+                setActiveIndex(
+                  (current) => (current - 1 + slides.length) % slides.length,
+                )
+              }
+              className="flex items-center justify-center rounded-xl border border-white/[0.09] bg-white/[0.025] px-3 text-white/45 transition hover:border-white/20 hover:text-white"
+              aria-label="Previous Featured game"
+            >
+              <ChevronLeft size={19} />
+            </button>
+
+            {slides.map((game, index) => {
+              const active = index === displayedIndex;
+              return (
+                <button
+                  key={game.id}
+                  type="button"
+                  onClick={() => setActiveIndex(index)}
+                  aria-current={active ? "true" : undefined}
+                  className={`min-w-0 rounded-xl border px-4 py-3 text-left transition ${
+                    active
+                      ? "border-violet-400/50 bg-violet-400/[0.09]"
+                      : "border-white/[0.09] bg-white/[0.025] hover:border-white/20 hover:bg-white/[0.045]"
+                  }`}
+                >
+                  <span className="block truncate text-sm font-bold text-white">
+                    {game.title}
+                  </span>
+                  <span className="mt-1 block text-[10px] font-bold uppercase tracking-[0.15em] text-white/35">
+                    Featured 0{index + 1}
+                  </span>
+                </button>
+              );
+            })}
+
+            <div className="flex flex-col gap-1.5">
+              <button
+                type="button"
+                onClick={() =>
+                  setIsUserPaused((currentPaused) => !currentPaused)
+                }
+                className="flex flex-1 items-center justify-center rounded-lg border border-white/[0.09] bg-white/[0.025] px-3 text-white/45 transition hover:border-white/20 hover:text-white"
+                aria-label={
+                  isUserPaused
+                    ? "Resume Featured carousel"
+                    : "Pause Featured carousel"
+                }
+              >
+                {isUserPaused ? <Play size={15} /> : <Pause size={15} />}
+              </button>
+              <button
+                type="button"
+                onClick={() =>
+                  setActiveIndex((current) => (current + 1) % slides.length)
+                }
+                className="flex flex-1 items-center justify-center rounded-lg border border-white/[0.09] bg-white/[0.025] px-3 text-white/45 transition hover:border-white/20 hover:text-white"
+                aria-label="Next Featured game"
+              >
+                <ChevronRight size={17} />
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
 function GameCard({ game, href }: { game: GameApi; href: string }) {
   return (
     <Link
@@ -194,7 +352,7 @@ export function PlatformStorefrontHome({
   searchAction,
   showDiscover,
 }: DefaultStorefrontProps) {
-  const spotlight = featured[0] ?? games[0];
+  const spotlightGames = (featured.length > 0 ? featured : games).slice(0, 3);
   const categoryLinks = useMemo(
     () =>
       categories.map((label) => ({
@@ -221,10 +379,10 @@ export function PlatformStorefrontHome({
           </p>
         </div>
 
-        {isFeaturedLoading && !spotlight ? (
+        {isFeaturedLoading && spotlightGames.length === 0 ? (
           <HeroSkeleton />
-        ) : spotlight ? (
-          <Spotlight game={spotlight} itemHref={itemHref(spotlight.slug)} />
+        ) : spotlightGames.length > 0 ? (
+          <SpotlightCarousel games={spotlightGames} itemHref={itemHref} />
         ) : (
           <div className="flex min-h-[280px] items-center justify-center rounded-xl border border-dashed border-white/10 bg-white/[0.025] px-6 text-center text-white/40">
             The first games are being prepared for the catalog.

--- a/components/storefront/types.ts
+++ b/components/storefront/types.ts
@@ -65,7 +65,7 @@ export type StorefrontViewProps = {
    */
   featured: GameApi[];
   /** Whether the Outlet chose these games or the catalog ranked them. */
-  featuredMode: "EDITORIAL" | "AUTOMATIC";
+  featuredMode: "EDITORIAL" | "HYBRID" | "AUTOMATIC";
   isFeaturedLoading: boolean;
 
   /** The required surface. A view that does not render this fails the contract. */

--- a/components/storefront/types.ts
+++ b/components/storefront/types.ts
@@ -64,6 +64,8 @@ export type StorefrontViewProps = {
    * outlet with two curated games showing a blank band.
    */
   featured: GameApi[];
+  /** Whether the Outlet chose these games or the catalog ranked them. */
+  featuredMode: "EDITORIAL" | "AUTOMATIC";
   isFeaturedLoading: boolean;
 
   /** The required surface. A view that does not render this fails the contract. */

--- a/components/storefront/useStorefrontController.ts
+++ b/components/storefront/useStorefrontController.ts
@@ -18,7 +18,7 @@ type ListResponse = {
   games: GameApi[];
   pagination?: PaginationApi;
   currency?: string;
-  mode?: "EDITORIAL" | "AUTOMATIC";
+  mode?: "EDITORIAL" | "HYBRID" | "AUTOMATIC";
 };
 
 const fetcher = (url: string): Promise<ListResponse> =>

--- a/components/storefront/useStorefrontController.ts
+++ b/components/storefront/useStorefrontController.ts
@@ -18,6 +18,7 @@ type ListResponse = {
   games: GameApi[];
   pagination?: PaginationApi;
   currency?: string;
+  mode?: "EDITORIAL" | "AUTOMATIC";
 };
 
 const fetcher = (url: string): Promise<ListResponse> =>
@@ -145,6 +146,7 @@ export function useStorefrontController({
 
   return {
     featured: featuredData?.games || [],
+    featuredMode: featuredData?.mode || "AUTOMATIC",
     isFeaturedLoading,
 
     games: data?.games || [],

--- a/models/store_featured_game.ts
+++ b/models/store_featured_game.ts
@@ -5,23 +5,61 @@ import storeCuration from "models/store_curation";
 import { z } from "zod";
 
 export const MAX_FEATURED_GAMES = 3;
+export const MAX_RECOMMENDATION_REASON_LENGTH = 240;
 
-export const featuredGameSelectionSchema = z
-  .object({
-    game_slugs: z
-      .array(z.string().trim().min(1).max(255))
-      .min(1)
-      .max(MAX_FEATURED_GAMES),
-  })
-  .superRefine(({ game_slugs }, context) => {
-    if (new Set(game_slugs).size !== game_slugs.length) {
+const recommendationSchema = z.object({
+  game_slug: z.string().trim().min(1).max(255),
+  recommendation_reason: z
+    .string()
+    .trim()
+    .max(MAX_RECOMMENDATION_REASON_LENGTH)
+    .nullish()
+    .transform((reason) => reason || null),
+});
+
+const recommendationsSchema = z
+  .array(recommendationSchema)
+  .min(1)
+  .max(MAX_FEATURED_GAMES)
+  .superRefine((recommendations, context) => {
+    const gameSlugs = recommendations.map(({ game_slug }) => game_slug);
+    if (new Set(gameSlugs).size !== gameSlugs.length) {
       context.addIssue({
         code: "custom",
-        path: ["game_slugs"],
+        path: [],
         message: "Featured games must be unique.",
       });
     }
   });
+
+export const featuredGameSelectionSchema = z.union([
+  z.object({ recommendations: recommendationsSchema }),
+  z
+    .object({
+      game_slugs: z
+        .array(z.string().trim().min(1).max(255))
+        .min(1)
+        .max(MAX_FEATURED_GAMES),
+    })
+    .transform(({ game_slugs }) => ({
+      recommendations: game_slugs.map((game_slug) => ({
+        game_slug,
+        recommendation_reason: null,
+      })),
+    }))
+    .superRefine(({ recommendations }, context) => {
+      const gameSlugs = recommendations.map(({ game_slug }) => game_slug);
+      if (new Set(gameSlugs).size !== gameSlugs.length) {
+        context.addIssue({
+          code: "custom",
+          path: ["game_slugs"],
+          message: "Featured games must be unique.",
+        });
+      }
+    }),
+]);
+
+export type FeaturedRecommendation = z.infer<typeof recommendationSchema>;
 
 interface EditorialGameQuery {
   storeId: string;
@@ -31,8 +69,12 @@ interface EditorialGameQuery {
   limit: number;
 }
 
-async function replaceSelection(storeId: string, gameSlugs: string[]) {
+async function replaceSelection(
+  storeId: string,
+  recommendations: FeaturedRecommendation[],
+) {
   const curationWhere = await storeCuration.getCurationWhereClause(storeId);
+  const gameSlugs = recommendations.map(({ game_slug }) => game_slug);
 
   return prisma.$transaction(async (transaction) => {
     const andClauses: Prisma.GameWhereInput[] = [];
@@ -65,15 +107,16 @@ async function replaceSelection(storeId: string, gameSlugs: string[]) {
       where: { store_id: storeId },
     });
     await transaction.storeFeaturedGame.createMany({
-      data: gameSlugs.map((slug, index) => ({
+      data: recommendations.map((recommendation, index) => ({
         store_id: storeId,
-        game_id: gameBySlug.get(slug)!.id,
+        game_id: gameBySlug.get(recommendation.game_slug)!.id,
         position: index + 1,
+        recommendation_reason: recommendation.recommendation_reason,
       })),
     });
 
-    return gameSlugs.map((game_slug, index) => ({
-      game_slug,
+    return recommendations.map((recommendation, index) => ({
+      ...recommendation,
       position: index + 1,
     }));
   });
@@ -117,7 +160,15 @@ async function findAvailableEditorialGames({
 
   const gameById = new Map(games.map((game) => [game.id, game]));
   const orderedGames = selection
-    .map((entry) => gameById.get(entry.game_id))
+    .map((entry) => {
+      const selectedGame = gameById.get(entry.game_id);
+      return selectedGame
+        ? {
+            ...selectedGame,
+            recommendation_reason: entry.recommendation_reason,
+          }
+        : undefined;
+    })
     .filter((game) => game !== undefined);
   const total = orderedGames.length;
   const paginatedGames = orderedGames.slice((page - 1) * limit, page * limit);

--- a/pages/api/v1/stores/[slug]/featured/index.ts
+++ b/pages/api/v1/stores/[slug]/featured/index.ts
@@ -10,11 +10,16 @@ import { z } from "zod";
 import authorization from "models/authorization";
 import storeFeaturedGame, {
   featuredGameSelectionSchema,
+  MAX_FEATURED_GAMES,
 } from "models/store_featured_game";
 
 const listQuerySchema = z.object({
   page: z.coerce.number().min(1).default(1),
-  limit: z.coerce.number().min(1).max(100).default(20),
+  limit: z.coerce
+    .number()
+    .min(1)
+    .max(MAX_FEATURED_GAMES)
+    .default(MAX_FEATURED_GAMES),
 });
 
 export default createRouter<NextApiRequest, NextApiResponse>()
@@ -53,28 +58,62 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
   });
 
   if (editorialResult) {
-    const context = await storefrontPricing.contextFor(
-      currency,
-      editorialResult.games,
+    const editorialIds = new Set(
+      editorialResult.games.map((editorialGame) => editorialGame.id),
     );
+    const missingSlots = Math.max(
+      0,
+      MAX_FEATURED_GAMES - editorialResult.games.length,
+    );
+    let automaticGames: Awaited<
+      ReturnType<typeof game.findAllPaginated>
+    >["games"] = [];
+
+    if (missingSlots > 0) {
+      const automaticResult = await game.findAllPaginated({
+        priceableGameIds: gameIds,
+        page: 1,
+        // Fetch enough candidates to discard any editorial games that also
+        // rank naturally without leaving a hole in the three-slide carousel.
+        limit: MAX_FEATURED_GAMES + editorialResult.games.length,
+        order: "featured",
+        curationWhere,
+      });
+      automaticGames = automaticResult.games
+        .filter((automaticGame) => !editorialIds.has(automaticGame.id))
+        .slice(0, missingSlots);
+    }
+
+    const combinedGames = [...editorialResult.games, ...automaticGames];
+    const context = await storefrontPricing.contextFor(currency, combinedGames);
     const reasonByGameId = new Map(
       editorialResult.games.map((editorialGame) => [
         editorialGame.id,
         editorialGame.recommendation_reason,
       ]),
     );
-    const games = storefrontPricing
-      .filterAndPrice(req.context.user, editorialResult.games, context)
+    const pricedGames = storefrontPricing
+      .filterAndPrice(req.context.user, combinedGames, context)
       .map((featuredGame) => ({
         ...featuredGame,
-        recommendation_reason: reasonByGameId.get(featuredGame.id) ?? null,
+        featured_source: editorialIds.has(featuredGame.id)
+          ? "EDITORIAL"
+          : "AUTOMATIC",
+        ...(editorialIds.has(featuredGame.id) && {
+          recommendation_reason: reasonByGameId.get(featuredGame.id) ?? null,
+        }),
       }));
 
     return res.status(200).json({
-      games,
-      pagination: editorialResult.pagination,
+      games: pricedGames,
+      pagination: {
+        page: 1,
+        limit: MAX_FEATURED_GAMES,
+        total: pricedGames.length,
+        pages: pricedGames.length > 0 ? 1 : 0,
+      },
       currency,
-      mode: "EDITORIAL",
+      mode: automaticGames.length > 0 ? "HYBRID" : "EDITORIAL",
     });
   }
 
@@ -88,7 +127,12 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
   const context = await storefrontPricing.contextFor(currency, games);
 
   return res.status(200).json({
-    games: storefrontPricing.filterAndPrice(req.context.user, games, context),
+    games: storefrontPricing
+      .filterAndPrice(req.context.user, games, context)
+      .map((featuredGame) => ({
+        ...featuredGame,
+        featured_source: "AUTOMATIC",
+      })),
     pagination,
     currency,
     mode: "AUTOMATIC",

--- a/pages/api/v1/stores/[slug]/featured/index.ts
+++ b/pages/api/v1/stores/[slug]/featured/index.ts
@@ -57,13 +57,21 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse) {
       currency,
       editorialResult.games,
     );
+    const reasonByGameId = new Map(
+      editorialResult.games.map((editorialGame) => [
+        editorialGame.id,
+        editorialGame.recommendation_reason,
+      ]),
+    );
+    const games = storefrontPricing
+      .filterAndPrice(req.context.user, editorialResult.games, context)
+      .map((featuredGame) => ({
+        ...featuredGame,
+        recommendation_reason: reasonByGameId.get(featuredGame.id) ?? null,
+      }));
 
     return res.status(200).json({
-      games: storefrontPricing.filterAndPrice(
-        req.context.user,
-        editorialResult.games,
-        context,
-      ),
+      games,
       pagination: editorialResult.pagination,
       currency,
       mode: "EDITORIAL",
@@ -117,12 +125,16 @@ async function putHandler(req: NextApiRequest, res: NextApiResponse) {
 
   const selection = await storeFeaturedGame.replaceSelection(
     foundStore.id,
-    result.data.game_slugs,
+    result.data.recommendations,
   );
 
   return res.status(200).json({
     mode: "EDITORIAL",
     game_slugs: selection.map((entry) => entry.game_slug),
+    recommendations: selection.map(({ game_slug, recommendation_reason }) => ({
+      game_slug,
+      recommendation_reason,
+    })),
   });
 }
 

--- a/pages/store/[slug]/manage.tsx
+++ b/pages/store/[slug]/manage.tsx
@@ -1,9 +1,18 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import Head from "next/head";
 import Link from "next/link";
 import useSWR, { useSWRConfig } from "swr";
-import { Loader2, ExternalLink, X, ChevronDown } from "lucide-react";
+import {
+  Loader2,
+  ExternalLink,
+  X,
+  ChevronDown,
+  ArrowUp,
+  ArrowDown,
+  Trash2,
+  RotateCcw,
+} from "lucide-react";
 import { CreatorWorkspaceLayout } from "components/creator/CreatorWorkspaceLayout";
 import { GameAutocomplete } from "components/store/GameAutocomplete";
 import { type GameApi } from "components/store/types";
@@ -67,12 +76,12 @@ const fetcher = (url: string) =>
     return res.json();
   });
 
-type Tab = "curation" | "settings" | "sales" | "earnings";
+type Tab = "featured" | "curation" | "settings" | "sales" | "earnings";
 
 export default function StoreManagePage() {
   const router = useRouter();
   const slug = router.query.slug as string | undefined;
-  const [tab, setTab] = useState<Tab>("curation");
+  const [tab, setTab] = useState<Tab>("featured");
 
   const {
     data: storeData,
@@ -101,16 +110,6 @@ export default function StoreManagePage() {
     return (
       <div className="flex min-h-[calc(100vh-4rem)] items-center justify-center bg-[#0b0812]">
         <p className="text-rose-300 font-bold">Outlet not found.</p>
-      </div>
-    );
-  }
-
-  if (tagFiltersError) {
-    return (
-      <div className="flex min-h-[calc(100vh-4rem)] items-center justify-center bg-[#0b0812] px-4 text-center">
-        <p className="text-rose-300 font-bold">
-          You do not have permission to manage this outlet.
-        </p>
       </div>
     );
   }
@@ -147,6 +146,7 @@ export default function StoreManagePage() {
         <div className="-mx-4 flex items-center gap-2 overflow-x-auto border-b border-white/10 px-4 sm:mx-0 sm:px-0 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           {(
             [
+              ["featured", "Featured"],
               ["curation", "Curation"],
               ["settings", "Settings"],
               ["sales", "Sales"],
@@ -167,13 +167,22 @@ export default function StoreManagePage() {
           ))}
         </div>
 
-        {tab === "curation" && (
-          <CurationTab
-            storeSlug={storeData.slug}
-            tagFilters={tagFilters ?? []}
-            isTagFiltersLoading={isTagFiltersLoading}
-          />
+        {tab === "featured" && (
+          <FeaturedTab storeSlug={storeData.slug} storeName={storeData.name} />
         )}
+        {tab === "curation" &&
+          (tagFiltersError ? (
+            <p className="text-rose-300 font-bold text-sm">
+              You do not have permission to manage this outlet&apos;s catalog
+              curation.
+            </p>
+          ) : (
+            <CurationTab
+              storeSlug={storeData.slug}
+              tagFilters={tagFilters ?? []}
+              isTagFiltersLoading={isTagFiltersLoading}
+            />
+          ))}
         {tab === "settings" && <SettingsTab store={storeData} />}
         {tab === "sales" && <SalesTab storeSlug={storeData.slug} />}
         {tab === "earnings" && <EarningsTab storeSlug={storeData.slug} />}
@@ -185,6 +194,314 @@ export default function StoreManagePage() {
 StoreManagePage.getLayout = function getLayout(page: React.ReactElement) {
   return <CreatorWorkspaceLayout>{page}</CreatorWorkspaceLayout>;
 };
+
+type FeaturedRecommendationDraft = {
+  game: GameApi;
+  recommendationReason: string;
+};
+
+type FeaturedResponse = {
+  games: GameApi[];
+  mode: "EDITORIAL" | "AUTOMATIC";
+};
+
+function FeaturedTab({
+  storeSlug,
+  storeName,
+}: {
+  storeSlug: string;
+  storeName: string;
+}) {
+  const featuredKey = `/api/v1/stores/${storeSlug}/featured`;
+  const { data, isLoading, error, mutate } = useSWR<FeaturedResponse>(
+    featuredKey,
+    fetcher,
+  );
+  const [recommendations, setRecommendations] = useState<
+    FeaturedRecommendationDraft[]
+  >([]);
+  const [isInitialized, setIsInitialized] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  useEffect(() => {
+    setIsInitialized(false);
+    setRecommendations([]);
+  }, [featuredKey]);
+
+  useEffect(() => {
+    if (!data || isInitialized) return;
+    setRecommendations(
+      data.mode === "EDITORIAL"
+        ? data.games.map((featuredGame) => ({
+            game: featuredGame,
+            recommendationReason: featuredGame.recommendation_reason ?? "",
+          }))
+        : [],
+    );
+    setIsInitialized(true);
+  }, [data, isInitialized]);
+
+  function addGame(game: GameApi) {
+    setFormError(null);
+    setSuccess(null);
+    if (recommendations.some((entry) => entry.game.slug === game.slug)) {
+      setFormError(`${game.title} is already in Featured.`);
+      return;
+    }
+    if (recommendations.length >= 3) {
+      setFormError("Featured can contain up to three games.");
+      return;
+    }
+    setRecommendations((current) => [
+      ...current,
+      { game, recommendationReason: "" },
+    ]);
+  }
+
+  function moveGame(index: number, direction: -1 | 1) {
+    const nextIndex = index + direction;
+    if (nextIndex < 0 || nextIndex >= recommendations.length) return;
+    setRecommendations((current) => {
+      const next = [...current];
+      [next[index], next[nextIndex]] = [next[nextIndex], next[index]];
+      return next;
+    });
+    setSuccess(null);
+  }
+
+  function updateReason(index: number, recommendationReason: string) {
+    setRecommendations((current) =>
+      current.map((entry, entryIndex) =>
+        entryIndex === index ? { ...entry, recommendationReason } : entry,
+      ),
+    );
+    setSuccess(null);
+  }
+
+  async function handleSave() {
+    if (recommendations.length === 0) return;
+    setIsSubmitting(true);
+    setFormError(null);
+    setSuccess(null);
+    try {
+      const response = await fetch(featuredKey, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          recommendations: recommendations.map(
+            ({ game, recommendationReason }) => ({
+              game_slug: game.slug,
+              recommendation_reason: recommendationReason,
+            }),
+          ),
+        }),
+      });
+      const body = await response.json().catch(() => null);
+      if (!response.ok) {
+        setFormError(body?.message || "Failed to update Featured games.");
+        return;
+      }
+      setSuccess("Featured recommendations saved.");
+      await mutate();
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  async function handleReset() {
+    setIsSubmitting(true);
+    setFormError(null);
+    setSuccess(null);
+    try {
+      const response = await fetch(featuredKey, { method: "DELETE" });
+      if (!response.ok) {
+        const body = await response.json().catch(() => null);
+        setFormError(body?.message || "Failed to restore automatic Featured.");
+        return;
+      }
+      setRecommendations([]);
+      setSuccess("Automatic Featured restored.");
+      await mutate();
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  if (isLoading || !isInitialized) {
+    return <Loader2 className="animate-spin text-white/30" size={24} />;
+  }
+
+  if (error) {
+    return (
+      <p className="text-rose-300 font-bold text-sm">
+        Failed to load Featured recommendations.
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex max-w-4xl flex-col gap-7">
+      <div>
+        <h2 className="text-xl font-black">Your Featured recommendations</h2>
+        <p className="mt-1 max-w-2xl text-sm font-semibold leading-relaxed text-white/50">
+          Choose up to three games and tell visitors why each one is worth
+          playing. The first game receives the largest spot on {storeName}.
+        </p>
+      </div>
+
+      <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4 sm:p-5">
+        {recommendations.length < 3 ? (
+          <GameAutocomplete
+            endpoint={`/api/v1/stores/${storeSlug}/search`}
+            onSelect={addGame}
+            placeholder="Search games in this Outlet..."
+          />
+        ) : (
+          <p className="text-sm font-bold text-white/40">
+            All three Featured spots are filled. Remove a game to choose
+            another.
+          </p>
+        )}
+      </div>
+
+      {data?.mode === "EDITORIAL" && recommendations.length === 0 && (
+        <div className="rounded-xl border border-amber-400/20 bg-amber-400/10 px-4 py-3 text-sm font-bold text-amber-200">
+          This Outlet has an editorial selection, but none of its games are
+          currently available. Reset it or choose new games.
+        </div>
+      )}
+
+      {recommendations.length === 0 && data?.mode !== "EDITORIAL" ? (
+        <div className="rounded-2xl border border-dashed border-white/10 px-5 py-10 text-center">
+          <p className="font-black text-white/70">Featured is automatic</p>
+          <p className="mt-1 text-sm font-semibold text-white/35">
+            Add a game above to turn this into an editorial selection.
+          </p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {recommendations.map((entry, index) => (
+            <article
+              key={entry.game.id}
+              className="overflow-hidden rounded-2xl border border-white/10 bg-[#14101c]"
+            >
+              <div className="flex flex-col gap-4 p-4 sm:flex-row sm:p-5">
+                <div
+                  className="aspect-video w-full shrink-0 rounded-xl border border-white/10 bg-[#21152f] sm:w-48"
+                  style={{
+                    background: entry.game.media?.banner
+                      ? `url(${entry.game.media.banner}) center/cover no-repeat`
+                      : undefined,
+                  }}
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <span className="text-[10px] font-black uppercase tracking-[0.18em] text-violet-300/70">
+                        Position {index + 1}
+                      </span>
+                      <h3 className="truncate text-lg font-black text-white">
+                        {entry.game.title}
+                      </h3>
+                    </div>
+                    <div className="flex shrink-0 items-center gap-1">
+                      <button
+                        type="button"
+                        onClick={() => moveGame(index, -1)}
+                        disabled={index === 0}
+                        className="rounded-lg border border-white/10 p-2 text-white/60 transition hover:bg-white/10 hover:text-white disabled:cursor-not-allowed disabled:opacity-20"
+                        aria-label={`Move ${entry.game.title} up`}
+                      >
+                        <ArrowUp size={15} />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => moveGame(index, 1)}
+                        disabled={index === recommendations.length - 1}
+                        className="rounded-lg border border-white/10 p-2 text-white/60 transition hover:bg-white/10 hover:text-white disabled:cursor-not-allowed disabled:opacity-20"
+                        aria-label={`Move ${entry.game.title} down`}
+                      >
+                        <ArrowDown size={15} />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setRecommendations((current) =>
+                            current.filter(
+                              (_, entryIndex) => entryIndex !== index,
+                            ),
+                          );
+                          setSuccess(null);
+                        }}
+                        className="rounded-lg border border-rose-400/20 p-2 text-rose-300/70 transition hover:bg-rose-400/10 hover:text-rose-200"
+                        aria-label={`Remove ${entry.game.title}`}
+                      >
+                        <Trash2 size={15} />
+                      </button>
+                    </div>
+                  </div>
+
+                  <label className="mt-4 block">
+                    <span className="text-xs font-black uppercase tracking-wider text-white/45">
+                      Why do you recommend it?{" "}
+                      <span className="normal-case">(optional)</span>
+                    </span>
+                    <textarea
+                      value={entry.recommendationReason}
+                      onChange={(event) =>
+                        updateReason(index, event.target.value)
+                      }
+                      maxLength={240}
+                      rows={2}
+                      placeholder="A short, personal reason this game is worth their time."
+                      className="mt-2 w-full resize-none rounded-xl border border-white/10 bg-white/5 px-3.5 py-3 text-base font-semibold leading-relaxed text-white outline-none placeholder:text-white/25 focus:border-violet-400/40 focus:bg-white/[0.07] sm:text-sm"
+                    />
+                    <span className="mt-1 block text-right text-[11px] font-bold text-white/30">
+                      {entry.recommendationReason.length}/240
+                    </span>
+                  </label>
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+
+      {formError && (
+        <div className="rounded-xl border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm font-bold text-rose-300">
+          {formError}
+        </div>
+      )}
+      {success && (
+        <div className="rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-sm font-bold text-emerald-300">
+          {success}
+        </div>
+      )}
+
+      <div className="flex flex-col-reverse gap-3 border-t border-white/10 pt-5 sm:flex-row sm:items-center sm:justify-between">
+        <button
+          type="button"
+          onClick={handleReset}
+          disabled={isSubmitting}
+          className="inline-flex items-center justify-center gap-2 rounded-xl border border-white/10 px-4 py-3 text-sm font-black text-white/55 transition hover:bg-white/5 hover:text-white disabled:opacity-40"
+        >
+          <RotateCcw size={15} />
+          Use automatic Featured
+        </button>
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={isSubmitting || recommendations.length === 0}
+          className="rounded-xl bg-gradient-to-r from-violet-500 to-fuchsia-500 px-5 py-3 text-sm font-black uppercase tracking-wider text-white transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          {isSubmitting ? "Saving..." : "Save Featured"}
+        </button>
+      </div>
+    </div>
+  );
+}
 
 function CurationTab({
   storeSlug,

--- a/pages/store/[slug]/manage.tsx
+++ b/pages/store/[slug]/manage.tsx
@@ -202,7 +202,7 @@ type FeaturedRecommendationDraft = {
 
 type FeaturedResponse = {
   games: GameApi[];
-  mode: "EDITORIAL" | "AUTOMATIC";
+  mode: "EDITORIAL" | "HYBRID" | "AUTOMATIC";
 };
 
 function FeaturedTab({
@@ -238,7 +238,16 @@ function FeaturedTab({
             game: featuredGame,
             recommendationReason: featuredGame.recommendation_reason ?? "",
           }))
-        : [],
+        : data.mode === "HYBRID"
+          ? data.games
+              .filter(
+                (featuredGame) => featuredGame.featured_source === "EDITORIAL",
+              )
+              .map((featuredGame) => ({
+                game: featuredGame,
+                recommendationReason: featuredGame.recommendation_reason ?? "",
+              }))
+          : [],
     );
     setIsInitialized(true);
   }, [data, isInitialized]);
@@ -366,14 +375,14 @@ function FeaturedTab({
         )}
       </div>
 
-      {data?.mode === "EDITORIAL" && recommendations.length === 0 && (
+      {data?.mode !== "AUTOMATIC" && recommendations.length === 0 && (
         <div className="rounded-xl border border-amber-400/20 bg-amber-400/10 px-4 py-3 text-sm font-bold text-amber-200">
           This Outlet has an editorial selection, but none of its games are
           currently available. Reset it or choose new games.
         </div>
       )}
 
-      {recommendations.length === 0 && data?.mode !== "EDITORIAL" ? (
+      {recommendations.length === 0 && data?.mode === "AUTOMATIC" ? (
         <div className="rounded-2xl border border-dashed border-white/10 px-5 py-10 text-center">
           <p className="font-black text-white/70">Featured is automatic</p>
           <p className="mt-1 text-sm font-semibold text-white/35">

--- a/prisma/migrations/20260823170000_add_store_featured_recommendation_reason/migration.sql
+++ b/prisma/migrations/20260823170000_add_store_featured_recommendation_reason/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "store_featured_games"
+ADD COLUMN "recommendation_reason" VARCHAR(240);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -424,12 +424,13 @@ model StoreGameOverride {
 }
 
 model StoreFeaturedGame {
-  id         String   @id @default(uuid())
-  store_id   String // Logical reference to Store.id
-  game_id    String // Logical reference to Game.id
-  position   Int
-  created_at DateTime @default(now())
-  updated_at DateTime @updatedAt
+  id                    String   @id @default(uuid())
+  store_id              String // Logical reference to Store.id
+  game_id               String // Logical reference to Game.id
+  position              Int
+  recommendation_reason String?  @db.VarChar(240)
+  created_at            DateTime @default(now())
+  updated_at            DateTime @updatedAt
 
   @@unique([store_id, game_id])
   @@unique([store_id, position])

--- a/storefronts/_template/Storefront.tsx
+++ b/storefronts/_template/Storefront.tsx
@@ -60,6 +60,11 @@ export function TemplateStorefront({
               className="rounded-3xl border border-sf-border bg-sf-surface p-6 min-h-40 flex flex-col justify-end"
             >
               <h2 className="text-2xl font-black">{game.title}</h2>
+              {game.recommendation_reason && (
+                <p className="line-clamp-2 text-sm text-sf-muted">
+                  {game.recommendation_reason}
+                </p>
+              )}
               <span className="text-sf-accent font-black uppercase">
                 {isFree(game) ? "Free" : formatPrice(game)}
               </span>

--- a/storefronts/neon-alley/Storefront.tsx
+++ b/storefronts/neon-alley/Storefront.tsx
@@ -72,6 +72,11 @@ function Tile({
         >
           {game.title}
         </h3>
+        {game.recommendation_reason && (
+          <p className="line-clamp-2 text-sm font-semibold leading-relaxed text-sf-fg/80">
+            {game.recommendation_reason}
+          </p>
+        )}
         <div className="flex items-center justify-between gap-3">
           <Price game={game} />
           <span className="text-[10px] uppercase tracking-[0.25em] text-sf-muted truncate">

--- a/storefronts/strategos-void/Storefront.tsx
+++ b/storefronts/strategos-void/Storefront.tsx
@@ -222,9 +222,9 @@ export function StrategosVoidStorefront({
               <h3 className="text-2xl font-black uppercase tracking-tight text-sf-fg md:text-4xl">
                 {heroGame.title}
               </h3>
-              {heroGame.description && (
+              {(heroGame.recommendation_reason || heroGame.description) && (
                 <p className="line-clamp-2 max-w-xl text-sf-muted">
-                  {heroGame.description}
+                  {heroGame.recommendation_reason || heroGame.description}
                 </p>
               )}
               <span className="text-xl font-black uppercase tracking-wider text-sf-accent">

--- a/tests/integration/api/v1/stores/[slug]/featured/get.test.ts
+++ b/tests/integration/api/v1/stores/[slug]/featured/get.test.ts
@@ -47,6 +47,11 @@ describe("GET /api/v1/stores/[slug]/featured", () => {
       expect(response.status).toBe(200);
       const body = await response.json();
       expect(body.mode).toBe("AUTOMATIC");
+      expect(
+        body.games.every(
+          (game: Record<string, unknown>) => !("recommendation_reason" in game),
+        ),
+      ).toBe(true);
       const titles = body.games.map((g: { title: string }) => g.title);
       expect(titles).toContain("Featured Allowed");
       expect(titles).not.toContain("Featured Banned");

--- a/tests/integration/api/v1/stores/[slug]/featured/get.test.ts
+++ b/tests/integration/api/v1/stores/[slug]/featured/get.test.ts
@@ -22,11 +22,18 @@ describe("GET /api/v1/stores/[slug]/featured", () => {
       await orchestrator.activateUser(owner.id);
       const createdStore = await orchestrator.createStore(owner.id);
 
-      const allowedGame = await orchestrator.createGame(owner.id, {
-        title: "Featured Allowed",
-        tags: ["rpg"],
-      });
-      await gameModel.makePublic(allowedGame.id);
+      const allowedGames = await Promise.all(
+        ["Featured Allowed", "Second Allowed", "Third Allowed"].map(
+          async (title) => {
+            const allowedGame = await orchestrator.createGame(owner.id, {
+              title,
+              tags: ["rpg"],
+            });
+            await gameModel.makePublic(allowedGame.id);
+            return allowedGame;
+          },
+        ),
+      );
 
       const bannedGame = await orchestrator.createGame(owner.id, {
         title: "Featured Banned",
@@ -47,13 +54,22 @@ describe("GET /api/v1/stores/[slug]/featured", () => {
       expect(response.status).toBe(200);
       const body = await response.json();
       expect(body.mode).toBe("AUTOMATIC");
+      expect(body.games).toHaveLength(3);
+      expect(
+        body.games.every(
+          (game: { featured_source: string }) =>
+            game.featured_source === "AUTOMATIC",
+        ),
+      ).toBe(true);
       expect(
         body.games.every(
           (game: Record<string, unknown>) => !("recommendation_reason" in game),
         ),
       ).toBe(true);
       const titles = body.games.map((g: { title: string }) => g.title);
-      expect(titles).toContain("Featured Allowed");
+      allowedGames.forEach((allowedGame) =>
+        expect(titles).toContain(allowedGame.title),
+      );
       expect(titles).not.toContain("Featured Banned");
     });
   });

--- a/tests/integration/api/v1/stores/[slug]/featured/put.test.ts
+++ b/tests/integration/api/v1/stores/[slug]/featured/put.test.ts
@@ -130,6 +130,55 @@ describe("PUT /api/v1/stores/[slug]/featured", () => {
     );
   });
 
+  test("Fills unselected carousel slots automatically without claiming them as Outlet picks", async () => {
+    const owner = await orchestrator.createUser();
+    await orchestrator.activateUser(owner.id);
+    const session = await orchestrator.createSession(owner.id);
+    const store = await orchestrator.createStore(owner.id);
+    const chosen = await createPublicGame(owner.id, "The Outlet Choice");
+    await Promise.all(
+      ["Automatic One", "Automatic Two", "Automatic Three"].map((title) =>
+        createPublicGame(owner.id, title),
+      ),
+    );
+
+    const putResponse = await putRecommendations(store.slug, session.token, [
+      {
+        game_slug: chosen.slug,
+        recommendation_reason: "The sharpest systems in this catalog.",
+      },
+    ]);
+    expect(putResponse.status).toBe(200);
+
+    const publicResponse = await fetch(
+      `${webserver.getOrigin()}/api/v1/stores/${store.slug}/featured`,
+    );
+    const body = await publicResponse.json();
+
+    expect(body.mode).toBe("HYBRID");
+    expect(body.games).toHaveLength(3);
+    expect(body.games[0]).toEqual(
+      expect.objectContaining({
+        slug: chosen.slug,
+        featured_source: "EDITORIAL",
+        recommendation_reason: "The sharpest systems in this catalog.",
+      }),
+    );
+    expect(
+      body.games
+        .slice(1)
+        .every(
+          (featuredGame: Record<string, unknown>) =>
+            featuredGame.featured_source === "AUTOMATIC" &&
+            !("recommendation_reason" in featuredGame),
+        ),
+    ).toBe(true);
+    expect(
+      new Set(body.games.map((featuredGame: { id: string }) => featuredGame.id))
+        .size,
+    ).toBe(3);
+  });
+
   test("Rejects an overlong reason without replacing the current selection", async () => {
     const owner = await orchestrator.createUser();
     await orchestrator.activateUser(owner.id);
@@ -165,8 +214,12 @@ describe("PUT /api/v1/stores/[slug]/featured", () => {
       `${webserver.getOrigin()}/api/v1/stores/${store.slug}/featured`,
     );
     const publicBody = await publicResponse.json();
-    expect(publicBody.games).toHaveLength(1);
-    expect(publicBody.games[0]).toEqual(
+    const editorialGames = publicBody.games.filter(
+      (featuredGame: { featured_source: string }) =>
+        featuredGame.featured_source === "EDITORIAL",
+    );
+    expect(editorialGames).toHaveLength(1);
+    expect(editorialGames[0]).toEqual(
       expect.objectContaining({
         slug: original.slug,
         recommendation_reason: "The original recommendation.",
@@ -315,13 +368,18 @@ describe("PUT /api/v1/stores/[slug]/featured", () => {
       `${webserver.getOrigin()}/api/v1/stores/${store.slug}/featured`,
     );
     const publicBody = await publicResponse.json();
-    expect(publicBody.mode).toBe("EDITORIAL");
-    expect(publicBody.games.map((game: { slug: string }) => game.slug)).toEqual(
-      [valid.slug],
-    );
+    expect(publicBody.mode).toBe("HYBRID");
+    expect(
+      publicBody.games
+        .filter(
+          (featuredGame: { featured_source: string }) =>
+            featuredGame.featured_source === "EDITORIAL",
+        )
+        .map((featuredGame: { slug: string }) => featuredGame.slug),
+    ).toEqual([valid.slug]);
   });
 
-  test("Public GET hides a selected game that later becomes inactive without inventing an automatic recommendation", async () => {
+  test("Public GET replaces a selected game that becomes unavailable with clearly automatic slides", async () => {
     const owner = await orchestrator.createUser();
     await orchestrator.activateUser(owner.id);
     const session = await orchestrator.createSession(owner.id);
@@ -337,8 +395,15 @@ describe("PUT /api/v1/stores/[slug]/featured", () => {
       `${webserver.getOrigin()}/api/v1/stores/${store.slug}/featured`,
     );
     const publicBody = await publicResponse.json();
-    expect(publicBody.mode).toBe("EDITORIAL");
-    expect(publicBody.games).toEqual([]);
-    expect(publicBody.pagination.total).toBe(0);
+    expect(publicBody.mode).toBe("HYBRID");
+    expect(publicBody.games).toHaveLength(3);
+    expect(
+      publicBody.games.every(
+        (featuredGame: Record<string, unknown>) =>
+          featuredGame.featured_source === "AUTOMATIC" &&
+          !("recommendation_reason" in featuredGame),
+      ),
+    ).toBe(true);
+    expect(publicBody.pagination.total).toBe(3);
   });
 });

--- a/tests/integration/api/v1/stores/[slug]/featured/put.test.ts
+++ b/tests/integration/api/v1/stores/[slug]/featured/put.test.ts
@@ -28,6 +28,24 @@ async function putSelection(
   });
 }
 
+async function putRecommendations(
+  storeSlug: string,
+  sessionToken: string,
+  recommendations: {
+    game_slug: string;
+    recommendation_reason?: string | null;
+  }[],
+) {
+  return fetch(`${webserver.getOrigin()}/api/v1/stores/${storeSlug}/featured`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      Cookie: `session_id=${sessionToken}`,
+    },
+    body: JSON.stringify({ recommendations }),
+  });
+}
+
 describe("PUT /api/v1/stores/[slug]/featured", () => {
   test("An owner can replace the selection and public GET preserves its order", async () => {
     const owner = await orchestrator.createUser();
@@ -46,6 +64,10 @@ describe("PUT /api/v1/stores/[slug]/featured", () => {
     await expect(response.json()).resolves.toEqual({
       mode: "EDITORIAL",
       game_slugs: [second.slug, first.slug],
+      recommendations: [
+        { game_slug: second.slug, recommendation_reason: null },
+        { game_slug: first.slug, recommendation_reason: null },
+      ],
     });
 
     const publicResponse = await fetch(
@@ -55,6 +77,100 @@ describe("PUT /api/v1/stores/[slug]/featured", () => {
     expect(publicBody.mode).toBe("EDITORIAL");
     expect(publicBody.games.map((game: { slug: string }) => game.slug)).toEqual(
       [second.slug, first.slug],
+    );
+  });
+
+  test("Stores short editorial reasons and exposes them on public Featured games", async () => {
+    const owner = await orchestrator.createUser();
+    await orchestrator.activateUser(owner.id);
+    const session = await orchestrator.createSession(owner.id);
+    const store = await orchestrator.createStore(owner.id);
+    const first = await createPublicGame(owner.id, "Reasoned First");
+    const second = await createPublicGame(owner.id, "Reasoned Second");
+
+    const response = await putRecommendations(store.slug, session.token, [
+      {
+        game_slug: first.slug,
+        recommendation_reason:
+          "  A thoughtful campaign that respects your time.  ",
+      },
+      { game_slug: second.slug, recommendation_reason: "   " },
+    ]);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      mode: "EDITORIAL",
+      game_slugs: [first.slug, second.slug],
+      recommendations: [
+        {
+          game_slug: first.slug,
+          recommendation_reason:
+            "A thoughtful campaign that respects your time.",
+        },
+        { game_slug: second.slug, recommendation_reason: null },
+      ],
+    });
+
+    const publicResponse = await fetch(
+      `${webserver.getOrigin()}/api/v1/stores/${store.slug}/featured`,
+    );
+    const publicBody = await publicResponse.json();
+    expect(publicBody.games).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          slug: first.slug,
+          recommendation_reason:
+            "A thoughtful campaign that respects your time.",
+        }),
+        expect.objectContaining({
+          slug: second.slug,
+          recommendation_reason: null,
+        }),
+      ]),
+    );
+  });
+
+  test("Rejects an overlong reason without replacing the current selection", async () => {
+    const owner = await orchestrator.createUser();
+    await orchestrator.activateUser(owner.id);
+    const session = await orchestrator.createSession(owner.id);
+    const store = await orchestrator.createStore(owner.id);
+    const original = await createPublicGame(owner.id, "Original Reason");
+    const replacement = await createPublicGame(owner.id, "Long Reason");
+
+    expect(
+      (
+        await putRecommendations(store.slug, session.token, [
+          {
+            game_slug: original.slug,
+            recommendation_reason: "The original recommendation.",
+          },
+        ])
+      ).status,
+    ).toBe(200);
+
+    const invalidResponse = await putRecommendations(
+      store.slug,
+      session.token,
+      [
+        {
+          game_slug: replacement.slug,
+          recommendation_reason: "x".repeat(241),
+        },
+      ],
+    );
+    expect(invalidResponse.status).toBe(400);
+
+    const publicResponse = await fetch(
+      `${webserver.getOrigin()}/api/v1/stores/${store.slug}/featured`,
+    );
+    const publicBody = await publicResponse.json();
+    expect(publicBody.games).toHaveLength(1);
+    expect(publicBody.games[0]).toEqual(
+      expect.objectContaining({
+        slug: original.slug,
+        recommendation_reason: "The original recommendation.",
+      }),
     );
   });
 


### PR DESCRIPTION
Closes #232

## Summary

- stores an optional plain-text recommendation reason on each Outlet Featured game
- lets an Outlet choose one, two, or three editorial games and preserves their order
- automatically fills empty Outlet Featured slots so its carousel normally contains three unique games
- marks every Outlet slide as EDITORIAL or AUTOMATIC so automatic fillers are never presented as personal recommendations
- replaces the Outlet hero with an auto-advancing carousel, previous/next controls, pause control, and three selectable preview cards
- rotates three games in the main /store homepage spotlight as well, with its own responsive controls and direct slide selection
- adds a dedicated Featured management tab with search, ordering, removal, reset, and a 240-character editor
- displays editorial reasons in the default carousel and custom storefront showcases
- preserves the legacy game_slugs payload

## Validation

- npm run prisma:generate
- npm run migrate:deploy
- npx eslint on every changed TypeScript file
- npx jest --runInBand --testPathPatterns=featured (3 suites, 15 tests)
- npm run build
- npx commitlint --from HEAD~1 --to HEAD

## Stack

This PR is stacked on #231 and should be reviewed or merged after it.