### PR TITLE
feat: select language from visitor country

### DIFF
--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -2,6 +2,7 @@ import { Languages } from "lucide-react";
 import { useRouter } from "next/router";
 
 import { localeNames, type AppLocale, useI18n } from "lib/i18n";
+import { LOCALE_COOKIE } from "lib/locale";
 
 export function LanguageSwitcher({
   className = "",
@@ -14,7 +15,7 @@ export function LanguageSwitcher({
   const { locale, t } = useI18n();
 
   async function changeLocale(nextLocale: AppLocale) {
-    document.cookie = `NEXT_LOCALE=${nextLocale}; path=/; max-age=31536000; SameSite=Lax`;
+    document.cookie = `${LOCALE_COOKIE}=${nextLocale}; path=/; max-age=31536000; SameSite=Lax`;
     await router.push(router.asPath, router.asPath, { locale: nextLocale });
   }
 

--- a/lib/country.ts
+++ b/lib/country.ts
@@ -1,0 +1,25 @@
+// Vercel sets this on requests served through its network. Currency and
+// language detection deliberately share this source so they cannot disagree
+// about whether a visitor is in Brazil.
+export const COUNTRY_HEADER = "x-vercel-ip-country";
+
+type CountryHeaderValue = string | string[] | null | undefined;
+
+export function countryCodeFromHeader(
+  value: CountryHeaderValue,
+): string | null {
+  const candidate = Array.isArray(value) ? value[0] : value;
+
+  if (!candidate) {
+    return null;
+  }
+
+  const normalized = candidate.trim().toUpperCase();
+
+  // Vercel sends "XX" when it cannot geolocate the request.
+  if (!/^[A-Z]{2}$/.test(normalized) || normalized === "XX") {
+    return null;
+  }
+
+  return normalized;
+}

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -1,14 +1,10 @@
 import { createContext, useCallback, useContext, type ReactNode } from "react";
 import { useRouter } from "next/router";
 import { ptBR } from "lib/i18n/pt-BR";
+import { localeNames, locales, type AppLocale } from "lib/locale";
 
-export const locales = ["en", "pt-BR"] as const;
-export type AppLocale = (typeof locales)[number];
-
-export const localeNames: Record<AppLocale, string> = {
-  en: "English",
-  "pt-BR": "Português (Brasil)",
-};
+export { localeNames, locales };
+export type { AppLocale };
 
 type TranslationValues = Record<string, string | number>;
 

--- a/lib/internal-fetch.ts
+++ b/lib/internal-fetch.ts
@@ -1,0 +1,27 @@
+import type { IncomingHttpHeaders } from "node:http";
+
+import { COUNTRY_HEADER, countryCodeFromHeader } from "lib/country";
+
+/**
+ * Headers an SSR page must preserve when it calls Manifold's own API.
+ *
+ * Cookie keeps the internal request in the same authenticated session. Country
+ * keeps regional pricing consistent between the server-rendered page and
+ * subsequent browser requests.
+ */
+export function headersForInternalFetch(
+  incomingHeaders: IncomingHttpHeaders,
+): HeadersInit {
+  const forwarded: Record<string, string> = {};
+
+  if (incomingHeaders.cookie) {
+    forwarded.cookie = incomingHeaders.cookie;
+  }
+
+  const country = countryCodeFromHeader(incomingHeaders[COUNTRY_HEADER]);
+  if (country) {
+    forwarded[COUNTRY_HEADER] = country;
+  }
+
+  return forwarded;
+}

--- a/lib/locale.ts
+++ b/lib/locale.ts
@@ -1,0 +1,22 @@
+import { countryCodeFromHeader } from "./country";
+
+export const locales = ["en", "pt-BR"] as const;
+export type AppLocale = (typeof locales)[number];
+
+export const defaultLocale: AppLocale = "en";
+export const LOCALE_COOKIE = "NEXT_LOCALE";
+
+export const localeNames: Record<AppLocale, string> = {
+  en: "English",
+  "pt-BR": "Português (Brasil)",
+};
+
+export function isAppLocale(value: string | undefined): value is AppLocale {
+  return locales.some((locale) => locale === value);
+}
+
+export function localeForCountry(
+  countryHeader: string | string[] | null | undefined,
+): AppLocale {
+  return countryCodeFromHeader(countryHeader) === "BR" ? "pt-BR" : "en";
+}

--- a/models/region.ts
+++ b/models/region.ts
@@ -1,10 +1,9 @@
 import { NextApiRequest } from "next";
 import currency from "models/currency";
 import { BASE_CURRENCY } from "models/pricing";
+import { COUNTRY_HEADER, countryCodeFromHeader } from "lib/country";
 
-// Vercel sets this on every request from its edge network. Kept as the only
-// source so there is exactly one place to change if the platform changes.
-export const COUNTRY_HEADER = "x-vercel-ip-country";
+export { COUNTRY_HEADER };
 
 // ISO 3166-1 alpha-2 → ISO 4217. Deliberately a static map rather than a
 // table: it is a property of the world, not of our catalogue, so putting it in
@@ -73,21 +72,7 @@ const COUNTRY_CURRENCY: Record<string, string> = {
 };
 
 function countryFromRequest(req: NextApiRequest): string | null {
-  const header = req.headers[COUNTRY_HEADER];
-  const value = Array.isArray(header) ? header[0] : header;
-
-  if (!value) {
-    return null;
-  }
-
-  const normalized = value.trim().toUpperCase();
-
-  // Vercel sends "XX" when it cannot geolocate the request.
-  if (!/^[A-Z]{2}$/.test(normalized) || normalized === "XX") {
-    return null;
-  }
-
-  return normalized;
+  return countryCodeFromHeader(req.headers[COUNTRY_HEADER]);
 }
 
 export function currencyCodeForCountry(country: string | null): string {

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,12 @@
+import { defaultLocale, locales } from "./lib/locale";
+
 module.exports = {
   i18n: {
-    locales: ["en", "pt-BR"],
-    defaultLocale: "en",
+    locales: [...locales],
+    defaultLocale,
+    // Country-aware routing lives in proxy.ts. Disabling the built-in
+    // Accept-Language redirect prevents it from racing with geolocation.
+    localeDetection: false,
   },
   images: {
     remotePatterns: [

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,12 +1,18 @@
 import type { GetServerSideProps } from "next";
+import { defaultLocale } from "lib/locale";
 
-export const getServerSideProps: GetServerSideProps = async ({ query }) => {
+export const getServerSideProps: GetServerSideProps = async ({
+  locale,
+  query,
+}) => {
   const queryString = new URLSearchParams(
     query as Record<string, string>,
   ).toString();
+  const localePrefix = locale && locale !== defaultLocale ? `/${locale}` : "";
+
   return {
     redirect: {
-      destination: `/store${queryString ? `?${queryString}` : ""}`,
+      destination: `${localePrefix}/store${queryString ? `?${queryString}` : ""}`,
       permanent: false,
     },
   };

--- a/pages/item/[slug].tsx
+++ b/pages/item/[slug].tsx
@@ -11,6 +11,7 @@ import { resolveStorefront } from "storefronts/registry";
 import { storeSlugFromQuery } from "lib/store-context";
 import type { GameDetailApi, StoreApi } from "components/store/types";
 import { useI18n } from "lib/i18n";
+import { headersForInternalFetch } from "lib/internal-fetch";
 
 type ItemPageProps = {
   game: GameDetailApi;
@@ -35,14 +36,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   // Forwarded because the price shown here is regional (models/region.ts).
   // Without it a Brazilian visitor saw BRL on the storefront list and USD on
   // this page for the same game.
-  const headers: HeadersInit = {};
-  if (context.req.headers.cookie) {
-    headers.cookie = context.req.headers.cookie;
-  }
-  const country = context.req.headers["x-vercel-ip-country"];
-  if (typeof country === "string") {
-    headers["x-vercel-ip-country"] = country;
-  }
+  const headers = headersForInternalFetch(context.req.headers);
 
   try {
     const response = await fetch(

--- a/pages/store/[slug].tsx
+++ b/pages/store/[slug].tsx
@@ -8,6 +8,7 @@ import { StoreLayout } from "components/store/StoreLayout";
 import { Storefront } from "components/store/Storefront";
 import type { StoreApi } from "components/store/types";
 import { useI18n } from "lib/i18n";
+import { headersForInternalFetch } from "lib/internal-fetch";
 
 interface CurrentUser {
   id: string;
@@ -34,14 +35,7 @@ const userFetcher = (url: string) =>
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const { slug } = context.query;
 
-  const headers: HeadersInit = {};
-  if (context.req.headers.cookie) {
-    headers.cookie = context.req.headers.cookie;
-  }
-  const country = context.req.headers["x-vercel-ip-country"];
-  if (typeof country === "string") {
-    headers["x-vercel-ip-country"] = country;
-  }
+  const headers = headersForInternalFetch(context.req.headers);
 
   try {
     const response = await fetch(

--- a/proxy.ts
+++ b/proxy.ts
@@ -16,6 +16,18 @@ function hasLocalePrefix(pathname: string) {
   );
 }
 
+function isPageRoute(pathname: string) {
+  return (
+    pathname !== "/api" &&
+    !pathname.startsWith("/api/") &&
+    pathname !== "/_next" &&
+    !pathname.startsWith("/_next/") &&
+    pathname !== "/favicon.ico" &&
+    pathname !== "/site.webmanifest" &&
+    !/\/[^/]+\.[^/]+$/.test(pathname)
+  );
+}
+
 function preferredLocale(request: NextRequest) {
   const savedLocale = request.cookies.get(LOCALE_COOKIE)?.value;
 
@@ -34,7 +46,7 @@ export function proxy(request: NextRequest) {
   // A locale in the URL is an explicit choice and must never be overridden by
   // geolocation or a stale cookie.
   const pathname = new URL(request.url).pathname;
-  if (hasLocalePrefix(pathname)) {
+  if (!isPageRoute(pathname) || hasLocalePrefix(pathname)) {
     return NextResponse.next();
   }
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,60 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+import { COUNTRY_HEADER } from "lib/country";
+import {
+  defaultLocale,
+  isAppLocale,
+  LOCALE_COOKIE,
+  localeForCountry,
+  locales,
+} from "lib/locale";
+
+function hasLocalePrefix(pathname: string) {
+  return locales.some(
+    (locale) => pathname === `/${locale}` || pathname.startsWith(`/${locale}/`),
+  );
+}
+
+function preferredLocale(request: NextRequest) {
+  const savedLocale = request.cookies.get(LOCALE_COOKIE)?.value;
+
+  if (isAppLocale(savedLocale)) {
+    return savedLocale;
+  }
+
+  return localeForCountry(request.headers.get(COUNTRY_HEADER));
+}
+
+export function proxy(request: NextRequest) {
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return NextResponse.next();
+  }
+
+  // A locale in the URL is an explicit choice and must never be overridden by
+  // geolocation or a stale cookie.
+  const pathname = new URL(request.url).pathname;
+  if (hasLocalePrefix(pathname)) {
+    return NextResponse.next();
+  }
+
+  const locale = preferredLocale(request);
+  if (locale === defaultLocale) {
+    return NextResponse.next();
+  }
+
+  const destination = request.nextUrl.clone();
+  destination.pathname = `/${locale}${pathname}`;
+
+  return NextResponse.redirect(destination);
+}
+
+export const config = {
+  matcher: [
+    {
+      source:
+        "/((?!api|_next/static|_next/image|favicon.ico|site.webmanifest|.*\\..*).*)",
+      locale: false,
+    },
+  ],
+};

--- a/tests/unit/lib/country.test.ts
+++ b/tests/unit/lib/country.test.ts
@@ -1,0 +1,35 @@
+import { countryCodeFromHeader } from "lib/country";
+import { headersForInternalFetch } from "lib/internal-fetch";
+import { localeForCountry } from "lib/locale";
+
+describe("country-based locale selection", () => {
+  test.each(["BR", "br", " BR "])(
+    "selects Brazilian Portuguese for %s",
+    (country) => {
+      expect(localeForCountry(country)).toBe("pt-BR");
+    },
+  );
+
+  test.each([null, undefined, "", "XX", "US", "BRA"])(
+    "falls back to English for %s",
+    (country) => {
+      expect(localeForCountry(country)).toBe("en");
+    },
+  );
+
+  test("normalizes the same country header used by regional pricing", () => {
+    expect(countryCodeFromHeader([" br ", "US"])).toBe("BR");
+  });
+
+  test("forwards session and normalized country to internal SSR requests", () => {
+    expect(
+      headersForInternalFetch({
+        cookie: "session=abc",
+        "x-vercel-ip-country": " br ",
+      }),
+    ).toEqual({
+      cookie: "session=abc",
+      "x-vercel-ip-country": "BR",
+    });
+  });
+});

--- a/tests/unit/proxy.test.ts
+++ b/tests/unit/proxy.test.ts
@@ -1,0 +1,75 @@
+import { NextRequest } from "next/server";
+import {
+  getRedirectUrl,
+  unstable_doesMiddlewareMatch,
+} from "next/experimental/testing/server";
+
+import nextConfig from "../../next.config";
+import { config, proxy } from "../../proxy";
+
+function request(
+  path: string,
+  { country, cookie }: { country?: string; cookie?: string } = {},
+) {
+  const headers = new Headers();
+  if (country) headers.set("x-vercel-ip-country", country);
+  if (cookie) headers.set("cookie", cookie);
+
+  return new NextRequest(`https://manifoldpowered.com${path}`, { headers });
+}
+
+describe("country-aware language proxy", () => {
+  test("redirects a Brazilian visitor to the equivalent pt-BR route", () => {
+    const response = proxy(request("/store?tab=featured", { country: "BR" }));
+
+    expect(response.status).toBe(307);
+    expect(getRedirectUrl(response)).toBe(
+      "https://manifoldpowered.com/pt-BR/store?tab=featured",
+    );
+  });
+
+  test("keeps the default English route outside Brazil", () => {
+    const response = proxy(request("/store", { country: "US" }));
+
+    expect(response.status).toBe(200);
+    expect(getRedirectUrl(response)).toBeNull();
+  });
+
+  test("manual English selection overrides Brazilian geolocation", () => {
+    const response = proxy(
+      request("/store", { country: "BR", cookie: "NEXT_LOCALE=en" }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(getRedirectUrl(response)).toBeNull();
+  });
+
+  test("manual Portuguese selection overrides non-Brazilian geolocation", () => {
+    const response = proxy(
+      request("/library", {
+        country: "US",
+        cookie: "NEXT_LOCALE=pt-BR",
+      }),
+    );
+
+    expect(getRedirectUrl(response)).toBe(
+      "https://manifoldpowered.com/pt-BR/library",
+    );
+  });
+
+  test("does not redirect a route that already has an explicit locale", () => {
+    const response = proxy(request("/pt-BR/store", { country: "US" }));
+
+    expect(response.status).toBe(200);
+    expect(getRedirectUrl(response)).toBeNull();
+  });
+
+  test.each(["/api/v1/games", "/_next/static/chunk.js", "/images/logo.png"])(
+    "does not run for %s",
+    (url) => {
+      expect(unstable_doesMiddlewareMatch({ config, nextConfig, url })).toBe(
+        false,
+      );
+    },
+  );
+});

--- a/tests/unit/proxy.test.ts
+++ b/tests/unit/proxy.test.ts
@@ -64,6 +64,15 @@ describe("country-aware language proxy", () => {
     expect(getRedirectUrl(response)).toBeNull();
   });
 
+  test("does not redirect Next.js data requests for localized pages", () => {
+    const response = proxy(
+      request("/_next/data/build-id/pt-BR/store.json", { country: "BR" }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(getRedirectUrl(response)).toBeNull();
+  });
+
   test.each(["/api/v1/games", "/_next/static/chunk.js", "/images/logo.png"])(
     "never redirects non-page route %s, even for Brazil",
     (url) => {

--- a/tests/unit/proxy.test.ts
+++ b/tests/unit/proxy.test.ts
@@ -65,6 +65,16 @@ describe("country-aware language proxy", () => {
   });
 
   test.each(["/api/v1/games", "/_next/static/chunk.js", "/images/logo.png"])(
+    "never redirects non-page route %s, even for Brazil",
+    (url) => {
+      const response = proxy(request(url, { country: "BR" }));
+
+      expect(response.status).toBe(200);
+      expect(getRedirectUrl(response)).toBeNull();
+    },
+  );
+
+  test.each(["/api/v1/games", "/_next/static/chunk.js", "/images/logo.png"])(
     "does not run for %s",
     (url) => {
       expect(unstable_doesMiddlewareMatch({ config, nextConfig, url })).toBe(


### PR DESCRIPTION
Automatically selects Brazilian Portuguese when Vercel identifies the visitor country as Brazil, using the same x-vercel-ip-country signal as regional BRL pricing. Explicit locale URLs take priority, followed by the user's saved NEXT_LOCALE choice, then geolocation; users in Brazil can still choose English permanently. Refactors country parsing, locale constants, and internal SSR header forwarding into shared helpers so the production header name exists in one place only. Validation: production build, ESLint, Prettier on changed files, 25 locale/proxy tests, and live Next.js redirect checks.